### PR TITLE
Ability to clean given HTML

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -165,6 +165,11 @@ class Graby
             $contentBlock = $this->extractor->getContent();
         }
 
+        // in case of extractor failed
+        if (null === $contentBlock) {
+            return trim($this->cleanupXss($originalContentBlock));
+        }
+
         $this->extractor->readability->clean($contentBlock, 'select');
 
         if ($this->config['rewrite_relative_urls']) {

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -114,6 +114,17 @@ class Graby
     }
 
     /**
+     * Get the Content Extractor.
+     * Can be used to clean html content without fetching an url.
+     *
+     * @return ContentExtractor
+     */
+    public function getExtractor()
+    {
+        return $this->extractor;
+    }
+
+    /**
      * Return a config.
      *
      * @param string $key

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -158,6 +158,8 @@ class Graby
      */
     public function cleanupHtml($contentBlock, $url)
     {
+        $originalContentBlock = $contentBlock;
+
         // if content is pure html, convert it
         if (!$contentBlock instanceof \DOMElement) {
             $this->extractor->process($contentBlock, $url);
@@ -167,6 +169,8 @@ class Graby
 
         // in case of extractor failed
         if (null === $contentBlock) {
+            $this->logger->log('debug', 'Cleanup html failed. Return given content (a bit cleaned)');
+
             return trim($this->cleanupXss($originalContentBlock));
         }
 

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -11,7 +11,6 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
 
         $this->assertTrue($graby->getConfig('debug'));
-        $this->assertInstanceof('\Graby\Extractor\ContentExtractor', $graby->getExtractor());
     }
 
     /**

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -11,6 +11,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
 
         $this->assertTrue($graby->getConfig('debug'));
+        $this->assertInstanceof('\Graby\Extractor\ContentExtractor', $graby->getExtractor());
     }
 
     /**


### PR DESCRIPTION
Add ability to clean a given HTML content using same method as when fetching content from an url.
For example it'll allow wallabag to save content without fetching url (when using from a browser extension for example).

Code as been a refactored to move clean logic into a dedicated method.

Also, the method `handleMimeAction` is now more clear and less complex.

@tcitworld @nicosomb what crazy html content should I check for that particular case?
I've added some obvious xss using `<script>` tag but I think we can found more malicious HTML :skull_and_crossbones: 