### PR TITLE
Add ability to add pre/post filters to Readability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
 script:
     - mkdir -p build/logs
-    - phpunit -v $PHPUNIT_FLAGS
+    - ./vendor/bin/simple-phpunit -v $PHPUNIT_FLAGS
 
 after_script:
     - if [[ "$PHPUNIT_FLAGS" != "" ]]; then php vendor/bin/coveralls -v; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ php:
     - 7.0
     - 7.1
     - hhvm
+    - nightly
 
 # run build against nightly but allow them to fail
 matrix:
     fast_finish: true
     allow_failures:
+        - php: nightly
         - php: hhvm
     # only one build will send the coverage, this'll speed up other one
     include:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ $graby = new Graby(
             'site_config' => array(),
             'hostname_regex' => '/^(([a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9-]*[A-Za-z0-9])$/',
         ),
+        'readability' => array(
+            // filters might be like array('regex' => 'replace with')
+            // for example, to remove script content: array('!<script[^>]*>(.*?)</script>!is' => '')
+            'pre_filters' => array(),
+            'post_filters' => array(),
+        ),
     ),
 );
 ```

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "true/punycode": "~2.0"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "~0.6"
+        "satooshi/php-coveralls": "~0.6",
+        "symfony/phpunit-bridge": "~2.6|~3.0"
     },
     "autoload": {
         "psr-4": { "Graby\\": "src/" }

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -569,10 +569,10 @@ class ContentExtractor
     /**
      * Extract title for a given CSS class a node.
      *
-     * @param bool    $detectTitle Do we have to detect title ?
-     * @param string  $cssClass    CSS class to look for
-     * @param DOMNode $node        DOMNode to look into
-     * @param string  $logMessage
+     * @param bool     $detectTitle Do we have to detect title ?
+     * @param string   $cssClass    CSS class to look for
+     * @param \DOMNode $node        DOMNode to look into
+     * @param string   $logMessage
      *
      * @return bool Telling if we have to detect title again or not
      */

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -51,6 +51,10 @@ class ContentExtractor
                 '/\<meta\s*name=([\'"])generator([\'"])\s*content=([\'"])WordPress/i' => 'fingerprint.wordpress.com',
             ),
             'config_builder' => array(),
+            'readability' => array(
+                'pre_filters' => array(),
+                'post_filters' => array(),
+            ),
         ));
 
         $this->config = $resolver->resolve($config);
@@ -183,7 +187,8 @@ class ContentExtractor
         }
 
         $this->logger->log('debug', 'Attempting to parse HTML with {parser}', array('parser' => $parser));
-        $this->readability = new Readability($html, $url, $parser, $this->siteConfig->tidy() && $smartTidy);
+
+        $this->readability = $this->getReadability($html, $url, $parser, $this->siteConfig->tidy() && $smartTidy);
         $tidied = $this->readability->tidied;
 
         // we use xpath to find elements in the given HTML document
@@ -668,5 +673,34 @@ class ContentExtractor
         $this->logger->log('debug', '...{len} elements added to body', array('len' => $len));
 
         return false;
+    }
+
+    /**
+     * Return an instance of Readability with pre & post filters added.
+     *
+     * @param string $html       HTML to make readable from Readability lib
+     * @param string $url        URL of the content
+     * @param string $parser     Parser to use
+     * @param bool   $enableTidy Should it use tidy extension?
+     *
+     * @return Readability
+     */
+    private function getReadability($html, $url, $parser, $enableTidy)
+    {
+        $readability = new Readability($html, $url, $parser, $enableTidy);
+
+        if (isset($this->config['readability']['pre_filters']) && is_array($this->config['readability']['pre_filters'])) {
+            foreach ($this->config['readability']['pre_filters'] as $filter => $replacer) {
+                $readability->addPreFilter($filter, $replacer);
+            }
+        }
+
+        if (isset($this->config['readability']['post_filters']) && is_array($this->config['readability']['post_filters'])) {
+            foreach ($this->config['readability']['post_filters'] as $filter => $replacer) {
+                $readability->addPostFilter($filter, $replacer);
+            }
+        }
+
+        return $readability;
     }
 }

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -694,4 +694,73 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('Trying again without tidy', $records[5]['message']);
         }
     }
+
+    public function testWithCustomFiltersForReadability()
+    {
+        $contentExtractor = new ContentExtractor(
+            self::$contentExtractorConfig
+            + array('readability' => array(
+                'post_filters' => array('!<head[^>]*>(.*?)</head>!is' => ''),
+                'pre_filters' => array('!</?noscript>!is' => ''),
+            ))
+        );
+
+        $config = new SiteConfig();
+
+        $res = $contentExtractor->process(
+            '<!DOCTYPE html>
+<html lang="fr" dir="ltr">
+<head>
+<base href="http://www.lhc-france.fr/" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="SPIP 3.0.17 [21515]" />
+<link rel="shortcut icon" href="squelettes/favicon.ico" />
+<script type=\'text/javascript\'>
+document.createElement("header");document.createElement("footer");document.createElement("section");document.createElement("aside");document.createElement("nav");document.createElement("article");document.createElement("time");
+</script>
+<!--[if lt IE 9]>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <script type="text/javascript" src="http://www.lhc-france.fr/squelettes/js/ie.js"></script>
+<![endif]-->
+
+<script type="text/javascript" src="http://www.lhc-france.fr/squelettes/js/modernizr.js"></script>
+<script type="text/javascript">
+function handleError(){return true;}
+window.onerror = handleError;
+dossier_squelettes = \'squelettes\';
+secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
+</script>
+
+<link rel="alternate" type="application/rss+xml" title="Actualit��s du LHC" href="http://feeds.feedburner.com/lhcfranceactus?format=xml" />
+<link rel="alternate" type="application/rss+xml" title="La BD du LHC" href="http://www.lhc-france.fr/?page=backend&id_rubrique=65" />
+
+<link rel="stylesheet" href="http://www.lhc-france.fr/local/cache-css/styles-urlabs-b1fc-urlabs-b1fc-minify-3f10.css" type="text/css" media="all" />
+<link rel="stylesheet" href="http://www.lhc-france.fr/local/cache-css/milkbox-urlabs-fe01-urlabs-fe01-minify-1d16.css" media="screen" />
+<link rel="stylesheet" href="http://www.lhc-france.fr/local/cache-css/styles.print-urlabs-2157-urlabs-2157-minify-d3e7.css" type="text/css" media="print" />
+<link rel="stylesheet" href="http://www.lhc-france.fr/squelettes/styles.rouge.css" type="text/css" media="all" />
+
+<script type="text/javascript" src="http://www.lhc-france.fr/local/cache-js/AC_RunActiveContent-minify-d850.js"></script>
+<title>Novembre 2016 - Je voudrais de la mati��re noire �� No��l... | LHC France</title>
+<meta name="robots" content="index, follow, all" />
+<meta name="description" content="La contribution du CNRS et du CEA au LHC, un instrument international de physique des particules situ�� au Cern. Avec toute l\'actualit�� du projet et la BD du LHC." />
+<meta name="keywords" content="LHC,Higgs,Atlas,CMS,Alice,LHCb,acc��l��rateur,particule,Cern,grille,d��tecteur,exp��riences,boson de higgs" />
+
+<meta name="verify-v1" content="WWk3UJy6FdmEUs2ZATuUi6+OQnIL3Sci3WmPHmaWQWs=" />
+<meta name="verify-v1" content="VAs7L6UxdHUoi699A76rt8aDBfL4c6hBE3vJw2SRbh4=" />
+<meta property="og:image" content="http://www.lhc-france.fr/IMG/arton907.jpg" />
+<meta property="fb:admins" content="thomas.diluccio,proyoledegieux"/>
+</head>
+<body class="rouge "><p>'.str_repeat('This is important. ', 20).'</p></body></html>',
+            'https://lemonde.io/35941909',
+            $config
+        );
+
+        $this->assertTrue($res, 'Extraction went well');
+
+        $domElement = $contentExtractor->getContent();
+        $content = $domElement->ownerDocument->saveXML($domElement);
+
+        $this->assertNotContains('<head>', $content);
+        $this->assertNotContains('<base>', $content);
+    }
 }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -335,8 +335,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
             'extractor' => array(
                 'config_builder' => array(
                     'site_config' => array(dirname(__FILE__).'/fixtures/site_config'),
-                )
-            )
+                ),
+            ),
         ));
         $res = $graby->fetchContent('http://www.journaldugamer.com/tests/rencontre-ils-bossaient-sur-une-exclu-kinect-qui-ne-sortira-jamais/');
 


### PR DESCRIPTION
For the moment, we'll be able to add `pre_filters` & `post_filters` to Readability.
It'll ease the removal of content from the final client (like wallabag)

Should fix https://github.com/j0k3r/graby/issues/74