### PR TITLE
Avoid data:image in open graph data

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -185,9 +185,7 @@ class HttpClient
         // for AJAX sites, e.g. Blogger with its dynamic views templates.
         // Based on Google's spec: https://developers.google.com/webmasters/ajax-crawling/docs/specification
         if (strpos($effectiveUrl, '_escaped_fragment_') === false) {
-            $html = substr($body, 0, 4000);
-
-            $redirectURL = $this->getMetaRefreshURL($effectiveUrl, $html) ?: $this->getUglyURL($effectiveUrl, $html);
+            $redirectURL = $this->getMetaRefreshURL($effectiveUrl, $body) ?: $this->getUglyURL($effectiveUrl, $body);
 
             if (false !== $redirectURL) {
                 return $this->fetch($redirectURL, true);
@@ -440,6 +438,8 @@ class HttpClient
         if (!$found) {
             return false;
         }
+
+        $this->logger->log('debug', 'Added escaped fragment to url');
 
         $query = array('_escaped_fragment_' => '');
 

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -739,7 +739,14 @@ class Graby
 
         $rmetas = array();
         foreach ($metas as $meta) {
-            $rmetas[str_replace(':', '_', $meta->getAttribute('property'))] = $meta->getAttribute('content');
+            $property = str_replace(':', '_', $meta->getAttribute('property'));
+
+            // avoid image data:uri to avoid sending too much data
+            if ('og_image' === $property && 0 === stripos($meta->getAttribute('content'), 'data:image')) {
+                continue;
+            }
+
+            $rmetas[$property] = $meta->getAttribute('content');
         }
 
         return $rmetas;

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -1022,6 +1022,22 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://example.org/path/to/image.jpg', $e->firstChild->getAttribute('src'));
     }
 
+    public function testAvoidDataUriImageInOpenGraph()
+    {
+        $graby = new Graby();
+
+        $reflection = new \ReflectionClass(get_class($graby));
+        $method = $reflection->getMethod('extractOpenGraph');
+        $method->setAccessible(true);
+
+        $ogData = $method->invokeArgs($graby, array('<html><meta content="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" property="og:image" /><meta content="http://www.io.lol" property="og:url"/></html>'));
+
+        $this->assertCount(1, $ogData);
+        $this->assertArrayHasKey('og_url', $ogData);
+        $this->assertEquals('http://www.io.lol', $ogData['og_url']);
+        $this->assertFalse(isset($ogData['og_image']), 'og_image key does not exist');
+    }
+
     public function testContentLinksRemove()
     {
         $response = $this->getMockBuilder('GuzzleHttp\Message\Response')


### PR DESCRIPTION
It'll avoid sending a huge amount of data.

Also don't truncate body for escaped fragment check  …
Some blogger website use data:uri image as og:image, so the body is huge and 4000 chars isn't enough to get the fragment meta.
We'll later if we can avoid sending the whole body.

Should fix https://github.com/wallabag/wallabag/issues/803