### PR TITLE
ng-controller should not trigger escaped fragment

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -60,7 +60,6 @@ class HttpClient
                 '<meta name="fragment" content="!"',
                 "<meta content='!' name='fragment'",
                 '<meta content="!" name="fragment"',
-                ' ng-controller=',
             ],
             // timeout of the request in seconds
             'timeout' => 10,

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -302,11 +302,6 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
                 '<html><meta name="fragment" content="!"></html>',
                 'http://www.bernama.com/bernama/v6/newsindex.php?id=943513',
             ],
-            [
-                'http://fr.wikipedia.org/wiki/Copyright',
-                '<html><body ng-controller="MyCtrl"></body></html>',
-                'http://www.bernama.com/bernama/v6/newsindex.php?id=943513',
-            ],
         ];
     }
 


### PR DESCRIPTION
By convention, it seems that Angular website doesn't always handle escaped fragment to get full html page.

In fact, the website which used Angular with escaped fragment now handle the fragment meta: https://tempostorm.com/articles/the-singleton-special-when-to-oneoff:

```html
<meta name="fragment" content="!">
```

Might fix https://github.com/j0k3r/graby/issues/48