### PR TITLE
Use wallabag/tcpdf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/options-resolver": "~2.6|~3.0",
         "monolog/monolog": "^1.13.1",
         "smalot/pdfparser": "~0.9.24",
+        "wallabag/tcpdf": "^6.2",
         "true/punycode": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
tecnickcom/tcpdf is not maintain anymore.
Developer has moved to a new library which is far from being stable atm.
Instead of keeping an unmaintain deps, the wallabag/core team forked the original repo to submit patch.

See https://github.com/wallabag/wallabag/issues/2930