### PR TITLE
[WIP] Add support of date from site config

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -584,18 +584,19 @@ class ContentExtractor
     }
 
     /**
-     * Extract title for a given CSS class a node.
+     * Extract entity for a given CSS class a node.
      *
-     * @param bool     $detectTitle Do we have to detect title ?
-     * @param string   $cssClass    CSS class to look for
-     * @param \DOMNode $node        DOMNode to look into
+     * @param string   $entity       Entity to look for
+     * @param bool     $detectEntity Do we have to detect entity?
+     * @param string   $cssClass     CSS class to look for
+     * @param \DOMNode $node         DOMNode to look into
      * @param string   $logMessage
      *
-     * @return bool Telling if we have to detect title again or not
+     * @return bool Telling if we have to detect entity again or not
      */
-    private function extractTitle($detectTitle, $cssClass, \DOMNode $node, $logMessage)
+    private function extractEntity($entity, $detectEntity, $cssClass, \DOMNode $node, $logMessage)
     {
-        if (false === $detectTitle) {
+        if (false === $detectEntity) {
             return false;
         }
 
@@ -603,15 +604,45 @@ class ContentExtractor
         $elems = $this->xpath->query(".//*[contains(concat(' ',normalize-space(@class),' '),' ".$cssClass." ')]", $node);
 
         if (false === $this->hasElements($elems)) {
-            return $detectTitle;
+            return $detectEntity;
         }
 
-        $this->title = $elems->item(0)->textContent;
-        $this->logger->log('debug', $logMessage, array('title' => $this->title));
-        // remove title from document
+        $this->{$entity} = $elems->item(0)->textContent;
+        $this->logger->log('debug', $logMessage, array($entity => $this->{$entity}));
+        // remove entity from document
         $elems->item(0)->parentNode->removeChild($elems->item(0));
 
         return false;
+    }
+
+    /**
+     * Extract title for a given CSS class a node.
+     *
+     * @param bool    $detectTitle Do we have to detect title ?
+     * @param string  $cssClass    CSS class to look for
+     * @param DOMNode $node        DOMNode to look into
+     * @param string  $logMessage
+     *
+     * @return bool Telling if we have to detect title again or not
+     */
+    private function extractTitle($detectTitle, $cssClass, \DOMNode $node, $logMessage)
+    {
+        return $this->extractEntity('title', $detectTitle, $cssClass, $node, $logMessage);
+    }
+
+    /**
+     * Extract date for a given CSS class a node.
+     *
+     * @param bool    $detectDate  Do we have to detect date ?
+     * @param string  $cssClass    CSS class to look for
+     * @param DOMNode $node        DOMNode to look into
+     * @param string  $logMessage
+     *
+     * @return bool Telling if we have to detect date again or not
+     */
+    private function extractDate($detectDate, $cssClass, \DOMNode $node, $logMessage)
+    {
+        return $this->extractEntity('date', $detectDate, $cssClass, $node, $logMessage);
     }
 
     /**

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -517,6 +517,11 @@ class ContentExtractor
         return trim($this->title);
     }
 
+    public function getDate()
+    {
+        return $this->date;
+    }
+
     public function getLanguage()
     {
         return $this->language;

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -426,8 +426,15 @@ class ContentExtractor
             $this->logger->log('debug', 'Detected title: {title}', array('title' => $this->title));
         }
 
+        $parseDate = date_parse($this->date);
+
+        // If no year has been found during date_parse, we nuke the whole value
+        // because the date is invalid
+        if ($parseDate['year'] === FALSE) {
+            $this->date = null;
+        }
+
         if ($this->date) {
-            $this->date = strtotime(trim($this->date));
             $this->logger->log('debug', 'Detected date: {date}', array('date' => $this->date));
         }
 

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -231,6 +231,7 @@ class Graby
         $contentBlock = $this->extractor->getContent();
         $extractedTitle = $this->extractor->getTitle();
         $extractedLanguage = $this->extractor->getLanguage();
+        $extractedDate = $this->extractor->getDate();
 
         // Deal with multi-page articles
         $isMultiPage = (!$isSinglePage && $extractResult && null !== $this->extractor->getNextPageUrl());
@@ -308,6 +309,7 @@ class Graby
                 'html' => $this->config['error_message'],
                 'title' => $extractedTitle ?: $this->config['error_message_title'],
                 'language' => $extractedLanguage,
+                'date' => $extractedDate,
                 'url' => $effectiveUrl,
                 'content_type' => isset($mimeInfo['mime']) ? $mimeInfo['mime'] : '',
                 'open_graph' => $ogData,
@@ -365,6 +367,7 @@ class Graby
         $this->logger->log('debug', 'Returning data (most interesting ones): {data}', array('data' => array(
             'title' => $extractedTitle,
             'language' => $extractedLanguage,
+            'date' => $extractedDate,
             'url' => $effectiveUrl,
             'content_type' => $mimeInfo['mime'],
         )));
@@ -374,6 +377,7 @@ class Graby
             'html' => trim($html),
             'title' => $extractedTitle ?: $this->config['error_message_title'],
             'language' => $extractedLanguage,
+            'date' => $extractedDate,
             'url' => $effectiveUrl,
             'content_type' => $mimeInfo['mime'],
             'open_graph' => $ogData,
@@ -515,6 +519,7 @@ class Graby
             'status' => 200,
             'title' => $mimeInfo['name'],
             'language' => '',
+            'date' => '',
             'html' => '',
             'url' => $effectiveUrl,
             'content_type' => $mimeInfo['mime'],

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -274,7 +274,7 @@ class ConfigBuilder
     public function mergeConfig(SiteConfig $currentConfig, SiteConfig $newConfig)
     {
         // check for commands where we accept multiple statements (no test_url)
-        foreach (array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link') as $var) {
+        foreach (array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'date') as $var) {
             // append array elements for this config variable from $newConfig to this config
             $currentConfig->$var = array_unique(array_merge($currentConfig->$var, $newConfig->$var));
         }
@@ -333,7 +333,7 @@ class ConfigBuilder
             }
 
             // check for commands where we accept multiple statements
-            if (in_array($command, array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'test_url', 'find_string', 'replace_string', 'login_extra_fields', 'native_ad_clue'))) {
+            if (in_array($command, array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'test_url', 'find_string', 'replace_string', 'login_extra_fields', 'native_ad_clue', 'date'))) {
                 array_push($config->$command, $val);
             // check for single statement commands that evaluate to true or false
             } elseif (in_array($command, array('tidy', 'prune', 'autodetect_on_failure', 'requires_login'))) {

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -134,7 +134,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
             '<html><meta name="generator" content="WordPress.com" /></html>'
         );
 
-        foreach (array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src') as $value) {
+        foreach (array('title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'date') as $value) {
             $this->assertGreaterThan(0, count($res->$value), 'Check count XPatch for: '.$value);
         }
     }

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -26,6 +26,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $contentExtractor->getContent());
         $this->assertEquals(null, $contentExtractor->getTitle());
         $this->assertEquals(null, $contentExtractor->getLanguage());
+        $this->assertEquals(null, $contentExtractor->getDate());
         $this->assertEquals(null, $contentExtractor->getSiteConfig());
         $this->assertEquals(null, $contentExtractor->getNextPageUrl());
     }
@@ -96,11 +97,11 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
             $this->assertEmpty($res->$value, 'Check empty value for: '.$value);
         }
 
-        foreach (array('strip_image_src', 'http_header') as $value) {
+        foreach (array('date', 'strip_image_src', 'http_header') as $value) {
             $this->assertNotEmpty($res->$value, 'Check not empty value for: '.$value);
         }
 
-        foreach (array('title', 'body', 'strip', 'strip_id_or_class', 'test_url') as $value) {
+        foreach (array('title', 'body', 'strip', 'strip_id_or_class', 'test_url', 'date') as $value) {
             $this->assertGreaterThan(0, count($res->$value), 'Check count XPatch for: '.$value);
         }
     }
@@ -273,6 +274,39 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals($languageExpected, $contentExtractor->getLanguage());
+    }
+
+    public function dataForDate()
+    {
+        return array(
+            // good time format
+            array('//time[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', strtotime('2015-01-01')),
+            // bad time format, null result
+            array('//time[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">date</time></html>', null),
+            // bad pattern but good @pubdate
+            array('//date[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', strtotime('2015-01-01')),
+            // good time format
+            array('string(//time[@pubdate or @pubDate])', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', strtotime('2015-01-01')),
+        );
+    }
+
+    /**
+     * @dataProvider dataForDate
+     */
+    public function testExtractDate($pattern, $html, $dateExpected)
+    {
+        $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
+
+        $config = new SiteConfig();
+        $config->date = array($pattern);
+
+        $contentExtractor->process(
+            $html,
+            'https://lemonde.io/35941909',
+            $config
+        );
+
+        $this->assertEquals($dateExpected, $contentExtractor->getDate());
     }
 
     public function dataForStrip()
@@ -451,6 +485,15 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
                 '<p class="entry-content">'.str_repeat('this is the best part of the show', 10).'</p>',
                 array(
                     'title' => 'hello !',
+                    'date' => strtotime('2015-01-01'),
+                ),
+            ),
+            // hNews with bad date
+            array(
+                '<html><body><div class="hentry"><time pubdate="2015-01-01">aweomse!</time>hello !hello !hello !hello !hello !hello !hello !<p class="entry-content">'.str_repeat('this is the best part of the show', 10).'</p></div></body></html>',
+                '<p class="entry-content">'.str_repeat('this is the best part of the show', 10).'</p>',
+                array(
+                    'date' => null,
                 ),
             ),
             // hNews with many content

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -280,13 +280,13 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             // good time format
-            array('//time[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', strtotime('2015-01-01')),
+            array('//time[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', '2015-01-01'),
             // bad time format, null result
             array('//time[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">date</time></html>', null),
             // bad pattern but good @pubdate
