### PR TITLE
Handle a new img lazyload

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -436,7 +436,7 @@ class ContentExtractor
 
             // remove image lazy loading
             foreach ($this->body->getElementsByTagName('img') as $e) {
-                if (!$e->hasAttribute('data-lazy-src') && !$e->hasAttribute('data-src')) {
+                if (!$e->hasAttribute('data-lazy-src') && !$e->hasAttribute('data-src') && !$e->hasAttribute('data-original')) {
                     continue;
                 }
 
@@ -460,6 +460,11 @@ class ContentExtractor
                 if ($e->hasAttribute('data-lazy-src')) {
                     $src = $e->getAttribute('data-lazy-src');
                     $e->removeAttribute('data-lazy-src');
+                }
+
+                if ($e->hasAttribute('data-original')) {
+                    $src = $e->getAttribute('data-original');
+                    $e->removeAttribute('data-original');
                 }
 
                 $e->setAttribute('src', $src);

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -601,6 +601,11 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
                 '<div>'.str_repeat('this is the best part of the show', 10).'<img data-lazy-src="http://0.0.0.0/big_image.jpg" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="http://0.0.0.0/big_image_noscript.jpg"></noscript></div>',
                 '<img src="http://0.0.0.0/big_image_noscript.jpg"',
             ),
+            // test with img attribute data-original and image in noscript
+            array(
+                '<div>'.str_repeat('this is the best part of the show', 10).'<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-original="http://0.0.0.0/big_image.jpg" class="lazy"/></div>',
+                '<img src="http://0.0.0.0/big_image.jpg"',
+            ),
         );
     }
 


### PR DESCRIPTION
Found in https://github.com/wallabag/wallabag/issues/2269

Image from [www.outsideonline.com](http://www.outsideonline.com/2108066/emerald-citys-velo-thieves-have-problem-bike-batman) are lazyloaded using `data-original` instead of `data-src` or `data-lazy-src`:

```html
<img class="lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-original="http://www.outsideonline.com/sites/default/files/styles/img_850x480/public/bike-batman-saves-the-day.jpg?itok=11yfyV0r" alt="bike-batman-saves-the-day.jpg">
```