### PR TITLE
Safe iframe

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -147,6 +147,8 @@ class Graby
             $this->logger->log('debug', 'Filtering HTML to remove XSS');
             $infos['html'] = htmLawed($infos['html'], [
                 'safe' => 1,
+                // which means: do not remove iframe elements
+                'elements' => '*+iframe',
                 'deny_attribute' => 'style',
                 'comment' => 1,
                 'cdata' => 1,

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -75,7 +75,7 @@ class Graby
 
         if ($this->debug) {
             $this->logger = new Logger('graby');
-            $this->logger->pushHandler(new StreamHandler(dirname(__FILE__) . '/../log/graby.log'));
+            $this->logger->pushHandler(new StreamHandler(__DIR__ . '/../log/graby.log'));
         }
 
         $this->configBuilder = $configBuilder;

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -14,13 +14,13 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         self::$contentExtractorConfig = ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/../fixtures/site_config'],
+            'site_config' => [__DIR__ . '/../fixtures/site_config'],
         ]];
     }
 
     public function testConstructDefault()
     {
-        $contentExtractor = new ContentExtractor(['config_builder' => ['site_config' => [dirname(__FILE__)]]]);
+        $contentExtractor = new ContentExtractor(['config_builder' => ['site_config' => [__DIR__]]]);
         $contentExtractor->reset();
 
         $this->assertNull($contentExtractor->getContent());
@@ -58,7 +58,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
     public function testFingerPrints($html, $fingerprints)
     {
         $contentExtractor = new ContentExtractor([
-            'config_builder' => ['site_config' => [dirname(__FILE__)]],
+            'config_builder' => ['site_config' => [__DIR__]],
         ]);
 
         $res = $contentExtractor->findHostUsingFingerprints('');
@@ -79,7 +79,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
     public function testBuildSiteConfigUnknownSite()
     {
         $contentExtractor = new ContentExtractor(['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/../../wrong_site_config'],
+            'site_config' => [__DIR__ . '/../../wrong_site_config'],
         ]]);
         $contentExtractor->buildSiteConfig('http://0.0.0.0');
     }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -447,7 +447,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
             'debug' => true,
             'extractor' => [
                 'config_builder' => [
-                    'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+                    'site_config' => [__DIR__ . '/fixtures/site_config'],
                 ],
             ],
         ]);

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -208,7 +208,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
 
     public function testImageFile()
     {
-        $graby = new Graby(['debug' => true, 'xss_filter' => false]);
+        $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://i.imgur.com/w9n2ID2.jpg');
 
         $this->assertCount(11, $res);
@@ -230,7 +230,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($res['authors']);
         $this->assertSame('http://i.imgur.com/w9n2ID2.jpg', $res['url']);
         $this->assertSame('Image', $res['title']);
-        $this->assertSame('<a href="http://i.imgur.com/w9n2ID2.jpg"><img src="http://i.imgur.com/w9n2ID2.jpg" alt="Image" /></a>', $res['html']);
+        $this->assertSame('<a href="http://i.imgur.com/w9n2ID2.jpg"><img src="http://i.imgur.com/w9n2ID2.jpg" alt="image" /></a>', $res['html']);
         $this->assertEmpty($res['summary']);
         $this->assertSame('image/jpeg', $res['content_type']);
         $this->assertSame([], $res['open_graph']);
@@ -249,7 +249,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
      */
     public function testDate($url, $expectedDate)
     {
-        $graby = new Graby(['debug' => true, 'xss_filter' => false]);
+        $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent($url);
 
         $this->assertCount(11, $res);
@@ -282,7 +282,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
      */
     public function testAuthors($url, $expectedAuthors)
     {
-        $graby = new Graby(['debug' => true, 'xss_filter' => false]);
+        $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent($url);
 
         $this->assertCount(11, $res);
@@ -317,7 +317,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
      */
     public function testAccentuedUrls($url)
     {
-        $graby = new Graby(['debug' => true, 'xss_filter' => false]);
+        $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent($url);
 
         $this->assertCount(11, $res);
@@ -339,7 +339,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
 
     public function testYoutubeOembed()
     {
-        $graby = new Graby(['debug' => true, 'xss_filter' => false]);
+        $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml');
 
         $this->assertCount(11, $res);
@@ -360,7 +360,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($res['language']);
         $this->assertSame('http://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml', $res['url']);
         $this->assertSame('[Review] The Matrix Falling (Rain) Source Code C++', $res['title']);
-        $this->assertSame('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="">[embedded content]</iframe>', $res['html']);
+        $this->assertSame('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="allowfullscreen">[embedded content]</iframe>', $res['html']);
         $this->assertSame('[embedded content]', $res['summary']);
         $this->assertSame('text/xml', $res['content_type']);
         $this->assertSame([], $res['open_graph']);
@@ -418,7 +418,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
 
     public function testKoreanPage()
     {
-        $graby = new Graby(['debug' => true, 'xss_filter' => false]);
+        $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://www.newstown.co.kr/news/articleView.html?idxno=243722');
 
         $this->assertCount(11, $res);

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -122,10 +122,10 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             'extractor' => [
                 'config_builder' => [
                     'site_config' => [
-                        dirname(__FILE__) . '/fixtures/site_config'
+                        __DIR__ . '/fixtures/site_config',
                     ],
-                ]
-            ]
+                ],
+            ],
         ], $client);
 
         $res = $graby->fetchContent($url);
@@ -436,7 +436,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $response->expects($this->any())
             ->method('getBody')
-            ->willReturn(file_get_contents(dirname(__FILE__) . '/fixtures/document1.pdf'));
+            ->willReturn(file_get_contents(__DIR__ . '/fixtures/document1.pdf'));
 
         $client = $this->getMockBuilder('GuzzleHttp\Client')
             ->disableOriginalConstructor()
@@ -525,7 +525,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $response->expects($this->any())
             ->method('getBody')
-            ->willReturn(file_get_contents(dirname(__FILE__) . '/fixtures/Good_Product_Manager_Bad_Product_Manager_KV.pdf'));
+            ->willReturn(file_get_contents(__DIR__ . '/fixtures/Good_Product_Manager_Bad_Product_Manager_KV.pdf'));
 
         $client = $this->getMockBuilder('GuzzleHttp\Client')
             ->disableOriginalConstructor()
@@ -647,7 +647,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->willReturn($response);
 
         $graby = new Graby(['content_links' => 'footnotes', 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+            'site_config' => [__DIR__ . '/fixtures/site_config'],
         ]]], $client);
 
         $res = $graby->fetchContent('lexpress.io');
