### PR TITLE
Rise log level when catching exception

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -138,7 +138,7 @@ class HttpClient
                     'status' => 500,
                 ];
 
-                $this->logger->log('debug', 'Request throw exception (with no response): {error_message}', ['error_message' => $e->getMessage()]);
+                $this->logger->log('error', 'Request throw exception (with no response): {error_message}', ['error_message' => $e->getMessage()]);
                 $this->logger->log('debug', 'Data fetched: {data}', ['data' => $data]);
 
                 return $this->sendResults($data);
@@ -147,7 +147,7 @@ class HttpClient
             // exception has a response which means we might be able to retrieve content from it, log it and continue
             $response = $e->getResponse();
 
-            $this->logger->log('debug', 'Request throw exception (with a response): {error_message}', ['error_message' => $e->getMessage()]);
+            $this->logger->log('error', 'Request throw exception (with a response): {error_message}', ['error_message' => $e->getMessage()]);
         }
 
         $effectiveUrl = $response->getEffectiveUrl();

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -335,13 +335,13 @@ class ConfigBuilder
             // check for commands where we accept multiple statements
             if (in_array($command, ['title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'test_url', 'find_string', 'replace_string', 'login_extra_fields', 'native_ad_clue', 'date', 'author'], true)) {
                 array_push($config->$command, $val);
-            // check for single statement commands that evaluate to true or false
+                // check for single statement commands that evaluate to true or false
             } elseif (in_array($command, ['tidy', 'prune', 'autodetect_on_failure', 'requires_login'], true)) {
                 $config->$command = ($val === 'yes' || $val === 'true');
-            // check for single statement commands stored as strings
+                // check for single statement commands stored as strings
             } elseif (in_array($command, ['parser', 'login_username_field', 'login_password_field', 'not_logged_in_xpath', 'login_uri'], true)) {
                 $config->$command = $val;
-            // check for replace_string(find): replace
+                // check for replace_string(find): replace
             } elseif ((substr($command, -1) === ')') && preg_match('!^([a-z0-9_]+)\((.*?)\)$!i', $command, $match) && $match[1] === 'replace_string') {
                 array_push($config->find_string, $match[2]);
                 array_push($config->replace_string, $val);


### PR DESCRIPTION
Instead of a simple debug message when a content can’t be fetched because of a bad request (time out or whatever) it’s more interesting to log it as error so it’ll appear in the log file even in production.

We can see it more and more when a website can't be fetched in wallabag and most of the time it's because of a bad configuration on their side. So, to avoid forcing them to enable log, clear cache and retry, the `prod.log` file might now contains the error information we need.