### PR TITLE
Add support of http_header property in site config

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -52,19 +52,7 @@ class HttpClient
             // to see if returned content type matches $headerOnlyTypes.
             'header_only_clues' => array('pdf', 'mp3', 'zip', 'exe', 'gif', 'gzip', 'gz', 'jpeg', 'jpg', 'mpg', 'mpeg', 'png', 'ppt', 'mov'),
             // User Agent strings - mapping domain names
-            'user_agents' => array(
-                'lifehacker.com' => 'PHP/5.2',
-                'gawker.com' => 'PHP/5.2',
-                'deadspin.com' => 'PHP/5.2',
-                'kotaku.com' => 'PHP/5.2',
-                'jezebel.com' => 'PHP/5.2',
-                'io9.com' => 'PHP/5.2',
-                'jalopnik.com' => 'PHP/5.2',
-                'gizmodo.com' => 'PHP/5.2',
-                '.wikipedia.org' => 'Mozilla/5.2',
-                '.fok.nl' => 'Googlebot/2.1',
-                'getpocket.com' => 'PHP/5.2',
-            ),
+            'user_agents' => array(),
             // AJAX triggers to search for.
             // for AJAX sites, e.g. Blogger with its dynamic views templates.
             'ajax_triggers' => array(

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -360,10 +360,12 @@ class HttpClient
 
         foreach ($try as $h) {
             if (isset($this->config['user_agents'][$h])) {
+                $this->logger->log('debug', 'Found user-agent "{user-agent}" for url "{url}" from config', array('user-agent' => $this->config['user_agents'][$h], 'url' => $url));
                 return $this->config['user_agents'][$h];
             }
         }
 
+        $this->logger->log('debug', 'Use default user-agent "{user-agent}" for url "{url}"', array('user-agent' => $ua, 'url' => $url));
         return $ua;
     }
 

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -101,10 +101,11 @@ class HttpClient
      *
      * @param string $url
      * @param bool   $skipTypeVerification Avoid mime detection which means, force GET instead of potential HEAD
+     * @param array  $httpHeader Custom HTTP Headers from SiteConfig
      *
      * @return array With keys effective_url, body & headers
      */
