### PR TITLE
Use og & json-ld to improve results

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,24 +58,15 @@ array (
   'html' => "Fetched and readable content"
   'title' => "Ben E King: R&B legend dies at 76"
   'language' => "en"
-  'date' => NULL
-  'authors' => array ()
-  'url' => "http://www.bbc.com/news/entertainment-arts-32547474"
-  'content_type' => "text/html"
-  'open_graph' => array (
-    'og_title' => 'Ben E King: R&B legend dies at 76 - BBC News'
-    'og_type' => 'article'
-    'og_description' => 'R&B and soul singer Ben E King, best known for the classic song Stand By Me, dies at the age of 76.'
-    'og_site_name' => 'BBC News'
-    'og_locale' => 'en_GB'
-    'og_article_author' => 'BBC News'
-    'og_article_section' => 'Entertainment & Arts'
-    'og_url' => 'http://www.bbc.com/news/entertainment-arts-32547474'
-    'og_image' => 'http://ichef-1.bbci.co.uk/news/1024/media/images/82695000/jpg/_82695869_kingap.jpg'
+  'date' => "2015-05-01T16:24:37+01:00"
+  'authors' => array(
+    "BBC News"
   )
+  'url' => "http://www.bbc.com/news/entertainment-arts-32547474"
+  'image' => "https://ichef-1.bbci.co.uk/news/720/media/images/82709000/jpg/_82709878_146366806.jpg"
   'summary' => "Ben E King received an award from the Songwriters Hall of Fame in &hellip;"
   'native_ad' => false
-  'all_headers' => array (
+  'headers' => array (
     'server' => 'Apache'
     'content-type' => 'text/html; charset=utf-8'
     'x-news-data-centre' => 'cwwtf'
@@ -103,15 +94,14 @@ array(
   'status' => 404
   'html' => "[unable to retrieve full-text content]"
   'title' => "No title found"
-  'language' => NULL
-  'date' => NULL
+  'language' => "en-GB"
+  'date' => "2009-06-16T10:30:00Z"
   'authors' => array()
-  'url' => "http://www.bbc.com/404"
-  'content_type' => "text/html"
-  'open_graph' => array()
+  'url' => "http://www.bbc.co.uk/404"
+  'image' => NULL
   'summary' => "[unable to retrieve full-text content]"
   'native_ad' => false
-  'all_headers' => array()
+  'headers' => array()
 )
 */
 ```

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 1.x to 2.0
+=======================
+
+Return information from Graby has changed:
+
+- `all_headers` became `headers`
+- `open_graph` no longer exist (title, image & locale are merged into global result)
+- `content_type` no longer exist (check headers key instead)

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -1052,7 +1052,7 @@ class ContentExtractor
     /**
      * Extract OpenGraph data from the response.
      *
-     * @param DOMXPath $xpath DOMXpath from the DomDocument of the page
+     * @param \DOMXPath $xpath DOMXpath from the DomDocument of the page
      *
      * @see http://stackoverflow.com/a/7454737/569101
      */
@@ -1125,7 +1125,7 @@ class ContentExtractor
     /**
      * Extract data from JSON-LD information.
      *
-     * @param DOMXPath $xpath DOMXpath from the DomDocument of the page
+     * @param \DOMXPath $xpath DOMXpath from the DomDocument of the page
      *
      * @see https://json-ld.org/spec/latest/json-ld/
      */

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -26,6 +26,7 @@ class ContentExtractor
     private $language = null;
     private $authors = [];
     private $body = null;
+    private $image = null;
     private $nativeAd = false;
     private $date = null;
     private $success = false;
@@ -219,6 +220,9 @@ class ContentExtractor
                 }
             }
         }
+
+        // retrieve info from pre-defined source (OpenGraph / JSON-LD / etc.)
+        $this->extractDefinedInformation($html);
 
         // check if this is a native ad
         foreach ($this->siteConfig->native_ad_clue as $pattern) {
@@ -613,6 +617,11 @@ class ContentExtractor
     public function getLanguage()
     {
         return $this->language;
+    }
+
+    public function getImage()
+    {
+        return $this->image;
     }
 
     public function getSiteConfig()
@@ -1012,5 +1021,149 @@ class ContentExtractor
         }
 
         return false;
+    }
+
+    /**
+     * Extract information from defined source:
+     *     - OpenGraph
+     *     - JSON-LD.
+     *
+     * @param string $html Html from the page
+     */
+    private function extractDefinedInformation($html)
+    {
+        if ('' === trim($html)) {
+            return;
+        }
+
+        libxml_use_internal_errors(true);
+
+        $doc = new \DomDocument();
+        $doc->loadHTML($html);
+
+        libxml_use_internal_errors(false);
+
+        $xpath = new \DOMXPath($doc);
+
+        $this->extractOpenGraph($xpath);
+        $this->extractJsonLdInformation($xpath);
+    }
+
+    /**
+     * Extract OpenGraph data from the response.
+     *
+     * @param DOMXPath $xpath DOMXpath from the DomDocument of the page
+     *
+     * @see http://stackoverflow.com/a/7454737/569101
+     */
+    private function extractOpenGraph(\DOMXPath $xpath)
+    {
+        // retrieve "og:" properties
+        $metas = $xpath->query('//*/meta[starts-with(@property, \'og:\')]');
+
+        $ogMetas = [];
+        foreach ($metas as $meta) {
+            $property = str_replace(':', '_', $meta->getAttribute('property'));
+
+            if (in_array($property, ['og_image', 'og_image_url', 'og_image_secure_url'], true)) {
+                // avoid image data:uri to avoid sending too much data
+                // also, take the first og:image which is usually the best one
+                if (0 === stripos($meta->getAttribute('content'), 'data:image') || !empty($ogMetas[$property])) {
+                    continue;
+                }
+
+                $ogMetas[$property] = $meta->getAttribute('content');
+
+                continue;
+            }
+
+            $ogMetas[$property] = $meta->getAttribute('content');
+        }
+
+        $this->logger->log('debug', 'Opengraph "og:" data: {ogData}', ['ogData' => $ogMetas]);
+
+        if (!empty($ogMetas['og_title'])) {
+            $this->title = $ogMetas['og_title'];
+        }
+
+        // og:image by default, then og:image:url and finally og:image:secure_url
+        if (!empty($ogMetas['og_image'])) {
+            $this->image = $ogMetas['og_image'];
+        }
+
+        if (!empty($ogMetas['og_image_url'])) {
+            $this->image = $ogMetas['og_image_url'];
+        }
+
+        if (!empty($ogMetas['og_image_secure_url'])) {
+            $this->image = $ogMetas['og_image_secure_url'];
+        }
+
+        if (!empty($ogMetas['og_locale'])) {
+            $this->language = $ogMetas['og_locale'];
+        }
+
+        // retrieve "article:" properties
+        $metas = $xpath->query('//*/meta[starts-with(@property, \'article:\')]');
+
+        $articleMetas = [];
+        foreach ($metas as $meta) {
+            $articleMetas[str_replace(':', '_', $meta->getAttribute('property'))] = $meta->getAttribute('content');
+        }
+
+        $this->logger->log('debug', 'Opengraph "article:" data: {ogData}', ['ogData' => $articleMetas]);
+
+        if (!empty($articleMetas['article_modified_time'])) {
+            $this->date = $articleMetas['article_modified_time'];
+        }
+
+        if (!empty($articleMetas['article_published_time'])) {
+            $this->date = $articleMetas['article_published_time'];
+        }
+    }
+
+    /**
+     * Extract data from JSON-LD information.
+     *
+     * @param DOMXPath $xpath DOMXpath from the DomDocument of the page
+     *
+     * @see https://json-ld.org/spec/latest/json-ld/
+     */
+    private function extractJsonLdInformation(\DOMXPath $xpath)
+    {
+        $scripts = $xpath->query('//*/script[@type="application/ld+json"]');
+
+        foreach ($scripts as $script) {
+            $data = json_decode(trim($script->nodeValue), true);
+
+            $this->logger->log('debug', 'JSON-LD data: {data}', ['data' => $data]);
+
+            // just in case datePublished isn't defined, we use the modified one at first
+            if (!empty($data['dateModified'])) {
+                $this->date = $data['dateModified'];
+            }
+
+            if (!empty($data['datePublished'])) {
+                $this->date = $data['datePublished'];
+            }
+
+            // body should be a DOMNode
+            if (!empty($data['articlebody'])) {
+                $dom = new \DOMDocument('1.0', 'utf-8');
+                $this->body = $dom->createElement('p', htmlspecialchars(trim($data['articlebody'])));
+            }
+
+            if (!empty($data['headline'])) {
+                $this->title = $data['headline'];
+            }
+
+            if (!empty($data['author']['name'])) {
+                $this->authors[] = $data['author']['name'];
+            }
+
+            if (!empty($data['image']['url'])) {
+                $this->image = $data['image']['url'];
+            }
+        }
     }
 }

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -154,7 +154,7 @@ class HttpClient
                 'effective_url' => $url,
                 'body' => '',
                 'headers' => '',
-                'all_headers' => [],
+                'headers' => [],
                 // Too many Redirects
                 'status' => 310,
             ];
@@ -167,7 +167,7 @@ class HttpClient
                 'effective_url' => (string) $e->getRequest()->getUri(),
                 'body' => (string) $response->getBody(),
                 'headers' => isset($headers['content-type']) ? $headers['content-type'] : '',
-                'all_headers' => $headers,
+                'headers' => $headers,
                 'status' => $response->getStatusCode(),
             ];
 
@@ -180,7 +180,7 @@ class HttpClient
                 'effective_url' => (string) $e->getRequest()->getUri(),
                 'body' => '',
                 'headers' => '',
-                'all_headers' => [],
+                'headers' => [],
                 'status' => 500,
             ];
 

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -27,6 +27,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($contentExtractor->getTitle());
         $this->assertNull($contentExtractor->getLanguage());
         $this->assertNull($contentExtractor->getDate());
+        $this->assertNull($contentExtractor->getImage());
         $this->assertSame([], $contentExtractor->getAuthors());
         $this->assertNull($contentExtractor->getSiteConfig());
         $this->assertNull($contentExtractor->getNextPageUrl());
@@ -772,12 +773,15 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThanOrEqual(6, $records);
         $this->assertSame('Attempting to parse HTML with {parser}', $records[0]['message']);
         $this->assertSame('libxml', $records[0]['context']['parser']);
-        $this->assertSame('Trying {pattern} for language', $records[1]['message']);
-        $this->assertSame('Using Readability', $records[3]['message']);
-        $this->assertSame('Detected title: {title}', $records[4]['message']);
+        $this->assertSame('Opengraph "og:" data: {ogData}', $records[1]['message']);
+        $this->assertSame('Opengraph "article:" data: {ogData}', $records[2]['message']);
+        $this->assertSame('Trying {pattern} for language', $records[3]['message']);
+        $this->assertSame('Trying {pattern} for language', $records[4]['message']);
+        $this->assertSame('Using Readability', $records[5]['message']);
+        $this->assertSame('Detected title: {title}', $records[6]['message']);
 
         if (function_exists('tidy_parse_string')) {
-            $this->assertSame('Trying again without tidy', $records[5]['message']);
+            $this->assertSame('Trying again without tidy', $records[7]['message']);
         }
     }
 
@@ -855,7 +859,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
         $res = $contentExtractor->process(
-            ' <meta property="og:url" content="https://nativead.io/sponsored/woops"/><p><hihi/p>',
+            ' <meta property="og:url" content="https://nativead.io/sponsored/woops"/><p>hihi</p>',
             'https://nativead.io/woops!'
         );
 
@@ -864,6 +868,84 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $content_block = $contentExtractor->getContent();
 
         $this->assertTrue($contentExtractor->isNativeAd());
-        $this->assertContains('<p><hihi/></p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+    }
+
+    public function testJsonLd()
+    {
+        $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
+
+        $res = $contentExtractor->process(
+            ' <script type="application/ld+json">{ "@context": "https:\/\/schema.org", "@type": "NewsArticle", "headline": "title !!", "mainEntityOfPage": "http:\/\/jsonld.io\/toto", "datePublished": "2017-10-23T16:05:38+02:00", "dateModified": "2017-10-23T16:06:28+02:00", "description": "it is describe", "articlebody": " my body", "relatedLink": "", "image": { "@type": "ImageObject", "url": "https:\/\/static.jsonld.io\/medias.jpg", "height": "830", "width": "532" }, "author": { "@type": "Person", "name": "bob", "sameAs": ["https:\/\/twitter.com\/bob"] }, "keywords": ["syndicat", "usine", "licenciement", "Emmanuel Macron", "creuse", "plan social", "Automobile"] }</script><p>hihi</p>',
+            'https://nativead.io/jsonld'
+        );
+
+        $this->assertTrue($res);
+
+        $content_block = $contentExtractor->getContent();
+
+        $this->assertSame('title !!', $contentExtractor->getTitle());
+        $this->assertSame('2017-10-23T16:05:38+02:00', $contentExtractor->getDate());
+        $this->assertContains('bob', $contentExtractor->getAuthors());
+        $this->assertSame('https://static.jsonld.io/medias.jpg', $contentExtractor->getImage());
+        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+    }
+
+    public function testNoDefinedHtml()
+    {
+        $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
+
+        $res = $contentExtractor->process('', 'https://nativead.io/jsonld');
+
+        $this->assertFalse($res);
+
+        $this->assertEmpty($contentExtractor->getImage());
+    }
+
+    public function testOpenGraph()
+    {
+        $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
+
+        $res = $contentExtractor->process(
+            ' <meta property="og:title" content="title !!"/>
+            <meta property="og:site_name" content="opengraph.io" />
+            <meta property="og:type" content="article"/>
+            <meta property="og:locale" content="fr_FR"/>
+            <meta property="og:url" content="//opengraph.io/1954872.html"/>
+            <meta property="article:published_time" content="2017-10-23T17:04:21Z-09:00"/>
+            <meta property="article:modified_time" content="2017-10-23T17:04:17Z-09:00"/>
+            <meta property="og:image" content="http://static.opengraph.io/medias_11570.jpg"/>
+            <meta property="og:image:url" content="http://static.opengraph.io/medias_11570.jpg"/>
+            <meta property="og:image:secure_url" content="https://static.opengraph.io/medias_11570.jpg"/>
+            <p>hihi</p>',
+            'https://nativead.io/opengraph'
+        );
+
+        $this->assertTrue($res);
+
+        $content_block = $contentExtractor->getContent();
+
+        $this->assertSame('title !!', $contentExtractor->getTitle());
+        $this->assertSame('2017-10-23T17:04:21Z-09:00', $contentExtractor->getDate());
+        $this->assertSame('fr_FR', $contentExtractor->getLanguage());
+        $this->assertSame('https://static.opengraph.io/medias_11570.jpg', $contentExtractor->getImage());
+        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+    }
+
+    public function testAvoidDataUriImageInOpenGraph()
+    {
+        $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
+
+        $res = $contentExtractor->process(
+            ' <html><meta content="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" property="og:image" /><meta content="http://www.io.lol" property="og:url"/><p>hihi</p></html>',
+            'https://nativead.io/opengraph'
+        );
+
+        $this->assertTrue($res);
+
+        $content_block = $contentExtractor->getContent();
+
+        $this->assertEmpty($contentExtractor->getImage());
+        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
     }
 }

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -83,7 +83,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.google.co.uk/url?sa=t&source=web&cd=1', $request->getHeaderLine('Referer'));
         $this->assertSame($url, $res['effective_url']);
         $this->assertSame('yay', $res['body']);
-        $this->assertSame('image/jpg', $res['headers']);
+        $this->assertSame('image/jpg', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 
@@ -104,7 +104,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($url, $res['effective_url']);
         $this->assertSame('yay', $res['body']);
-        $this->assertSame('text/html', $res['headers']);
+        $this->assertSame('text/html', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 
@@ -125,7 +125,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($url, $res['effective_url']);
         $this->assertSame('yay', $res['body']);
-        $this->assertSame('fucked', $res['headers']);
+        $this->assertSame('fucked', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 
@@ -170,7 +170,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($metaUrl, $res['effective_url']);
         $this->assertEmpty($res['body']);
-        $this->assertSame('text/html', $res['headers']);
+        $this->assertSame('text/html', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 
@@ -192,7 +192,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('GET', $httpMockClient->getRequests()[0]->getMethod());
         $this->assertSame($url, $res['effective_url']);
         $this->assertSame($body, $res['body']);
-        $this->assertSame('text/html', $res['headers']);
+        $this->assertSame('text/html', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 
@@ -206,7 +206,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('http://example.com/my-map.html', $res['effective_url']);
         $this->assertSame('test', $res['body']);
-        $this->assertSame('text/html', $res['headers']);
+        $this->assertSame('text/html', $res['headers']['content-type']);
         $this->assertSame(404, $res['status']);
     }
 
@@ -220,7 +220,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('http://example.com/image.jpg', $res['effective_url']);
         $this->assertSame('test', $res['body']);
-        $this->assertSame('image/jpeg', $res['headers']);
+        $this->assertSame('image/jpeg', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 
@@ -278,8 +278,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame([
             'effective_url' => 'http://fr.wikipedia.org/wiki/Copyright',
             'body' => '(only length for debug): 3',
-            'headers' => '',
-            'all_headers' => [],
+            'headers' => [],
             'status' => 200,
         ], $records[3]['context']['data']);
     }
@@ -412,7 +411,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($url, $res['effective_url']);
         $this->assertContains($expectedBody, $res['body']);
-        $this->assertSame('text/html', $res['headers']);
+        $this->assertSame('text/html', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -245,7 +245,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('http://example.com', $res['effective_url']);
         $this->assertSame('', $res['body']);
-        $this->assertSame('', $res['headers']);
+        $this->assertEmpty($res['headers']);
         $this->assertSame(404, $res['status']);
     }
 

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -24,7 +24,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -33,29 +33,17 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertSame('fr', $res['language']);
         $this->assertSame('http://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html', $res['url']);
         $this->assertSame('Grève à Radio France : vers une sortie du conflit ?', $res['title']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame('max-age=300', $res['all_headers']['cache-control']);
-
-        $this->assertArrayHasKey('og_site_name', $res['open_graph']);
-        $this->assertArrayHasKey('og_locale', $res['open_graph']);
-        $this->assertArrayHasKey('og_url', $res['open_graph']);
-        $this->assertArrayHasKey('og_title', $res['open_graph']);
-        $this->assertArrayHasKey('og_description', $res['open_graph']);
-        $this->assertArrayHasKey('og_image', $res['open_graph']);
-        $this->assertArrayHasKey('og_image_width', $res['open_graph']);
-        $this->assertArrayHasKey('og_image_height', $res['open_graph']);
-        $this->assertArrayHasKey('og_image_type', $res['open_graph']);
-        $this->assertArrayHasKey('og_type', $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertSame('max-age=300', $res['headers']['cache-control']);
 
         $records = $handler->getRecords();
 
@@ -78,7 +66,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('get', $records[13]['context']['method']);
         $this->assertSame('Use default referer "{referer}" for url "{url}"', $records[15]['message']);
         $this->assertSame('Data fetched: {data}', $records[16]['message']);
-        $this->assertSame('Opengraph data: {ogData}', $records[18]['message']);
+        $this->assertSame('Looking for site config files to see if single page link exists', $records[18]['message']);
     }
 
     public function testRealFetchContent2()
@@ -86,7 +74,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://bjori.blogspot.fr/2015/04/next-gen-mongodb-driver.html');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -95,11 +83,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertSame(['bjori'], $res['authors']);
@@ -107,7 +94,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('https://bjori.blogspot.fr/2015/04/next-gen-mongodb-driver.html', $res['url']);
         $this->assertSame('Next Generation MongoDB Driver for PHP!', $res['title']);
         $this->assertContains('For the past few months I\'ve been working on a "next-gen" MongoDB driver for PHP', $res['html']);
-        $this->assertSame('text/html', $res['content_type']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
     }
 
     public function testContentWithXSS()
@@ -123,7 +110,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://bjori.blogspot.fr/201');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -132,11 +119,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(404, $res['status']);
         $this->assertEmpty($res['language']);
@@ -144,8 +130,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame("bjori doesn't blog", $res['title']);
         $this->assertSame('[unable to retrieve full-text content]', $res['html']);
         $this->assertSame('[unable to retrieve full-text content]', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertNotEmpty($res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
     }
 
     public function testPdfFile()
@@ -153,7 +139,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://img3.free.fr/im_tv/telesites/documentation.pdf');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -162,11 +148,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertEmpty($res['language']);
@@ -176,8 +161,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('PDF', $res['title']);
         $this->assertContains('Free 2008', $res['html']);
         $this->assertContains('Free 2008', $res['summary']);
-        $this->assertSame('application/pdf', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('application/pdf', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
     }
 
     public function testPdfFileBadEncoding()
@@ -185,7 +170,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://a-eon.biz/PDF/News_Release_Developer.pdf');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -194,11 +179,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertEmpty($res['language']);
@@ -208,8 +192,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('News_Release_Developer', $res['title']);
         $this->assertContains('Amiga developers and users', $res['html']);
         $this->assertContains('Kickstarting', $res['summary']);
-        $this->assertSame('application/pdf', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('application/pdf', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
     }
 
     public function testImageFile()
@@ -217,7 +201,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://i.imgur.com/w9n2ID2.jpg');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -226,11 +210,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertEmpty($res['language']);
@@ -239,8 +222,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Image', $res['title']);
         $this->assertSame('<a href="http://i.imgur.com/w9n2ID2.jpg"><img src="http://i.imgur.com/w9n2ID2.jpg" alt="image" /></a>', $res['html']);
         $this->assertEmpty($res['summary']);
-        $this->assertSame('image/jpeg', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('image/jpeg', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
     }
 
     public function dataDate()
@@ -259,7 +242,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -268,11 +251,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame($expectedDate, $res['date']);
     }
@@ -300,7 +282,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         ]);
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -309,11 +291,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame($expectedAuthors, $res['authors']);
     }
@@ -336,7 +317,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -345,11 +326,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
     }
@@ -359,7 +339,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -368,11 +348,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertEmpty($res['language']);
@@ -380,8 +359,8 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('[Review] The Matrix Falling (Rain) Source Code C++', $res['title']);
         $this->assertSame('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="allowfullscreen">[embedded content]</iframe>', $res['html']);
         $this->assertSame('[embedded content]', $res['summary']);
-        $this->assertSame('text/xml', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/xml', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
     }
 
     public function testEncodedUrl()
@@ -391,7 +370,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://blog.niqnutn.com/index.php?article49/commandes-de-base');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -400,11 +379,10 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
     }
@@ -414,7 +392,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://www.ufocasebook.com/gulfbreeze.html');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -423,17 +401,16 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertContains('The Gulf Breeze, Florida UFOs (Ed Walters), UFO Casebook files', $res['title']);
         $this->assertContains('Location of last UFO sighting in Gulf Breeze on Soundside Drive', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
     }
 
     public function testKoreanPage()
@@ -441,7 +418,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://www.newstown.co.kr/news/articleView.html?idxno=243722');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -450,16 +427,15 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertContains('뉴스타운', $res['title']);
         $this->assertContains('프랑스 현대적 자연주의 브랜드', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
     }
 
     public function testMultipage()
@@ -474,7 +450,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         ]);
         $res = $graby->fetchContent('http://www.journaldugamer.com/tests/rencontre-ils-bossaient-sur-une-exclu-kinect-qui-ne-sortira-jamais/');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -483,17 +459,16 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertSame('2016-01-25T15:25:51+00:00', $res['date']);
         $this->assertContains('[Rencontre] Ils bossaient sur une exclu Kinect qui ne sortira jamais', $res['title']);
         $this->assertContains('Le Journal du Gamer', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
     }
 
     public function testMultipleOgImage()
@@ -503,7 +478,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         ]);
         $res = $graby->fetchContent('https://blog.tinned-software.net/restore-mysql-replication-after-error/');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -512,16 +487,15 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertSame('2015-06-08T19:08:47+00:00', $res['date']);
         $this->assertContains('Restore MySQL replication after error - Experiencing Technology', $res['title']);
-        $this->assertSame('https://blog.tinned-software.net/wp-content/uploads/2014/03/Fix_MySQL_replication_error.png', $res['open_graph']['og_image']);
+        $this->assertSame('https://blog.tinned-software.net/wp-content/uploads/2014/03/Fix_MySQL_replication_error.png', $res['image']);
     }
 
     public function testKeepOlStartAttribute()
@@ -531,7 +505,7 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         ]);
         $res = $graby->fetchContent('https://www.timothysykes.com/blog/10-things-know-short-selling/');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         $this->assertArrayHasKey('status', $res);
         $this->assertArrayHasKey('html', $res);
@@ -540,15 +514,41 @@ class GrabyFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('date', $res);
         $this->assertArrayHasKey('authors', $res);
         $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('content_type', $res);
         $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('image', $res);
         $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('all_headers', $res);
+        $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
         $this->assertContains('<ol start="2">', $res['html']);
         $this->assertContains('<ol start="3">', $res['html']);
         $this->assertContains('<ol start="4">', $res['html']);
+    }
+
+    public function testJsonLd()
+    {
+        $graby = new Graby([
+            'debug' => true,
+        ]);
+        $res = $graby->fetchContent('http://www.20minutes.fr/sport/football/2155935-20171022-stade-rennais-portugais-paulo-fonseca-remplacer-christian-gourcuff');
+
+        $this->assertCount(11, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
+        $this->assertArrayHasKey('authors', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('image', $res);
+        $this->assertArrayHasKey('native_ad', $res);
+        $this->assertArrayHasKey('headers', $res);
+
+        $this->assertSame(200, $res['status']);
+        $this->assertSame('Stade Rennais: Le Portugais Paulo Fonseca pour remplacer Christian Gourcuff?', $res['title']);
+        $this->assertCount(1, $res['authors']);
+        $this->assertSame('Jeremy Goujon', $res['authors'][0]);
     }
 }

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -297,7 +297,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(1, $httpMockClient->getRequests());
         $this->assertEquals('HEAD', $httpMockClient->getRequests()[0]->getMethod());
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame($title, $res['title']);
         $this->assertSame($html, $res['html']);
@@ -353,7 +353,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('HEAD', $httpMockClient->getRequests()[0]->getMethod());
         $this->assertEquals('GET', $httpMockClient->getRequests()[1]->getMethod());
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('ZIP', $res['title']);
         $this->assertContains('<a href="https://github.com/nathanaccidentally/Cydia-Repo-Template/archive/master.zip">Download ZIP</a>', $res['html']);

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -112,7 +112,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
 
         if ($language) {
             $this->assertSame($language, $res['language']);
@@ -136,24 +136,8 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
             $this->assertSame($parsedContentWithoutTidy, $res['html'], 'Same html');
         }
 
-        $this->assertSame('text/html', $res['content_type']);
-
-        // blogger doesn't have OG data, but lemonde has
-        if (empty($res['open_graph'])) {
-            $this->assertSame([], $res['open_graph']);
-            $this->assertFalse($res['native_ad']);
-        } else {
-            $this->assertArrayHasKey('og_site_name', $res['open_graph']);
-            $this->assertArrayHasKey('og_locale', $res['open_graph']);
-            $this->assertArrayHasKey('og_url', $res['open_graph']);
-            $this->assertArrayHasKey('og_title', $res['open_graph']);
-            $this->assertArrayHasKey('og_description', $res['open_graph']);
-            $this->assertArrayHasKey('og_image', $res['open_graph']);
-            $this->assertArrayHasKey('og_image_width', $res['open_graph']);
-            $this->assertArrayHasKey('og_image_height', $res['open_graph']);
-            $this->assertArrayHasKey('og_image_type', $res['open_graph']);
-            $this->assertArrayHasKey('og_type', $res['open_graph']);
-        }
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertFalse($res['native_ad']);
     }
 
     public function dataForAllowed()
@@ -249,15 +233,14 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://example.com/my%20awesome%20image.jpg');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('Image', $res['title']);
         $this->assertSame('<a href="http://example.com/my%20awesome%20image.jpg"><img src="http://example.com/my%20awesome%20image.jpg" alt="Image" /></a>', $res['html']);
         $this->assertSame('http://example.com/my%20awesome%20image.jpg', $res['url']);
         $this->assertEmpty($res['summary']);
-        $this->assertSame('image/jpeg', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
-        $this->assertFalse($res['native_ad']);
+        $this->assertSame('image/jpeg', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -320,8 +303,8 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($html, $res['html']);
         $this->assertSame($url, $res['url']);
         $this->assertSame($summary, $res['summary']);
-        $this->assertSame($header, $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame($header, $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -338,15 +321,15 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://example.com/test.pdf');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('Document1', $res['title']);
         $this->assertContains('Document title', $res['html']);
         $this->assertContains('Morbi vulputate tincidunt ve nenatis.', $res['html']);
         $this->assertContains('http://example.com/test.pdf', $res['url']);
         $this->assertContains('Document title Calibri : Lorem ipsum dolor sit amet', $res['summary']);
-        $this->assertSame('application/pdf', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame('application/pdf', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -374,8 +357,8 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($res['language']);
         $this->assertSame('ZIP', $res['title']);
         $this->assertContains('<a href="https://github.com/nathanaccidentally/Cydia-Repo-Template/archive/master.zip">Download ZIP</a>', $res['html']);
-        $this->assertSame('application/zip', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame('application/zip', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -391,7 +374,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://example.com/test.pdf');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('2011-12-20T21:58:48+00:00', $res['date']);
         $this->assertSame(['David Baca'], $res['authors']);
@@ -399,8 +382,8 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Good Product Manager Bad Product Manager By Ben Horowitz and David Weiden', $res['html']);
         $this->assertContains('http://example.com/test.pdf', $res['url']);
         $this->assertContains('Good Product Manager Bad Product Manager By Ben Horowitz and David Weiden', $res['summary']);
-        $this->assertSame('application/pdf', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame('application/pdf', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -413,14 +396,14 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
 
         $res = $graby->fetchContent('http://example.com/test.txt');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('Plain text', $res['title']);
         $this->assertSame('<pre>plain text :)</pre>', $res['html']);
         $this->assertSame('http://example.com/test.txt', $res['url']);
         $this->assertSame('plain text :)', $res['summary']);
-        $this->assertSame('text/plain', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame('text/plain', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -472,14 +455,14 @@ HTML
 
         $res = $graby->fetchContent('http://' . $url);
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertSame('en', $res['language']);
         $this->assertSame('my title', $res['title']);
         $this->assertSame('my content', $res['html']);
         $this->assertSame($expectedUrl, $res['url']);
         $this->assertSame('my content', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -510,14 +493,14 @@ HTML
 
         $res = $graby->fetchContent('http://singlepage1.com/data.jpg');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('Image', $res['title']);
         $this->assertSame('<a href="http://singlepage1.com/data.jpg"><img src="http://singlepage1.com/data.jpg" alt="Image" /></a>', $res['html']);
         $this->assertSame('http://singlepage1.com/data.jpg', $res['url']);
         $this->assertSame('', $res['summary']);
-        $this->assertSame('image/jpeg', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame('image/jpeg', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -547,14 +530,14 @@ HTML
 
         $res = $graby->fetchContent('http://multiplepage1.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
         $this->assertSame('my content<div class="story">my content</div>', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content my content', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -584,14 +567,14 @@ HTML
 
         $res = $graby->fetchContent('http://multiplepage1.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
-        $this->assertSame('application/pdf', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame('application/pdf', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -621,14 +604,14 @@ HTML
 
         $res = $graby->fetchContent('http://multiplepage1.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -658,14 +641,14 @@ HTML
 
         $res = $graby->fetchContent('http://multiplepage1.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -695,14 +678,14 @@ HTML
 
         $res = $graby->fetchContent('http://multiplepage1.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
         $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -850,28 +833,6 @@ HTML
         $this->assertSame('http://example.org/path/to/image.jpg', $e->firstChild->getAttribute('src'));
     }
 
-    public function testAvoidDataUriImageInOpenGraph()
-    {
-        $graby = new Graby();
-
-        $reflection = new \ReflectionClass(get_class($graby));
-        $method = $reflection->getMethod('extractOpenGraph');
-        $method->setAccessible(true);
-
-        $ogData = $method->invokeArgs(
-            $graby,
-            [
-                '<html><meta content="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" property="og:image" /><meta content="http://www.io.lol" property="og:url"/></html>',
-                'http://www.io.lol',
-            ]
-        );
-
-        $this->assertCount(1, $ogData);
-        $this->assertArrayHasKey('og_url', $ogData);
-        $this->assertSame('http://www.io.lol', $ogData['og_url']);
-        $this->assertFalse(isset($ogData['og_image']), 'og_image key does not exist');
-    }
-
     public function testContentLinksRemove()
     {
         $httpMockClient = new HttpMockClient();
@@ -885,14 +846,14 @@ HTML
 
         $res = $graby->fetchContent('http://example.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('No title found', $res['title']);
         $this->assertContains('<p>' . str_repeat('This is an awesome text with some links, here there are the awesome', 7) . ' links :)</p>', $res['html']);
         $this->assertSame('http://example.com', $res['url']);
         $this->assertSame('This is an awesome text with some links, here there are the awesomeThis is an awesome text with some links, here there are the awesomeThis is an awesome text with some links, here there are the awesomeThis is an awesome text with some links, here there &hellip;', $res['summary']);
-        $this->assertSame('text/html', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -905,14 +866,14 @@ HTML
 
         $res = $graby->fetchContent('example.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('No title found', $res['title']);
         $this->assertSame('[unable to retrieve full-text content]', $res['html']);
         $this->assertSame('http://example.com', $res['url']);
         $this->assertSame('[unable to retrieve full-text content]', $res['summary']);
-        $this->assertSame('application/pdf', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertSame('application/pdf', $res['headers']['content-type']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -938,13 +899,13 @@ HTML
         $graby = new Graby();
         $res = $graby->fetchContent($url);
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('No title found', $res['title']);
         $this->assertSame('[unable to retrieve full-text content]', $res['html']);
         $this->assertSame('[unable to retrieve full-text content]', $res['summary']);
-        $this->assertSame('', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertEmpty($res['headers']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
         $this->assertSame(500, $res['status']);
     }
@@ -961,14 +922,14 @@ HTML
 
         $res = $graby->fetchContent('example.com');
 
-        $this->assertCount(12, $res);
+        $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('No title detected', $res['title']);
         $this->assertSame('Nothing found, hu?', $res['html']);
         $this->assertSame('http://example.com', $res['url']);
         $this->assertSame('Nothing found, hu?', $res['summary']);
-        $this->assertSame('', $res['content_type']);
-        $this->assertSame([], $res['open_graph']);
+        $this->assertEmpty($res['headers']);
+        $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
@@ -996,28 +957,6 @@ HTML
         $res = $method->invokeArgs($graby, [$url]);
 
         $this->assertSame($urlExpected, $res);
-    }
-
-    public function testAbsolutePreviewInOgImage()
-    {
-        $graby = new Graby();
-
-        $reflection = new \ReflectionClass(get_class($graby));
-        $method = $reflection->getMethod('extractOpenGraph');
-        $method->setAccessible(true);
-
-        $ogData = $method->invokeArgs(
-            $graby,
-            [
-                '<html><meta content="/assets/lol.jpg" property="og:image" /><meta content="http://www.io.lol" property="og:url"/></html>',
-                'http://www.io.lol',
-            ]
-        );
-
-        $this->assertCount(2, $ogData);
-        $this->assertArrayHasKey('og_url', $ogData);
-        $this->assertSame('http://www.io.lol', $ogData['og_url']);
-        $this->assertSame('http://www.io.lol/assets/lol.jpg', $ogData['og_image']);
     }
 
     public function dataForCleanupHtml()


### PR DESCRIPTION
Parsing OpenGraph information is now perform in ContentExtract instead
of Graby. As well as JSON-LD.
These information are fetched before trying to extract information from
html using xpath & readability.

Information from xpath & readability override og & json-ld.

Also, some breaking changes from what Graby return:
- `all_headers` became `headers`
- `open_graph` no longer exist (see above)
- `content_type` no longer exist (check headers instead)