### PR TITLE
Use parseContent method for parsing PDFs

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -42,7 +42,6 @@ class HttpClient
             // HTTP responses which match these content types will
             // be returned without body.
             'header_only_types' => array(
-                'application/pdf',
                 'image',
                 'audio',
                 'video',

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -47,9 +47,9 @@ class HttpClient
                 'video',
             ),
             // URLs ending with one of these extensions will
-            // prompt Humble HTTP Agent to send a HEAD request first
+            // prompt client to send a HEAD request first
             // to see if returned content type matches $headerOnlyTypes.
-            'header_only_clues' => array('pdf', 'mp3', 'zip', 'exe', 'gif', 'gzip', 'gz', 'jpeg', 'jpg', 'mpg', 'mpeg', 'png', 'ppt', 'mov'),
+            'header_only_clues' => array('mp3', 'zip', 'exe', 'gif', 'gzip', 'gz', 'jpeg', 'jpg', 'mpg', 'mpeg', 'png', 'ppt', 'mov'),
             // User Agent strings - mapping domain names
             'user_agents' => array(),
             // AJAX triggers to search for.

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -535,7 +535,7 @@ class Graby
 
                 if ($mimeInfo['mime'] == 'application/pdf') {
                     $parser = new PdfParser();
-                    $pdf = $parser->parseFile($effectiveUrl);
+                    $pdf = $parser->parseContent($body);
 
                     // tiny hack to avoid character like �
                     $html = mb_convert_encoding(nl2br($pdf->getText()), 'UTF-8', 'UTF-8');

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -402,10 +402,9 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        // hacking stuff to avoid to mock the file_get_contents from PdfParser->parseFile()
         $response->expects($this->once())
             ->method('getEffectiveUrl')
-            ->willReturn(dirname(__FILE__).'/fixtures/document1.pdf');
+            ->willReturn('http://lexpress.io/test.pdf');
 
         $response->expects($this->any())
             ->method('getHeader')
@@ -415,12 +414,16 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->willReturn(200);
 
+        $response->expects($this->any())
+            ->method('getBody')
+            ->willReturn(file_get_contents(dirname(__FILE__).'/fixtures/document1.pdf'));
+
         $client = $this->getMockBuilder('GuzzleHttp\Client')
             ->disableOriginalConstructor()
             ->getMock();
 
         $client->expects($this->once())
-            ->method('head')
+            ->method('get')
             ->willReturn($response);
 
         $graby = new Graby(array(), $client);
@@ -432,7 +435,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Document1', $res['title']);
         $this->assertContains('Document title', $res['html']);
         $this->assertContains('Morbi vulputate tincidunt ve nenatis.', $res['html']);
-        $this->assertContains('fixtures/document1.pdf', $res['url']);
+        $this->assertContains('http://lexpress.io/test.pdf', $res['url']);
         $this->assertContains('Document title Calibri : Lorem ipsum dolor sit amet', $res['summary']);
         $this->assertEquals('application/pdf', $res['content_type']);
         $this->assertEquals(array(), $res['open_graph']);
@@ -488,10 +491,9 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        // hacking stuff to avoid to mock the file_get_contents from PdfParser->parseFile()
         $response->expects($this->once())
             ->method('getEffectiveUrl')
-            ->willReturn(dirname(__FILE__).'/fixtures/Good_Product_Manager_Bad_Product_Manager_KV.pdf');
+            ->willReturn('http://lexpress.io/test.pdf');
 
         $response->expects($this->any())
             ->method('getHeader')
@@ -501,12 +503,16 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->method('getStatusCode')
             ->willReturn(200);
 
+        $response->expects($this->any())
+            ->method('getBody')
+            ->willReturn(file_get_contents(dirname(__FILE__).'/fixtures/Good_Product_Manager_Bad_Product_Manager_KV.pdf'));
+
         $client = $this->getMockBuilder('GuzzleHttp\Client')
             ->disableOriginalConstructor()
             ->getMock();
 
         $client->expects($this->once())
-            ->method('head')
+            ->method('get')
             ->willReturn($response);
 
         $graby = new Graby(array(), $client);
@@ -517,7 +523,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $res['language']);
         $this->assertEquals('Microsoft Word - Good_Product_Manager_Bad_Product_Manager_KV.doc', $res['title']);
         $this->assertContains('Good Product Manager Bad Product Manager By Ben Horowitz and David Weiden', $res['html']);
-        $this->assertContains('fixtures/Good_Product_Manager_Bad_Product_Manager_KV.pdf', $res['url']);
+        $this->assertContains('http://lexpress.io/test.pdf', $res['url']);
         $this->assertContains('Good Product Manager Bad Product Manager By Ben Horowitz and David Weiden', $res['summary']);
         $this->assertEquals('application/pdf', $res['content_type']);
         $this->assertEquals(array(), $res['open_graph']);
@@ -767,12 +773,8 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $client->expects($this->once())
+        $client->expects($this->exactly(2))
             ->method('get')
-            ->willReturn($response);
-
-        $client->expects($this->once())
-            ->method('head')
             ->willReturn($response);
 
         $graby = new Graby(array('content_links' => 'footnotes', 'extractor' => array('config_builder' => array(


### PR DESCRIPTION
Since the response body is available, there is no need to re-fetch the resource again. Additionally, the PDF parser [does not handle errors when fetching files](https://github.com/smalot/pdfparser/blob/c20bfd40e3d7f40ff4083de5971b2a9e7a839dd5/src/Smalot/PdfParser/Parser.php#L72), so this also improves error handling. This is the brokenness I mentioned [here](https://github.com/j0k3r/graby/pull/80#issuecomment-287549743), the server returned 403 but PdfParser complained about being unable to parse.