### PR TITLE
Avoid sending encoded query string

### DIFF
--- a/src/Ring/Client/SafeCurlHandler.php
+++ b/src/Ring/Client/SafeCurlHandler.php
@@ -56,7 +56,7 @@ class SafeCurlHandler
         try {
             // override the default body stream with the request response
             $safecurl = new SafeCurl($h);
-            $body = $safecurl->execute(Core::url($request));
+            $body = $safecurl->execute(urldecode(Core::url($request)));
         } catch (Exception $e) {
             // URL wasn't safe, return empty content
             $body = '';

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -86,7 +86,6 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Next Generation MongoDB Driver for PHP!', $res['title']);
         $this->assertContains('For the past few months I\'ve been working on a "next-gen" MongoDB driver for PHP', $res['html']);
         $this->assertEquals('text/html', $res['content_type']);
-        $this->assertEquals(array('og_url' => 'http://bjori.blogspot.com/2015/04/next-gen-mongodb-driver.html'), $res['open_graph']);
     }
 
     public function testBadUrl()
@@ -191,5 +190,24 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('[embedded content]', $res['summary']);
         $this->assertEquals('text/xml', $res['content_type']);
         $this->assertEquals(array(), $res['open_graph']);
+    }
+
+    public function testEncodedUrl()
+    {
+        $graby = new Graby(array('debug' => true));
+        $res = $graby->fetchContent('http://blog.niqnutn.com/index.php?article49/commandes-de-base');
+
+        $this->assertCount(8, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+
+        $this->assertEquals(200, $res['status']);
     }
 }


### PR DESCRIPTION
For example, this `index.php?article49/commandes-de-base` became `index.php?article49%2Fcommandes-de-base` which can generate an endless 301.

This should fix https://github.com/wallabag/wallabag/issues/1888 & https://github.com/wallabag/wallabag/issues/1897