### PR TITLE
Fix a non-object in some case

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -408,7 +408,7 @@ class ContentExtractor
         if (isset($this->body)) {
             // remove any h1-h6 elements that appear as first thing in the body
             // and which match our title
-            if (isset($this->title) && $this->title != '') {
+            if (isset($this->title) && $this->title != '' && null !== $this->body->firstChild) {
                 $firstChild = $this->body->firstChild;
 
                 while ($firstChild->nextSibling != null && $firstChild->nodeType && ($firstChild->nodeType !== XML_ELEMENT_NODE)) {
@@ -427,6 +427,11 @@ class ContentExtractor
                 if (!$e->hasChildNodes()) {
                     $e->appendChild($this->body->ownerDocument->createTextNode('[embedded content]'));
                 }
+            }
+
+            // prevent self-closing iframe when content is ONLY an iframe
+            if ('iframe' === $this->body->nodeName && !$this->body->hasChildNodes()) {
+                $this->body->appendChild($this->body->ownerDocument->createTextNode('[embedded content]'));
             }
 
             // remove image lazy loading

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -166,7 +166,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
 
         $content_block = $contentExtractor->getContent();
 
-        $this->assertContains('<iframe src=""/>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertContains('<iframe src="">[embedded content]</iframe>', $content_block->ownerDocument->saveXML($content_block));
     }
 
     public function dataForNextPage()

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -166,4 +166,30 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('image/jpeg', $res['content_type']);
         $this->assertEquals(array(), $res['open_graph']);
     }
+
+    public function testYoutubeOembed()
+    {
+        $graby = new Graby(array('debug' => true));
+        $res = $graby->fetchContent('http://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml');
+
+        $this->assertCount(8, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+
+        $this->assertEquals(200, $res['status']);
+        $this->assertEquals('', $res['language']);
+        $this->assertEquals('http://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml', $res['url']);
+        $this->assertEquals('[Review] The Matrix Falling (Rain) Source Code C++', $res['title']);
+        $this->assertEquals('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="">[embedded content]</iframe>', $res['html']);
+        $this->assertEquals('[embedded content]', $res['summary']);
+        $this->assertEquals('text/xml', $res['content_type']);
+        $this->assertEquals(array(), $res['open_graph']);
+    }
 }


### PR DESCRIPTION
When the body contains only one node (like `<p>content</p>`), `->firstChild` is null.

/see https://github.com/wallabag/wallabag/issues/1661