### PR TITLE
Add support of referer from site config

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -121,7 +121,7 @@ class HttpClient
                     'headers' => array(
                         'User-Agent' => $this->getUserAgent($url, $httpHeader),
                         // add referer for picky sites
-                        'Referer' => $this->config['default_referer'],
+                        'Referer' => $this->getReferer($url, $httpHeader),
                     ),
                     'timeout' => $this->config['timeout'],
                     'connect_timeout' => $this->config['timeout'],
@@ -355,6 +355,29 @@ class HttpClient
 
         $this->logger->log('debug', 'Use default user-agent "{user-agent}" for url "{url}"', array('user-agent' => $ua, 'url' => $url));
         return $ua;
+    }
+
+    /**
+     * Find a Referer for this url.
+     * Based on the site config, it will return the Referer if any.
+     * Otherwise it will use the default one
+     *
+     * @param string $url Absolute url
+     * @param array $httpHeader Custom HTTP Headers from SiteConfig
+     *
+     * @return string
+     */
+    private function getReferer($url, $httpHeader = array())
+    {
+        $default_referer = $this->config['default_referer'];
+
+        if (!empty($httpHeader['referer'])) {
+            $this->logger->log('debug', 'Found referer "{referer}" for url "{url}" from site config', array('referer' => $httpHeader['referer'], 'url' => $url));
+            return $httpHeader['referer'];
+        }
+
+        $this->logger->log('debug', 'Use default referer "{referer}" for url "{url}"', array('referer' => $default_referer, 'url' => $url));
+        return $default_referer;
     }
 
     /**

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -345,7 +345,7 @@ class ConfigBuilder
             } elseif ((substr($command, -1) == ')') && preg_match('!^([a-z0-9_]+)\((.*?)\)$!i', $command, $match) && $match[1] == 'replace_string') {
                 array_push($config->find_string, $match[2]);
                 array_push($config->replace_string, $val);
-            } elseif ((substr($command, -1) == ')') && preg_match('!^([a-z0-9_]+)\(([a-z0-9_-]+)\)$!i', $command, $match) && $match[1] == 'http_header' && in_array($match[2], array('user-agent'))) {
+            } elseif ((substr($command, -1) == ')') && preg_match('!^([a-z0-9_]+)\(([a-z0-9_-]+)\)$!i', $command, $match) && $match[1] == 'http_header' && in_array($match[2], array('user-agent', 'referer'))) {
                 $config->http_header[$match[2]] = $val;
             }
         }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -71,8 +71,9 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html', $records[12]['context']['url']);
         $this->assertEquals('Trying using method "{method}" on url "{url}"', $records[13]['message']);
         $this->assertEquals('get', $records[13]['context']['method']);
-        $this->assertEquals('Data fetched: {data}', $records[15]['message']);
-        $this->assertEquals('Opengraph data: {ogData}', $records[17]['message']);
+        $this->assertEquals('Use default referer "{referer}" for url "{url}"', $records[15]['message']);
+        $this->assertEquals('Data fetched: {data}', $records[16]['message']);
+        $this->assertEquals('Opengraph data: {ogData}', $records[18]['message']);
     }
 
     public function testRealFetchContent2()

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -33,6 +33,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
             'tidy: yes',
             'parser: bob',
             'replace_string(toto): titi',
+            'http_header(referer): http://idontl.ie',
         ));
 
         $configExpected = new SiteConfig();
@@ -41,6 +42,9 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         $configExpected->parser = 'bob';
         $configExpected->find_string = array('toto');
         $configExpected->replace_string = array('titi');
+        $configExpected->http_header = array(
+            'referer' => 'http://idontl.ie'
+        );
 
         $this->assertEquals($configExpected, $configActual);
 


### PR DESCRIPTION
Following #61, this PR adds the support of `http_header(referer)` property from site config.

Fixes #62 