-            array('//date[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', strtotime('2015-01-01')),
+            array('//date[@pubdate or @pubDate]', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', '2015-01-01'),
             // good time format
-            array('string(//time[@pubdate or @pubDate])', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', strtotime('2015-01-01')),
+            array('string(//time[@pubdate or @pubDate])', '<html><time pubdate="2015-01-01">2015-01-01</time></html>', '2015-01-01'),
         );
     }
 
@@ -485,7 +485,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
                 '<p class="entry-content">'.str_repeat('this is the best part of the show', 10).'</p>',
                 array(
                     'title' => 'hello !',
-                    'date' => strtotime('2015-01-01'),
+                    'date' => '2015-01-01',
                 ),
             ),
             // hNews with bad date

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -224,6 +224,38 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $res['open_graph']);
     }
 
+    public function dataDate()
+    {
+        return array(
+            array('http://www.lemonde.fr/economie/article/2011/07/05/moody-s-abaisse-la-note-du-portugal-de-quatre-crans_1545237_3234.html', '2011-07-05T22:09:59+02:00'),
+            array('https://www.reddit.com/r/LinuxActionShow/comments/1fccny/arch_linux_survival_guide/', '2013-05-30T16:01:58+00:00'),
+        );
+    }
+
+    /**
+     * @dataProvider dataDate
+     */
+    public function testDate($url, $expectedDate)
+    {
+        $graby = new Graby(array('debug' => true, 'xss_filter' => false));
+        $res = $graby->fetchContent($url);
+
+        $this->assertCount(10, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('native_ad', $res);
+
+        $this->assertEquals($expectedDate, $res['date']);
+    }
+
     public function dataWithAccent()
     {
         return array(

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -24,12 +24,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -82,12 +83,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true));
         $res = $graby->fetchContent('http://bjori.blogspot.fr/2015/04/next-gen-mongodb-driver.html');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -115,12 +117,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true));
         $res = $graby->fetchContent('http://bjori.blogspot.fr/201');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -142,12 +145,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true));
         $res = $graby->fetchContent('http://img3.free.fr/im_tv/telesites/documentation.pdf');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -169,12 +173,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true));
         $res = $graby->fetchContent('http://a-eon.biz/PDF/News_Release_Developer.pdf');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -196,12 +201,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true, 'xss_filter' => false));
         $res = $graby->fetchContent('http://i.imgur.com/w9n2ID2.jpg');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -236,12 +242,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true, 'xss_filter' => false));
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -256,12 +263,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true, 'xss_filter' => false));
         $res = $graby->fetchContent('http://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -285,12 +293,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true));
         $res = $graby->fetchContent('http://blog.niqnutn.com/index.php?article49/commandes-de-base');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -305,12 +314,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true));
         $res = $graby->fetchContent('http://www.ufocasebook.com/gulfbreeze.html');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -329,12 +339,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(array('debug' => true, 'xss_filter' => false));
         $res = $graby->fetchContent('http://www.newstown.co.kr/news/articleView.html?idxno=243722');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
