### PR TITLE
Update regex for html IE conditional

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -177,9 +177,9 @@ class HttpClient
         preg_match('/^\<!--\[if(\X+)\<!\[endif\]--\>(\X+)\<head\>$/mi', $body, $matchesConditional);
 
         if (count($matchesConditional) > 1) {
-            preg_match_all('/\<html([\sa-z0-9\=\"\"\-]+)\>$/mi', $matchesConditional[0], $matchesHtml);
+            preg_match_all('/\<html([\sa-z0-9\=\"\"\-:\/\.\#]+)\>$/mi', $matchesConditional[0], $matchesHtml);
 
-            if (count($matchesHtml) > 1) {
+            if (count($matchesHtml) > 1 && !empty(end($matchesHtml[0]))) {
                 $htmlTag = end($matchesHtml[0]);
 
                 $body = str_replace($matchesConditional[0], $htmlTag.'<head>', $body);

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -179,10 +179,12 @@ class HttpClient
         if (count($matchesConditional) > 1) {
             preg_match_all('/\<html([\sa-z0-9\=\"\"\-:\/\.\#]+)\>$/mi', $matchesConditional[0], $matchesHtml);
 
-            if (count($matchesHtml) > 1 && !empty(end($matchesHtml[0]))) {
+            if (count($matchesHtml) > 1) {
                 $htmlTag = end($matchesHtml[0]);
 
-                $body = str_replace($matchesConditional[0], $htmlTag.'<head>', $body);
+                if (!empty($htmlTag)) {
+                    $body = str_replace($matchesConditional[0], $htmlTag.'<head>', $body);
+                }
             }
         }
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -623,6 +623,22 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">',
                 'expectedBody' => '<html lang="fr"><head>',
+            ],
+            [
+                'url' => 'https://venngage.com/blog/hashtags-are-worthless/',
+                'html' => '<!DOCTYPE html>
+<!--[if IE 7]>
+<html class="ie ie7" lang="en-US" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
+<![endif]-->
+<!--[if IE 8]>
+<html class="ie ie8" lang="en-US" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
+<![endif]-->
+<!--[if !(IE 7) | !(IE 8)  ]><!-->
+<html lang="en-US" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
+<!--<![endif]-->
+        <head>
+                <meta charset="UTF-8" />',
+                'expectedBody' => '<html lang="en-US" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#"><head>',
             ]
         ];
     }


### PR DESCRIPTION
The regex doesn’t matche every case. And if it matches, it now check that the matching value isn’t empty (which was the case for `https://venngage.com/blog/hashtags-are-worthless/`)