### PR TITLE
Added login settings support

### DIFF
--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -196,7 +196,7 @@ class ConfigBuilder
 
         // check for single statement commands
         // we do not overwrite existing non null values
-        foreach (array('tidy', 'prune', 'parser', 'autodetect_on_failure') as $var) {
+        foreach (array('tidy', 'prune', 'parser', 'autodetect_on_failure', 'requires_login') as $var) {
             if ($currentConfig->$var === null) {
                 $currentConfig->$var = $newConfig->$var;
             }
@@ -244,13 +244,13 @@ class ConfigBuilder
             }
 
             // check for commands where we accept multiple statements
-            if (in_array($command, array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'http_header', 'test_url', 'find_string', 'replace_string'))) {
+            if (in_array($command, array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'http_header', 'test_url', 'find_string', 'replace_string', 'login_extra_fields'))) {
                 array_push($config->$command, $val);
             // check for single statement commands that evaluate to true or false
-            } elseif (in_array($command, array('tidy', 'prune', 'autodetect_on_failure'))) {
+            } elseif (in_array($command, array('tidy', 'prune', 'autodetect_on_failure', 'requires_login'))) {
                 $config->$command = ($val == 'yes' || $val == 'true');
             // check for single statement commands stored as strings
-            } elseif (in_array($command, array('parser'))) {
+            } elseif (in_array($command, array('parser', 'login_username_field', 'login_password_field', 'not_logged_in_xpath', 'login_uri'))) {
                 $config->$command = $val;
             // check for replace_string(find): replace
             } elseif ((substr($command, -1) == ')') && preg_match('!^([a-z0-9_]+)\((.*?)\)$!i', $command, $match)) {

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -87,11 +87,40 @@ class SiteConfig
     // the options below cannot be set in the config files which this class represents
     public $cache_key = null;
 
+    /**
+     * If fetching the site's content requires to authentify.
+     * @var bool
+     */
     public $requires_login = false;
+
+    /**
+     * XPath query to detect if login is requested in a page from the site.
+     * @var string
+     */
     public $not_logged_in_xpath = false;
+
+    /**
+     * Site's login form URI, if applicable.
+     * @var string
+     */
     public $login_uri = false;
+
+    /**
+     * Name of the site's login form username field. Example: username.
+     * @var string
+     */
     public $login_username_field = false;
+
+    /**
+     * Name of the site's login form password field. Example: password.
+     * @var string
+     */
     public $login_password_field = false;
+
+    /**
+     * Extra fields to POST to the site's login form.
+     * @var array hash of form field name => value
+     */
     public $login_extra_fields = array();
 
     /**

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -87,6 +87,13 @@ class SiteConfig
     // the options below cannot be set in the config files which this class represents
     public $cache_key = null;
 
+    public $requires_login = false;
+    public $not_logged_in_xpath = false;
+    public $login_uri = false;
+    public $login_username_field = false;
+    public $login_password_field = false;
+    public $login_extra_fields = array();
+
     /**
      * Process HTML with tidy before creating DOM (bool or null if undeclared).
      *


### PR DESCRIPTION
> Required by wallabag's site login support.

Adds new settings that cover login to a site.

### Settings
- `requires_login`: boolean, indicates if the site requires login or not (default: false)
- `not_logged_in_xpath`: string, xpath query for an element in articles pages indicating that login is needed
- `login_uri`: string, the uri to which login data must be POSTed
- `login_username_field`: string, name of the username field in the form
- `login_password_field`: string, name of the password field in the form
- `login_extra_fields`: hash of form field => field value to POST with the login form