### PR TITLE
Implemented extra config builder extension point

### DIFF
--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -16,6 +16,7 @@ class ConfigBuilder
 
     /**
      * Third party config builders, indexed by their prefix.
+     *
      * @var \Graby\SiteConfig\ExtraConfigBuilder[]
      */
     private $extraConfigBuilders = [];
@@ -351,7 +352,7 @@ class ConfigBuilder
             }
 
             foreach (array_keys($this->extraConfigBuilders) as $prefix) {
-                if (strpos($command, $prefix . "_") === false) {
+                if (strpos($command, $prefix.'_') === false) {
                     continue;
                 }
                 $command = substr($command, strlen($prefix) + 1);
@@ -360,7 +361,7 @@ class ConfigBuilder
                 } elseif (!is_array($extraConfigItems[$prefix][$command])) {
                     $extraConfigItems[$prefix][$command] = [
                         $extraConfigItems[$prefix][$command],
-                        $val
+                        $val,
                     ];
                 } else {
                     $extraConfigItems[$prefix][$command][] = $val;

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -351,20 +351,21 @@ class ConfigBuilder
             }
 
             foreach (array_keys($this->extraConfigBuilders) as $prefix) {
-                if (strpos($command, $prefix . "_") === 0) {
-                    $command = substr($command, strlen($prefix) + 1);
-                    if (!isset($extraConfigItems[$prefix][$command])) {
-                        $extraConfigItems[$prefix][$command] = $val;
-                    } elseif (!is_array($extraConfigItems[$prefix][$command])) {
-                        $extraConfigItems[$prefix][$command] = [
-                            $extraConfigItems[$prefix][$command],
-                            $val
-                        ];
-                    } else {
-                        $extraConfigItems[$prefix][$command][] = $val;
-                    }
-                    continue 2;
+                if (strpos($command, $prefix . "_") === false) {
+                    continue;
                 }
+                $command = substr($command, strlen($prefix) + 1);
+                if (!isset($extraConfigItems[$prefix][$command])) {
+                    $extraConfigItems[$prefix][$command] = $val;
+                } elseif (!is_array($extraConfigItems[$prefix][$command])) {
+                    $extraConfigItems[$prefix][$command] = [
+                        $extraConfigItems[$prefix][$command],
+                        $val
+                    ];
+                } else {
+                    $extraConfigItems[$prefix][$command][] = $val;
+                }
+                continue 2;
             }
 
             // check for commands where we accept multiple statements

--- a/src/SiteConfig/ExtraConfigBuilder.php
+++ b/src/SiteConfig/ExtraConfigBuilder.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
- * @license For full copyright and license information view LICENSE file distributed with this source code.
- */
-
 namespace Graby\SiteConfig;
-
 
 interface ExtraConfigBuilder
 {

--- a/src/SiteConfig/ExtraConfigBuilder.php
+++ b/src/SiteConfig/ExtraConfigBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Graby\SiteConfig;
 
 interface ExtraConfigBuilder

--- a/src/SiteConfig/ExtraConfigBuilder.php
+++ b/src/SiteConfig/ExtraConfigBuilder.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace Graby\SiteConfig;
+
+
+interface ExtraConfigBuilder
+{
+    /**
+     * Parses an array of commands => values into a SiteExtraConfig object.
+     *
+     * @param array $commands
+     *
+     * @return \Graby\SiteConfig\SiteExtraConfig
+     */
+    public function parseCommands(array $commands);
+}

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -129,6 +129,11 @@ class SiteConfig
     public $login_extra_fields = array();
 
     /**
+     * @var \Graby\SiteConfig\SiteExtraConfig[]
+     */
+    public $extraConfigs = [];
+
+    /**
      * Process HTML with tidy before creating DOM (bool or null if undeclared).
      *
      * @param bool $use_default

--- a/src/SiteConfig/SiteExtraConfig.php
+++ b/src/SiteConfig/SiteExtraConfig.php
@@ -1,0 +1,7 @@
+<?php
+namespace Graby\SiteConfig;
+
+interface SiteExtraConfig
+{
+
+}

--- a/src/SiteConfig/SiteExtraConfig.php
+++ b/src/SiteConfig/SiteExtraConfig.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Graby\SiteConfig;
 
 interface SiteExtraConfig
 {
-
 }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -335,8 +335,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
             'extractor' => array(
                 'config_builder' => array(
                     'site_config' => array(dirname(__FILE__).'/fixtures/site_config'),
-                )
-            )
+                ),
+            ),
         ));
         $res = $graby->fetchContent('http://www.journaldugamer.com/tests/rencontre-ils-bossaient-sur-une-exclu-kinect-qui-ne-sortira-jamais/');
 


### PR DESCRIPTION
Third parties can register extra configuration, given a prefix and an `ExtraConfigBuilder`.
All commands starting with the given prefix will be sent to the matching builder, that will return a custom `ExtraSiteConfig` object.

Example:

```
$configBuilder->addExtraConfigBuilder('paywall', new PaywallExtraConfigBuilder());
```

Implementors are responsible for defining their own ExtraSiteConfig object, as well as their own
`ExtraConfigBuilder`.