-    public function fetch($url, $skipTypeVerification = false)
+    public function fetch($url, $skipTypeVerification = false, $httpHeader = array())
     {
         if (false === $this->checkNumberRedirects($url)) {
             return $this->sendResults(array(
@@ -176,7 +177,7 @@ class HttpClient
         // but we'd issues a HEAD request because we assumed it would. So
         // let's queue a proper GET request for this item...
         if ('head' === $method && !$this->headerOnlyType($contentType)) {
-            return $this->fetch($effectiveUrl, true);
+            return $this->fetch($effectiveUrl, true, $httpHeader);
         }
 
         $body = (string) $response->getBody();
@@ -204,7 +205,7 @@ class HttpClient
             $redirectURL = $this->getMetaRefreshURL($effectiveUrl, $body) ?: $this->getUglyURL($effectiveUrl, $body);
 
             if (false !== $redirectURL) {
-                return $this->fetch($redirectURL, true);
+                return $this->fetch($redirectURL, true, $httpHeader);
             }
         }
 

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -131,7 +131,7 @@ class HttpClient
                 $url,
                 array(
                     'headers' => array(
-                        'User-Agent' => $this->getUserAgent($url),
+                        'User-Agent' => $this->getUserAgent($url, $httpHeader),
                         // add referer for picky sites
                         'Referer' => $this->config['default_referer'],
                     ),
@@ -330,12 +330,19 @@ class HttpClient
      * Otherwise it will use the default one.
      *
      * @param string $url Absolute url
+     * @param array  $httpHeader Custom HTTP Headers from SiteConfig
      *
      * @return string
      */
-    private function getUserAgent($url)
+    private function getUserAgent($url, $httpHeader = array())
     {
         $ua = $this->config['ua_browser'];
+
+        if (!empty($httpHeader['user-agent'])) {
+            $this->logger->log('debug', 'Found user-agent "{user-agent}" for url "{url}" from site config', array('user-agent' => $httpHeader['user-agent'], 'url' => $url));
+            return $httpHeader['user-agent'];
+        }
+
         $host = parse_url($url, PHP_URL_HOST);
 
         if (strtolower(substr($host, 0, 4)) == 'www.') {

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -171,10 +171,11 @@ class Graby
     private function doFetchContent($url)
     {
         $url = $this->validateUrl($url);
+        $siteConfig = $this->configBuilder->buildFromUrl($url);
 
         $this->logger->log('debug', 'Fetching url: {url}', array('url' => $url));
 
-        $response = $this->httpClient->fetch($url);
+        $response = $this->httpClient->fetch($url, false, $siteConfig->http_header);
 
         $effectiveUrl = $response['effective_url'];
         $effectiveUrl = str_replace(' ', '%20', $effectiveUrl);
@@ -259,7 +260,7 @@ class Graby
                 // it's not, store it for later check & so let's attempt to fetch it
                 $multiPageUrls[] = $nextPageUrl;
 
-                $response = $this->httpClient->fetch($nextPageUrl);
+                $response = $this->httpClient->fetch($nextPageUrl, false, $siteConfig->http_header);
 
                 // make sure mime type is not something with a different action associated
                 $mimeInfo = $this->getMimeActionInfo($response['headers']);
@@ -623,7 +624,7 @@ class Graby
         // check it's not what we have already!
         if (false !== $singlePageUrl && $singlePageUrl != $url) {
             // it's not, so let's try to fetch it...
-            $response = $this->httpClient->fetch($singlePageUrl);
+            $response = $this->httpClient->fetch($singlePageUrl, false, $siteConfig->http_header);
 
             if ($response['status'] < 300) {
                 $this->logger->log('debug', 'Single page content found with url', ['url' => $singlePageUrl]);

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -36,7 +36,6 @@ class SiteConfig
     public $strip_image_src = array();
 
     // Additional HTTP headers to send
-    // NOT YET USED
     public $http_header = array();
 
     // Process HTML with tidy before creating DOM (bool or null if undeclared)

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -92,11 +92,11 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Graby\SiteConfig\SiteConfig', $res);
 
-        foreach (array('http_header', 'single_page_link', 'next_page_link', 'find_string', 'replace_string') as $value) {
+        foreach (array('single_page_link', 'next_page_link', 'find_string', 'replace_string') as $value) {
             $this->assertEmpty($res->$value, 'Check empty value for: '.$value);
         }
 
-        foreach (array('strip_image_src') as $value) {
+        foreach (array('strip_image_src', 'http_header') as $value) {
             $this->assertNotEmpty($res->$value, 'Check not empty value for: '.$value);
         }
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -95,7 +95,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn($response);
 
-        $http = new HttpClient($client);
+        $http = new HttpClient($client, array('user_agents' => array('.wikipedia.org' => 'Mozilla/5.2')));
         $res = $http->fetch($url);
 
         $this->assertEquals($urlEffective, $res['effective_url']);
@@ -147,7 +147,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn($response);
 
-        $http = new HttpClient($client);
+        $http = new HttpClient($client, array('user_agents' => array('.wikipedia.org' => 'Mozilla/5.2')));
         $res = $http->fetch($url);
 
         $this->assertEquals($url, $res['effective_url']);
@@ -211,7 +211,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn($response);
 
-        $http = new HttpClient($client);
+        $http = new HttpClient($client, array('user_agents' => array('.wikipedia.org' => 'Mozilla/5.2')));
         $res = $http->fetch($url);
 
         $this->assertEquals($url, $res['effective_url']);
@@ -275,7 +275,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
             )
             ->willReturn($response);
 
-        $http = new HttpClient($client);
+        $http = new HttpClient($client, array('user_agents' => array('.wikipedia.org' => 'Mozilla/5.2')));
         $res = $http->fetch($url);
 
         $this->assertEquals($url, $res['effective_url']);
@@ -489,7 +489,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $handler = new TestHandler();
         $logger->pushHandler($handler);
 
-        $http = new HttpClient($client);
+        $http = new HttpClient($client, array('user_agents' => array('.wikipedia.org' => 'Mozilla/5.2')));
         $http->setLogger($logger);
 
         $res = $http->fetch('http://fr.m.wikipedia.org/wiki/Copyright#bottom');

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -500,17 +500,17 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $records = $handler->getRecords();
 
-        $this->assertCount(2, $records);
+        $this->assertCount(3, $records);
         $this->assertEquals('Trying using method "{method}" on url "{url}"', $records[0]['message']);
         $this->assertEquals('get', $records[0]['context']['method']);
         $this->assertEquals('http://fr.wikipedia.org/wiki/Copyright', $records[0]['context']['url']);
-        $this->assertEquals('Data fetched: {data}', $records[1]['message']);
+        $this->assertEquals('Data fetched: {data}', $records[2]['message']);
         $this->assertEquals(array(
             'effective_url' => 'http://fr.wikipedia.org/wiki/Copyright',
             'body' => '(only length for debug): 3',
             'headers' => '',
             'status' => 200,
-        ), $records[1]['context']['data']);
+        ), $records[2]['context']['data']);
     }
 
     public function testTimeout()
@@ -529,9 +529,9 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $records = $handler->getRecords();
 
-        $this->assertEquals('Request throw exception (with no response): {error_message}', $records[1]['message']);
+        $this->assertEquals('Request throw exception (with no response): {error_message}', $records[2]['message']);
         // cURL error 28 is: CURLE_OPERATION_TIMEDOUT
-        $this->assertContains('cURL error 28', $records[1]['formatted']);
+        $this->assertContains('cURL error 28', $records[2]['formatted']);
     }
 
     public function testNbRedirectsReached()

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -56,12 +56,23 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $this->assertGreaterThan(30, $records);
         $this->assertEquals('Graby is ready to fetch', $records[0]['message']);
-        $this->assertEquals('Fetching url: {url}', $records[1]['message']);
-        $this->assertEquals('http://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html', $records[1]['context']['url']);
-        $this->assertEquals('Trying using method "{method}" on url "{url}"', $records[2]['message']);
-        $this->assertEquals('get', $records[2]['context']['method']);
-        $this->assertEquals('Data fetched: {data}', $records[3]['message']);
-        $this->assertEquals('Opengraph data: {ogData}', $records[5]['message']);
+        $this->assertEquals('. looking for site config for {host} in primary folder', $records[1]['message']);
+        $this->assertEquals('... found site config {host}', $records[2]['message']);
+        $this->assertEquals('Appending site config settings from global.txt', $records[3]['message']);
+        $this->assertEquals('. looking for site config for {host} in primary folder', $records[4]['message']);
+        $this->assertEquals('... found site config {host}', $records[5]['message']);
+        $this->assertEquals('Cached site config with key: {key}', $records[6]['message']);
+        $this->assertEquals('. looking for site config for {host} in primary folder', $records[7]['message']);
+        $this->assertEquals('... found site config {host}', $records[8]['message']);
+        $this->assertEquals('Appending site config settings from global.txt', $records[9]['message']);
+        $this->assertEquals('Cached site config with key: {key}', $records[10]['message']);
+        $this->assertEquals('Cached site config with key: {key}', $records[11]['message']);
+        $this->assertEquals('Fetching url: {url}', $records[12]['message']);
+        $this->assertEquals('http://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html', $records[12]['context']['url']);
+        $this->assertEquals('Trying using method "{method}" on url "{url}"', $records[13]['message']);
+        $this->assertEquals('get', $records[13]['context']['method']);
+        $this->assertEquals('Data fetched: {data}', $records[14]['message']);
+        $this->assertEquals('Opengraph data: {ogData}', $records[16]['message']);
     }
 
     public function testRealFetchContent2()

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -71,8 +71,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html', $records[12]['context']['url']);
         $this->assertEquals('Trying using method "{method}" on url "{url}"', $records[13]['message']);
         $this->assertEquals('get', $records[13]['context']['method']);
-        $this->assertEquals('Data fetched: {data}', $records[14]['message']);
-        $this->assertEquals('Opengraph data: {ogData}', $records[16]['message']);
+        $this->assertEquals('Data fetched: {data}', $records[15]['message']);
+        $this->assertEquals('Opengraph data: {ogData}', $records[17]['message']);
     }
 
     public function testRealFetchContent2()

--- a/tests/fixtures/site_config/.wikipedia.org.txt
+++ b/tests/fixtures/site_config/.wikipedia.org.txt
@@ -14,6 +14,7 @@ strip: //div[@id='contentSub']
 strip: //table[contains(@class, 'metadata')]
 strip: //*[contains(@class, 'noprint')]
 strip: //span[@class='noexcerpt']
+http_header(user-agent): Mozilla/5.2
 prune: no
 tidy: no
 test_url: http://en.wikipedia.org/wiki/Christopher_Lloyd


### PR DESCRIPTION
This PR adds the ability to graby to use user-agent provided in site configs instead of `default_ua` and `user_agents` from `HttpClient`.

http_header is extracted from site config and provided to `HttpClient#fetch()` and `HttpClient#getUserAgent()` to extract the user-agent, if any. In case of missing value we fall back to the original behavior: check host from `user_agents` or use `default_ua`.

There are some issues however, at this time:
* ~~`default_ua` is not used anymore as long as a `http_header(user-agent)` is currently provided in `global.txt`. A solution could be to ignore the user-agent provided by global, any thoughts?~~
* `HttpClient` does not have access to SiteConfig, some tests began to fail because of the deletion of default `user_agents` array (e9f2981e573). I fixed them by providing a custom array with `user_agents` to the `HttpClient` instance in the test. Not sure if it's okay for you.

Fixes #49 