### PR TITLE
Change syntax of licence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "graby/graby",
-    "license": "AGPLv3",
+    "license": "AGPL-3.0",
     "authors": [{
         "name": "Jeremy Benoist",
         "email": "jeremy.benoist@gmail.com",


### PR DESCRIPTION
I had the following error : 
License "AGPLv3" is not a valid SPDX license identifier, see http://www.spdx.org/licenses/ if you use an open license.