### PR TITLE
Share ConfigBuilder between classes

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -34,8 +34,9 @@ class ContentExtractor
     /**
      * @param array                $config
      * @param LoggerInterface|null $logger
+     * @param ConfigBuilder        $configBuilder
      */
-    public function __construct($config = array(), LoggerInterface $logger = null)
+    public function __construct($config = array(), LoggerInterface $logger = null, ConfigBuilder $configBuilder = null)
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults(array(
@@ -59,8 +60,10 @@ class ContentExtractor
             $this->logger = new NullLogger();
         }
 
-        // Set up Content Extractor
-        $this->configBuilder = new ConfigBuilder($this->config['config_builder'], $this->logger);
+        $this->configBuilder = $configBuilder;
+        if (null === $this->configBuilder) {
+            $this->configBuilder = new ConfigBuilder($this->config['config_builder'], $this->logger);
+        }
     }
 
     public function setLogger(LoggerInterface $logger)

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -79,9 +79,18 @@ class Graby
             $this->logger->pushHandler(new StreamHandler(dirname(__FILE__).'/../log/graby.log'));
         }
 
+        $this->configBuilder = $configBuilder;
+        if (null === $this->configBuilder) {
+            $this->configBuilder = new ConfigBuilder(
+                isset($this->config['extractor']['config_builder']) ? $this->config['extractor']['config_builder'] : [],
+                $this->logger
+            );
+        }
+
         $this->extractor = new ContentExtractor(
             $this->config['extractor'],
-            $this->logger
+            $this->logger,
+            $this->configBuilder
         );
 
         $this->httpClient = new HttpClient(
@@ -90,14 +99,6 @@ class Graby
             $this->logger
         );
 
-        if ($configBuilder === null) {
-            $configBuilder = new ConfigBuilder(
-                isset($this->config['extractor']['config_builder']) ? $this->config['extractor']['config_builder'] : [],
-                $this->logger
-            );
-        }
-
-        $this->configBuilder = $configBuilder;
         $this->punycode = new Punycode();
     }
 
@@ -579,6 +580,8 @@ class Graby
 
         // no single page found?
         if (empty($siteConfig->single_page_link)) {
+            $this->logger->log('debug', 'No "single_page_link" config found');
+
             return false;
         }
 


### PR DESCRIPTION
Avoid ConfigBuilder to build config multiple times.
Previously it was build in Graby and then rebuild in ContentExtractor.

Now, when it’s build in Graby, ContentExtractor will received cached config and will not rebuild config.