### PR TITLE
Fix importNode error in some case

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -282,7 +282,7 @@ class Graby
                     break;
                 }
 
-                $multiPageContent[] = $this->extractor->getContent();
+                $multiPageContent[] = clone $this->extractor->getContent();
             }
 
             // did we successfully deal with this multi-page article?

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -327,4 +327,33 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('프랑스 현대적 자연주의 브랜드', $res['summary']);
         $this->assertEquals('text/html', $res['content_type']);
     }
+
+    public function testMultipage()
+    {
+        $graby = new Graby(array(
+            'debug' => true,
+            'extractor' => array(
+                'config_builder' => array(
+                    'site_config' => array(dirname(__FILE__).'/fixtures/site_config'),
+                )
+            )
+        ));
+        $res = $graby->fetchContent('http://www.journaldugamer.com/tests/rencontre-ils-bossaient-sur-une-exclu-kinect-qui-ne-sortira-jamais/');
+
+        $this->assertCount(8, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+
+        $this->assertEquals(200, $res['status']);
+        $this->assertContains('[Rencontre] Ils bossaient sur une exclu Kinect qui ne sortira jamais', $res['title']);
+        $this->assertContains('Le Journal du Gamer', $res['summary']);
+        $this->assertEquals('text/html', $res['content_type']);
+    }
 }

--- a/tests/fixtures/site_config/journaldugamer.com.txt
+++ b/tests/fixtures/site_config/journaldugamer.com.txt
@@ -1,0 +1,10 @@
+date: //meta[@property="og:updated_time"]/@content
+next_page_link: //div[@class="post-content"]/div[@class='row pagination']/a[contains(concat(' ',normalize-space(@class),' '),' next ')]
+
+strip_id_or_class: jdg-recommend
+strip_id_or_class: proofreader-bloc
+
+# this line is for the test GrabyFunctionalTest->testMultipage
+strip_id_or_class: single-test
+
+body: //div[contains(concat(' ',normalize-space(@class),' '),' post-content ')]


### PR DESCRIPTION
Sometimes, error like this raise:

> DOMDocument::importNode(): Couldn't fetch Readability\JSLikeHTMLElement

Should fix #71 