### PR TITLE
Use default guzzle cookies settings

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -143,8 +143,7 @@ class HttpClient
                         'User-Agent' => $this->getUserAgent($url),
                         // add referer for picky sites
                         'Referer' => $this->config['default_referer'],
-                    ),
-                    'cookies' => true,
+                    )
                 )
             );
         } catch (RequestException $e) {

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -75,9 +75,7 @@ class Graby
             $this->logger
         );
         $this->httpClient = new HttpClient(
-            $guzzleClient = $client ?: new Client(
-                array('handler' => new SafeCurlHandler(), 'defaults' => array('cookies' => true))
-            ),
+            $client ?: new Client(array('handler' => new SafeCurlHandler(), 'defaults' => array('cookies' => true))),
             $this->config['http_client'],
             $this->logger
         );

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -75,7 +75,9 @@ class Graby
             $this->logger
         );
         $this->httpClient = new HttpClient(
-            $client ?: new Client(array('handler' => new SafeCurlHandler())),
+            $guzzleClient = $client ?: new Client(
+                array('handler' => new SafeCurlHandler(), 'defaults' => array('cookies' => true))
+            ),
             $this->config['http_client'],
             $this->logger
         );

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -79,7 +79,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with(
                 $this->equalTo($urlRewritten),
-                $this->equalTo(array('headers' => $headers, 'cookies' => true))
+                $this->equalTo(array('headers' => $headers))
             )
             ->willReturn($response);
 
@@ -127,7 +127,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             ->method('head')
             ->with(
                 $this->equalTo($url),
-                $this->equalTo(array('headers' => $headers, 'cookies' => true))
+                $this->equalTo(array('headers' => $headers))
             )
             ->willReturn($response);
 
@@ -178,7 +178,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             ->method('head')
             ->with(
                 $this->equalTo($url),
-                $this->equalTo(array('headers' => $headers, 'cookies' => true))
+                $this->equalTo(array('headers' => $headers))
             )
             ->willReturn($response);
 
@@ -187,7 +187,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with(
                 $this->equalTo($url),
-                $this->equalTo(array('headers' => $headers, 'cookies' => true))
+                $this->equalTo(array('headers' => $headers))
             )
             ->willReturn($response);
 
@@ -393,7 +393,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo(array('headers' => array(
                     'User-Agent' => 'Mozilla/5.2',
                     'Referer' => 'http://www.google.co.uk/url?sa=t&source=web&cd=1',
-                ), 'cookies' => true))
+                )))
             )
             ->willReturn($response);
 


### PR DESCRIPTION
Changes the guzzle call to use the default cookie settings.
Also set the default guzzle client to accept cookies by default.

This allows customization of the guzzle client's cookies handling by providing a custom one with a CookieJar.