### PR TITLE
Fix url extraction when url contains the symbol '+'

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -206,7 +206,7 @@ class HttpClient
         }
 
         // remove utm parameters & fragment
-        $effectiveUrl = preg_replace('/((\?)?(&(amp;)?)?utm_(.*?)\=[^&]+)|(#(.*?)\=[^&]+)/', '', urldecode($effectiveUrl));
+        $effectiveUrl = preg_replace('/((\?)?(&(amp;)?)?utm_(.*?)\=[^&]+)|(#(.*?)\=[^&]+)/', '', rawurldecode($effectiveUrl));
 
         $this->logger->log('debug', 'Data fetched: {data}', ['data' => [
             'effective_url' => $effectiveUrl,

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -436,6 +436,22 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(200, $res['status']);
     }
 
+    public function testWithUrlContainingPlusSymbol()
+    {
+        $client = new Client();
+
+        $mock = new Mock([
+            new Response(200),
+        ]);
+
+        $client->getEmitter()->attach($mock);
+
+        $http = new HttpClient($client);
+        $res = $http->fetch('https://example.com/foo/+bar/baz/+quuz/corge');
+
+        $this->assertSame('https://example.com/foo/+bar/baz/+quuz/corge', $res['effective_url']);
+    }
+
     public function testWith404ResponseWithoutResponse()
     {
         $request = $this->getMockBuilder('GuzzleHttp\Message\Request')


### PR DESCRIPTION
The plus symbols ('+') was replaced by a space character.

See https://github.com/wallabag/wallabag/issues/3002