@@ -359,12 +370,13 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         ));
         $res = $graby->fetchContent('http://www.journaldugamer.com/tests/rencontre-ils-bossaient-sur-une-exclu-kinect-qui-ne-sortira-jamais/');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
         $this->assertArrayHasKey('title', $res);
         $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('url', $res);
         $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -122,7 +122,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals($language, $res['language']);
         $this->assertEquals($urlEffective, $res['url'], 'Same url');
         $this->assertEquals($title, $res['title'], 'Same title');
@@ -290,7 +290,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('Image', $res['title']);
         $this->assertEquals('<a href="http://lexpress.io/my%20awesome%20image.jpg"><img src="http://lexpress.io/my%20awesome%20image.jpg" alt="Image" /></a>', $res['html']);
@@ -385,7 +385,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals($title, $res['title']);
         $this->assertEquals($html, $res['html']);
@@ -430,7 +430,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://lexpress.io/test.pdf');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('Document1', $res['title']);
         $this->assertContains('Document title', $res['html']);
@@ -476,7 +476,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('https://github.com/nathanaccidentally/Cydia-Repo-Template/archive/master.zip');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('ZIP', $res['title']);
         $this->assertContains('<a href="https://github.com/nathanaccidentally/Cydia-Repo-Template/archive/master.zip">Download ZIP</a>', $res['html']);
