### PR TITLE
Take only the first og:image

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -829,9 +829,10 @@ class Graby
         foreach ($metas as $meta) {
             $property = str_replace(':', '_', $meta->getAttribute('property'));
 
-            // avoid image data:uri to avoid sending too much data
             if ('og_image' === $property) {
-                if (0 === stripos($meta->getAttribute('content'), 'data:image')) {
+                // avoid image data:uri to avoid sending too much data
+                // also, take the first og:image which is usually the best one
+                if (0 === stripos($meta->getAttribute('content'), 'data:image') || !empty($rmetas[$property])) {
                     continue;
                 }
 

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -495,4 +495,32 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Le Journal du Gamer', $res['summary']);
         $this->assertSame('text/html', $res['content_type']);
     }
+
+    public function testMultipleOgImage()
+    {
+        $graby = new Graby([
+            'debug' => true,
+        ]);
+        $res = $graby->fetchContent('https://blog.tinned-software.net/restore-mysql-replication-after-error/');
+
+        $this->assertCount(12, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
+        $this->assertArrayHasKey('authors', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('native_ad', $res);
+        $this->assertArrayHasKey('all_headers', $res);
+
+        $this->assertSame(200, $res['status']);
+        $this->assertSame('2015-06-08T19:08:47+00:00', $res['date']);
+        $this->assertContains('Restore MySQL replication after error - Experiencing Technology', $res['title']);
+        $this->assertSame('https://blog.tinned-software.net/wp-content/uploads/2014/03/Fix_MySQL_replication_error.png', $res['open_graph']['og_image']);
+    }
 }


### PR DESCRIPTION
Keep only the og:image we found, which is usually the best one.
Should fix https://github.com/wallabag/wallabag/issues/3115