### PR TITLE
If request fail try to fetch content anyway

### DIFF
--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -407,7 +407,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $res = $http->fetch('http://www.lexpress.io/my-map.html');
 
         $this->assertSame('http://www.lexpress.io/my-map.html', $res['effective_url']);
-        $this->assertSame('', $res['body']);
+        $this->assertSame('test', $res['body']);
         $this->assertSame('text/html', $res['headers']);
         $this->assertSame(404, $res['status']);
     }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -141,11 +141,11 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(404, $res['status']);
         $this->assertEmpty($res['language']);
         $this->assertSame('https://bjori.blogspot.fr/201', $res['url']);
-        $this->assertSame('No title found', $res['title']);
+        $this->assertSame("bjori doesn't blog", $res['title']);
         $this->assertSame('[unable to retrieve full-text content]', $res['html']);
         $this->assertSame('[unable to retrieve full-text content]', $res['summary']);
         $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertNotEmpty($res['open_graph']);
     }
 
     public function testPdfFile()


### PR DESCRIPTION
Some content fail to be requested (because they return a code 50x or 40x) but they content a response.
Some website doesn’t work as expected and return an error when they actually send the good content.

So if the exception contain a response, we’ll now try to retrieve content from it.

Will fix https://github.com/wallabag/wallabag/issues/3250