### PR TITLE
Remove gzip decode, it's done on the request

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -203,10 +203,6 @@ class HttpClient
             }
         }
 
-        if ('gzip' == $response->getHeader('Content-Encoding')) {
-            $body = gzdecode($body);
-        }
-
         // remove utm parameters & fragment
         $effectiveUrl = preg_replace('/((\?)?(&(amp;)?)?utm_(.*?)\=[^&]+)|(#(.*?)\=[^&]+)/', '', urldecode($effectiveUrl));
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -314,55 +314,6 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $res['status']);
     }
 
-    public function testFetchGzip()
-    {
-        $url = 'http://fr.wikipedia.org/wiki/Copyright';
-        $headers = array(
-            'User-Agent' => 'Mozilla/5.2',
-            'Referer' => 'http://www.google.co.uk/url?sa=t&source=web&cd=1',
-        );
-
-        $response = $this->getMockBuilder('GuzzleHttp\Message\Response')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $response->expects($this->once())
-            ->method('getEffectiveUrl')
-            ->willReturn($url);
-
-        $response->expects($this->any())
-            ->method('getHeader')
-            ->willReturn('gzip');
-
-        $response->expects($this->any())
-            ->method('getStatusCode')
-            ->willReturn(200);
-
-        $response->expects($this->any())
-            ->method('getBody')
-            ->willReturn(gzencode('yay'));
-
-        $client = $this->getMockBuilder('GuzzleHttp\Client')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $client->expects($this->once())
-            ->method('get')
-            ->with(
-                $this->equalTo($url),
-                $this->equalTo(array('headers' => $headers, 'cookies' => true))
-            )
-            ->willReturn($response);
-
-        $http = new HttpClient($client);
-        $res = $http->fetch($url);
-
-        $this->assertEquals($url, $res['effective_url']);
-        $this->assertEquals('yay', $res['body']);
-        $this->assertEquals('gzip', $res['headers']);
-        $this->assertEquals(200, $res['status']);
-    }
-
     public function testWith404ResponseWithResponse()
     {
         $client = new Client();

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -103,9 +103,6 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
                 switch ($parameter) {
                     case 'Content-Type':
                         return $header;
-
-                    case 'Content-Encoding':
-                        return 'text';
                 }
             }));
 
@@ -594,13 +591,11 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->willReturn(200);
 
-        $response->expects($this->exactly(4))
+        $response->expects($this->exactly(2))
             ->method('getHeader')
             ->will($this->onConsecutiveCalls(
                 'text/html',
-                '',
-                'image/jpeg',
-                ''
+                'image/jpeg'
             ));
 
         $response->expects($this->any())
@@ -694,13 +689,11 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->willReturn(200);
 
-        $response->expects($this->exactly(4))
+        $response->expects($this->exactly(2))
             ->method('getHeader')
             ->will($this->onConsecutiveCalls(
                 'text/html',
-                '',
-                'application/pdf',
-                ''
+                'application/pdf'
             ));
 
         $response->expects($this->any())


### PR DESCRIPTION
By default, Guzzle send a request with option `CURLOPT_ENCODING` empty. It means, the server will answer with a plain content instead of gzipped content.
So we don't need to decode it.