### PR TITLE
Fix bad url for multipage

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -226,11 +226,11 @@ class Graby
         $extracted_language = $this->extractor->getLanguage();
 
         // Deal with multi-page articles
-        //die('Next: '.$this->extractor->getNextPageUrl());
         $is_multi_page = (!$is_single_page && $extract_result && null !== $this->extractor->getNextPageUrl());
         if ($this->config['multipage'] && $is_multi_page) {
             $this->logger->log('debug', 'Attempting to process multi-page article');
-            $multi_page_urls = array();
+            // store first page to avoid parsing it again (previous url content is in `$content_block`)
+            $multi_page_urls = array($effective_url);
             $multi_page_content = array();
 
             while ($next_page_url = $this->extractor->getNextPageUrl()) {
@@ -250,10 +250,10 @@ class Graby
                     break;
                 }
 
-                // it's not, so let's attempt to fetch it
+                // it's not, store it for later check & so let's attempt to fetch it
                 $multi_page_urls[] = $next_page_url;
 
-                $response = $this->httpClient->fetch($url);
+                $response = $this->httpClient->fetch($next_page_url);
 
                 // make sure mime type is not something with a different action associated
                 $mimeInfo = $this->getMimeActionInfo($response['headers']);

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -681,7 +681,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $response->expects($this->any())
+        $response->expects($this->exactly(2))
             ->method('getEffectiveUrl')
             ->willReturn('http://multiplepage1.com');
 
@@ -696,7 +696,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
                 'application/pdf'
             ));
 
-        $response->expects($this->any())
+        $response->expects($this->exactly(2))
             ->method('getBody')
             ->will($this->onConsecutiveCalls(
                 '<html><h2 class="primary">my title</h2><div class="story">my content</div><ul><li class="next"><a href="multiplepage1.com/data.pdf">next page</a></li></ul></html>',
@@ -707,8 +707,12 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $client->expects($this->any())
+        $client->expects($this->once())
             ->method('get')
+            ->willReturn($response);
+
+        $client->expects($this->once())
+            ->method('head')
             ->willReturn($response);
 
         $graby = new Graby(array('content_links' => 'footnotes', 'extractor' => array('config_builder' => array(


### PR DESCRIPTION
The current url was used for each new page instead of the extracted one.