@@ -697,7 +697,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->willReturn($response);
 
         $graby = new Graby(['xss_filter' => false, 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+            'site_config' => [__DIR__ . '/fixtures/site_config'],
         ]]], $client);
 
         $res = $graby->fetchContent('lexpress.io');
@@ -747,7 +747,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->willReturn($response);
 
         $graby = new Graby(['content_links' => 'footnotes', 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+            'site_config' => [__DIR__ . '/fixtures/site_config'],
         ]]], $client);
 
         $res = $graby->fetchContent('lexpress.io');
@@ -800,7 +800,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->willReturn($response);
 
         $graby = new Graby(['content_links' => 'footnotes', 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+            'site_config' => [__DIR__ . '/fixtures/site_config'],
         ]]], $client);
 
         $res = $graby->fetchContent('lexpress.io');
@@ -850,7 +850,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->willReturn($response);
 
         $graby = new Graby(['content_links' => 'footnotes', 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+            'site_config' => [__DIR__ . '/fixtures/site_config'],
         ]]], $client);
 
         $res = $graby->fetchContent('lexpress.io');
@@ -900,7 +900,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->willReturn($response);
 
         $graby = new Graby(['content_links' => 'footnotes', 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+            'site_config' => [__DIR__ . '/fixtures/site_config'],
         ]]], $client);
 
         $res = $graby->fetchContent('lexpress.io');