@@ -519,7 +519,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://lexpress.io/test.pdf');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('Microsoft Word - Good_Product_Manager_Bad_Product_Manager_KV.doc', $res['title']);
         $this->assertContains('Good Product Manager Bad Product Manager By Ben Horowitz and David Weiden', $res['html']);
@@ -564,7 +564,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://lexpress.io/test.txt');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('Plain text', $res['title']);
         $this->assertEquals('<pre>plain text :)</pre>', $res['html']);
@@ -630,7 +630,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('my title', $res['title']);
         $this->assertEquals('my content', $res['html']);
@@ -680,7 +680,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('Image', $res['title']);
         $this->assertEquals('<a href="http://singlepage1.com/data.jpg"><img src="http://singlepage1.com/data.jpg" alt="Image" /></a>', $res['html']);
@@ -730,7 +730,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('my title', $res['title']);
         $this->assertEquals('my content<div class="story">my content</div>', $res['html']);
@@ -783,7 +783,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
@@ -833,7 +833,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
@@ -883,7 +883,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
@@ -933,7 +933,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
@@ -1144,7 +1144,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('No title found', $res['title']);
         $this->assertContains('<p>'.str_repeat('This is an awesome text with some links, here there are the awesome', 7).' links :)</p>', $res['html']);
@@ -1185,7 +1185,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('No title found', $res['title']);
         $this->assertEquals('[unable to retrieve full-text content]', $res['html']);
@@ -1218,7 +1218,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby();
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('No title found', $res['title']);
         $this->assertEquals('[unable to retrieve full-text content]', $res['html']);
@@ -1258,7 +1258,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('lexpress.io');
 
-        $this->assertCount(9, $res);
+        $this->assertCount(10, $res);
         $this->assertEquals('', $res['language']);
         $this->assertEquals('No title detected', $res['title']);
         $this->assertEquals('Nothing found, hu?', $res['html']);

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -32,6 +32,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
             'title: hoho',
             'tidy: yes',
             'parser: bob',
+            'date: foo',
             'replace_string(toto): titi',
             'http_header(user-agent): my-user-agent',
             'http_header(referer): http://idontl.ie',
@@ -47,6 +48,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
             'user-agent' => 'my-user-agent',
             'referer' => 'http://idontl.ie',
         );
+        $configExpected->date = array('foo');
 
         $this->assertEquals($configExpected, $configActual);
 


### PR DESCRIPTION
This PR adds back the support of date to extract the publication date of articles. Partially based on #22. 

Fixes #67 

- [x] Support of `date` in ConfigBuilder
- [x] Support of date extraction in ContentExtractor
- [x] Support of date in Graby
- [x] Tests for ContentExtractor
- [x] Tests for Graby