### PR TITLE
 Retrieve information from JSON-LD schema 

### DIFF
--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -866,4 +866,23 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertTrue($contentExtractor->isNativeAd());
         $this->assertContains('<p><hihi/></p>', $content_block->ownerDocument->saveXML($content_block));
     }
+
+    public function testJsonLd()
+    {
+        $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
+
+        $res = $contentExtractor->process(
+            ' <script type="application/ld+json">{ "@context": "https:\/\/schema.org", "@type": "NewsArticle", "headline": "title !!", "mainEntityOfPage": "http:\/\/jsonld.io\/toto", "datePublished": "2017-10-23T16:05:38+02:00", "dateModified": "2017-10-23T16:06:28+02:00", "description": "it is describe", "articlebody": " my body", "relatedLink": "", "image": { "@type": "ImageObject", "url": "https:\/\/static.jsonld.io\/medias.jpg", "height": "830", "width": "532" }, "author": { "@type": "Person", "name": "bob", "sameAs": ["https:\/\/twitter.com\/bob"] }, "keywords": ["syndicat", "usine", "licenciement", "Emmanuel Macron", "creuse", "plan social", "Automobile"] }</script><p>hihi</p>',
+            'https://nativead.io/jsonld'
+        );
+
+        $this->assertTrue($res);
+
+        $content_block = $contentExtractor->getContent();
+
+        $this->assertSame('title !!', $contentExtractor->getTitle());
+        $this->assertSame('2017-10-23T16:05:38+02:00', $contentExtractor->getDate());
+        $this->assertContains('bob', $contentExtractor->getAuthors());
+        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+    }
 }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -246,7 +246,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
     public function dataDate()
     {
         return [
-            ['http://www.lemonde.fr/economie/article/2011/07/05/moody-s-abaisse-la-note-du-portugal-de-quatre-crans_1545237_3234.html', '2011-07-05T22:09:59+02:00'],
+            ['http://www.lemonde.fr/economie/article/2011/07/05/moody-s-abaisse-la-note-du-portugal-de-quatre-crans_1545237_3234.html', '2011-07-05T22:09:18+0200'],
             ['https://www.reddit.com/r/LinuxActionShow/comments/1fccny/arch_linux_survival_guide/', '2013-05-30T16:01:58+00:00'],
         ];
     }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -551,4 +551,32 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('<ol start="3">', $res['html']);
         $this->assertContains('<ol start="4">', $res['html']);
     }
+
+    public function testJsonLd()
+    {
+        $graby = new Graby([
+            'debug' => true,
+        ]);
+        $res = $graby->fetchContent('http://www.20minutes.fr/sport/football/2155935-20171022-stade-rennais-portugais-paulo-fonseca-remplacer-christian-gourcuff');
+
+        $this->assertCount(12, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
+        $this->assertArrayHasKey('authors', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('native_ad', $res);
+        $this->assertArrayHasKey('all_headers', $res);
+
+        $this->assertSame(200, $res['status']);
+        $this->assertSame('Stade Rennais: Le Portugais Paulo Fonseca pour remplacer Christian Gourcuff?', $res['title']);
+        $this->assertCount(1, $res['authors']);
+        $this->assertSame('Jeremy Goujon', $res['authors'][0]);
+    }
 }


### PR DESCRIPTION
JSON-LD schema is mostly used by Google to understand more easily what’s in the website page.
There is some precious information we can extract from here without parsing the whole document.

First try is using a regex to match the script tag because Readability remove all script from its dom.