@@ -950,7 +950,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->willReturn($response);
 
         $graby = new Graby(['content_links' => 'footnotes', 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
+            'site_config' => [__DIR__ . '/fixtures/site_config'],
         ]]], $client);
 
         $res = $graby->fetchContent('lexpress.io');

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -117,9 +117,16 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             ->with($url)
             ->willReturn($response);
 
-        $graby = new Graby(['xss_filter' => false, 'extractor' => ['config_builder' => [
-            'site_config' => [dirname(__FILE__) . '/fixtures/site_config'],
-        ]]], $client);
+        $graby = new Graby([
+            'xss_filter' => false,
+            'extractor' => [
+                'config_builder' => [
+                    'site_config' => [
+                        dirname(__FILE__) . '/fixtures/site_config'
+                    ],
+                ]
+            ]
+        ], $client);
 
         $res = $graby->fetchContent($url);
 

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -11,12 +11,12 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructDefault()
     {
-        $configBuilder = new ConfigBuilder(['site_config' => [dirname(__FILE__)]]);
+        $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
     }
 
     public function testBuildFromArrayNoLines()
     {
-        $configBuilder = new ConfigBuilder(['site_config' => [dirname(__FILE__)]]);
+        $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
         $configActual = $configBuilder->parseLines([]);
 
         $this->assertEquals($configBuilder->create(), $configActual);
@@ -24,7 +24,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFromArray()
     {
-        $configBuilder = new ConfigBuilder(['site_config' => [dirname(__FILE__)]]);
+        $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
         $configActual = $configBuilder->parseLines([
             '# this is a comment and it will be removed',
             'no colon on this line, it will be removed',
@@ -81,7 +81,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddToCache($key, $cachedKey, $expectedKey)
     {
-        $configBuilder = new ConfigBuilder(['site_config' => [dirname(__FILE__)]]);
+        $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
 
         $config = $configBuilder->create();
         $config->body = ['//test'];
@@ -109,7 +109,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
     public function testCachedVersion($key, $cached)
     {
         $config = false;
-        $configBuilder = new ConfigBuilder(['site_config' => [dirname(__FILE__)]]);
+        $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
 
         if ($cached) {
             $config = $configBuilder->create();
@@ -123,7 +123,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildOnCachedVersion()
     {
-        $configBuilder = new ConfigBuilder(['site_config' => [dirname(__FILE__)]]);
+        $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
         $config1 = $configBuilder->buildForHost('www.host.io');
 
         $this->assertInstanceOf('Graby\SiteConfig\SiteConfig', $config1);
@@ -166,7 +166,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
     public function testBuildSiteConfig($host, $expectedRes, $matchedHost = null)
     {
         $configBuilder = new ConfigBuilder([
-            'site_config' => [dirname(__FILE__) . '/../fixtures/site_config'],
+            'site_config' => [__DIR__ . '/../fixtures/site_config'],
         ]);
 
         $res = $configBuilder->loadSiteConfig($host);
@@ -182,7 +182,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
     public function testBuildWithCachedVersion()
     {
         $configBuilder = new ConfigBuilder([
-            'site_config' => [dirname(__FILE__) . '/../fixtures/site_config'],
+            'site_config' => [__DIR__ . '/../fixtures/site_config'],
         ]);
 
         $res = $configBuilder->loadSiteConfig('fr.wikipedia.org');
@@ -204,7 +204,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
         $logger->pushHandler($handler);
 
         $configBuilder = new ConfigBuilder([
-            'site_config' => [dirname(__FILE__) . '/../fixtures/site_config'],
+            'site_config' => [__DIR__ . '/../fixtures/site_config'],
         ]);
         $configBuilder->setLogger($logger);
 


### PR DESCRIPTION
Since a previous fix (https://github.com/j0k3r/graby/pull/82), iframes were removed by htmLawed leaving them as `[embedded content]` only

Might fix https://github.com/j0k3r/f43.me/issues/133