### PR TITLE
Agnostic Guzzle

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,2 +1,11 @@
+filter:
+    paths:
+        - src/*
+    excluded_paths:
+        - 'log/*'
+        - 'vendor/*'
+        - 'tests/*'
+
 tools:
-    external_code_coverage: false
+    external_code_coverage:
+        timeout: 600

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
           env: PHPUNIT_FLAGS="--coverage-clover coverage.clover" CS_FIXER=run
         - php: 7.0
           env: GUZZLE6=run
+        - php: 7.0
+          env: CURL=run
 
 # faster builds on new travis setup not using sudo
 sudo: false
@@ -35,6 +37,8 @@ before_install:
     - composer self-update
     - if [ "$GUZZLE6" = "run" ]; then composer remove php-http/guzzle5-adapter --dev -n ; fi;
     - if [ "$GUZZLE6" = "run" ]; then composer require php-http/guzzle6-adapter --dev -n ; fi;
+    - if [ "$CURL" = "run" ]; then composer remove php-http/guzzle5-adapter --dev -n ; fi;
+    - if [ "$CURL" = "run" ]; then composer require php-http/curl-client --dev -n ; fi;
 
 install:
     - composer install --no-interaction --prefer-dist -o

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     include:
         - php: 7.0
           env: PHPUNIT_FLAGS="--coverage-clover coverage.clover" CS_FIXER=run
+        - php: 7.0
+          env: GUZZLE6=run
 
 # faster builds on new travis setup not using sudo
 sudo: false
@@ -31,6 +33,8 @@ cache:
 before_install:
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
     - composer self-update
+    - if [ "$GUZZLE6" = "run" ]; then composer remove php-http/guzzle5-adapter --dev -n ; fi;
+    - if [ "$GUZZLE6" = "run" ]; then composer require php-http/guzzle6-adapter --dev -n ; fi;
 
 install:
     - composer install --no-interaction --prefer-dist -o

--- a/README.md
+++ b/README.md
@@ -165,6 +165,40 @@ You can then retrieve logs from graby in your controller using:
 $logs = $this->get('monolog.handler.graby')->getRecords();
 ```
 
+### Timeout configuration
+
+If you need to define a timeout, you must create the `Http\Client\HttpClient` manually,
+configure it and inject it to `Graby\Graby`.
+
+- For Guzzle 5:
+
+    ```php
+    use Graby\Graby;
+    use GuzzleHttp\Client as GuzzleClient;
+    use Http\Adapter\Guzzle5\Client as GuzzleAdapter;
+
+    $guzzle = new GuzzleClient([
+        'defaults' => [
+            'timeout' => 2,
+        ]
+    ]);
+    $graby = new Graby([], new GuzzleAdapter($guzzle));
+    ```
+
+- For Guzzle 6:
+
+    ```php
+    use Graby\Graby;
+    use GuzzleHttp\Client as GuzzleClient;
+    use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
+
+    $guzzle = new GuzzleClient([
+        'timeout' => 2,
+    ]);
+    $graby = new Graby([], new GuzzleAdapter($guzzle));
+    ```
+
+
 ## Full configuration
 
 This is the full documented configuration and also the default one.
@@ -282,26 +316,5 @@ $graby = new Graby(array(
             'post_filters' => array(),
         ),
     ),
-));
-```
-
-### Timeout configuration
-
-If you need to define a timeout, you must create the `Http\Client\HttpClient` manually, 
-configure it and inject it to `Graby\Graby`.
-
-Exemple with `php-http/guzzle5-adapter`
-
-```
-use Graby\Graby;
-use GuzzleHttp\Client as GuzzleClient;
-use Http\Adapter\Guzzle5\Client as GuzzleAdapter;
-
-$guzzle = new GuzzleClient([
-    'defaults' => [
-        'timeout' => 2,
-    ]
-]);
-$graby = new Graby([], new GuzzleAdapter($guzzle));
 ));
 ```

--- a/README.md
+++ b/README.md
@@ -36,10 +36,14 @@ That's why I made this fork:
 
 Add the lib using composer:
 
-    composer require j0k3r/graby php-http/guzzle5-adapter
+    composer require j0k3r/graby php-http/guzzle6-adapter
 
-Why `php-http/guzzle5-adapter`? Because Graby is decoupled form any HTTP messaging client with help by [HTTPlug](http://httplug.io/).
-See [HTTPlug for library users]()http://docs.php-http.org/en/latest/httplug/users.html)
+Why `php-http/guzzle6-adapter`? Because Graby is decoupled form any HTTP messaging client with help by [HTTPlug](http://httplug.io/) (see [HTTPlug for library users](http://docs.php-http.org/en/latest/httplug/users.html)).
+
+Graby is tested & should work great with:
+- `php-http/guzzle6-adapter`
+- `php-http/guzzle5-adapter`
+- `php-http/curl-client`
 
 Use the class to retrieve content:
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -5,7 +5,6 @@ namespace Tests\Graby\Extractor;
 use Graby\Extractor\HttpClient;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Response;
-use Http\Adapter\Guzzle5\Client as GuzzleAdapter;
 use Http\Mock\Client as HttpMockClient;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -290,8 +289,16 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         $handler = new TestHandler();
         $logger->pushHandler($handler);
 
-        $guzzle = new GuzzleClient(['defaults' => ['timeout' => 2]]);
-        $adapter = new GuzzleAdapter($guzzle);
+        if (class_exists('Http\Adapter\Guzzle6\Client')) {
+            $guzzle = new GuzzleClient(['timeout' => 2]);
+            $adapter = new \Http\Adapter\Guzzle6\Client($guzzle);
+        } elseif (class_exists('Http\Adapter\Guzzle5\Client')) {
+            $guzzle = new GuzzleClient(['defaults' => ['timeout' => 2]]);
+            $adapter = new \Http\Adapter\Guzzle5\Client($guzzle);
+        } else {
+            $this->markTestSkipped('No Guzzle adapter defined ?');
+        }
+
         $http = new HttpClient($adapter, [], $logger);
 
         $res = $http->fetch('http://blackhole.webpagetest.org/');

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -3,10 +3,6 @@
 namespace Tests\Graby;
 
 use Graby\Graby;
-use GuzzleHttp\Client;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Subscriber\Mock;
 use Http\Mock\Client as HttpMockClient;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Graby;
 
 use Graby\Graby;
+use GuzzleHttp\Psr7\Response;
 use Http\Mock\Client as HttpMockClient;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -92,8 +93,8 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testFetchContent($url, $urlEffective, $header, $language, $author, $title, $summary, $rawContent, $parsedContent, $parsedContentWithoutTidy)
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => $header], $rawContent));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => $header], $rawContent));
+        $httpMockClient->addResponse(new Response(200, ['Content-Type' => $header], $rawContent));
+        $httpMockClient->addResponse(new Response(200, ['Content-Type' => $header], $rawContent));
 
         $graby = new Graby([
             'xss_filter' => false,
@@ -166,8 +167,8 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testAllowedUrls($url, $urlChanged)
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(301, ['Location' => $urlChanged]));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200));
+        $httpMockClient->addResponse(new Response(301, ['Location' => $urlChanged]));
+        $httpMockClient->addResponse(new Response(200));
 
         $graby = new Graby([
             'allowed_urls' => ['wikipedia.org', 'wikimedia.com'],
@@ -227,7 +228,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testBlockedUrlsAfterFetch()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200));
+        $httpMockClient->addResponse(new Response(200));
 
         $graby = new Graby([
             'blocked_urls' => ['t411.io'],
@@ -239,7 +240,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testMimeTypeActionLink()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'image/jpeg']));
+        $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'image/jpeg']));
 
         $graby = new Graby(['xss_filter' => false], $httpMockClient);
 
@@ -264,11 +265,11 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testMimeTypeActionExclude()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'application/x-msdownload']
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'application/x-msdownload']
         ));
@@ -299,7 +300,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testAssetExtension($url, $header, $title, $summary, $html)
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => $header]
         ));
@@ -324,7 +325,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testAssetExtensionPDF()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'application/pdf'],
             file_get_contents(__DIR__ . '/fixtures/document1.pdf')
@@ -349,11 +350,11 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testAssetExtensionZIP()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'application/zip']
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'application/zip']
         ));
@@ -378,7 +379,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testAssetExtensionPDFWithArrayDetails()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'application/pdf'],
             file_get_contents(__DIR__ . '/fixtures/Good_Product_Manager_Bad_Product_Manager_KV.pdf')
@@ -403,7 +404,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
     public function testAssetExtensionTXT()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'text/plain'], 'plain text :)'));
+        $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/plain'], 'plain text :)'));
 
         $graby = new Graby([], $httpMockClient);
 
@@ -446,7 +447,7 @@ class GrabyTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $httpMockClient = new HttpMockClient();
-        $response = new \GuzzleHttp\Psr7\Response(
+        $response = new Response(
             200,
             [
                 'Content-Type' => 'text/html',
@@ -489,12 +490,12 @@ HTML
         ]);
 
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h1 class="print-title">my title</h1><div class="print-submitted">my content</div><ul><li class="service-links-print"><a href="http://moreintelligentlife.com/print/content" class="service-links-print">printed view</a></li></ul></html>'
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'image/jpeg'],
             '<html><h1 class="print-title">my title</h1><div class="print-submitted">my content</div><ul><li class="service-links-print"><a href="http://moreintelligentlife.com/print/content" class="service-links-print">printed view</a></li></ul></html>'
@@ -526,12 +527,12 @@ HTML
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
         ]);
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div><ul><li class="next"><a href="multiplepage1.com">next page</a></li></ul></html>'
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div></html>'
@@ -563,12 +564,12 @@ HTML
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
         ]);
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div><ul><li class="next"><a href="multiplepage1.com/data.pdf">next page</a></li></ul></html>'
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'application/pdf'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div></html>'
@@ -600,12 +601,12 @@ HTML
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
         ]);
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div><ul><li class="next"><a href="multiplepage1.com">next page</a></li></ul></html>'
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             ''
@@ -637,12 +638,12 @@ HTML
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
         ]);
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div><ul><li class="next"><a href="/:/">next page</a></li></ul></html>'
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div></html>'
@@ -674,12 +675,12 @@ HTML
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
         ]);
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div><ul><li class="next"><a href="http://multiplepage1.com">next page</a></li></ul></html>'
         ));
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<html><h2 class="primary">my title</h2><div class="story">my content</div><ul><li class="next"><a href="http://multiplepage1.com">next page</a></li></ul></html>'
@@ -871,7 +872,7 @@ HTML
     public function testContentLinksRemove()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(
+        $httpMockClient->addResponse(new Response(
             200,
             ['Content-Type' => 'text/html'],
             '<article><p>' . str_repeat('This is an awesome text with some links, here there are the awesome', 7) . ' <a href="#links">links :)</a></p></article>'
@@ -895,7 +896,7 @@ HTML
     public function testMimeActionNotDefined()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/pdf']));
+        $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'application/pdf']));
 
         $graby = new Graby(['content_type_exc' => ['application/pdf' => ['action' => 'delete', 'name' => 'PDF']]], $httpMockClient);
 
@@ -948,7 +949,7 @@ HTML
     public function testErrorMessages()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, [], 'yay'));
+        $httpMockClient->addResponse(new Response(200, [], 'yay'));
 
         $graby = new Graby([
             'error_message' => 'Nothing found, hu?',
@@ -1076,7 +1077,7 @@ HTML
     public function testEncodingUtf8ForTextPlainPage()
     {
         $httpMockClient = new HttpMockClient();
-        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, ['content-type' => 'text/plain'], file_get_contents(__DIR__ . '/fixtures/malformed_UTF8_characters.txt')));
+        $httpMockClient->addResponse(new Response(200, ['content-type' => 'text/plain'], file_get_contents(__DIR__ . '/fixtures/malformed_UTF8_characters.txt')));
 
         $graby = new Graby([], $httpMockClient);
         $res = $graby->fetchContent('http://www.ais.org/~jrh/acn/text/ACN8-1.txt');

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -1079,17 +1079,10 @@ HTML
 
     public function testEncodingUtf8ForTextPlainPage()
     {
-        $reponse = new Response(
-            200,
-            [
-                'content-type' => 'text/plain',
-            ],
-            Stream::factory(__DIR__ . '/fixtures/sites/malformed_UTF8_characters.txt')
-        );
-        $client = new Client();
-        $client->getEmitter()->attach(new Mock([$reponse]));
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new \GuzzleHttp\Psr7\Response(200, ['content-type' => 'text/plain'], file_get_contents(__DIR__ . '/fixtures/malformed_UTF8_characters.txt')));
 
-        $graby = new Graby();
+        $graby = new Graby([], $httpMockClient);
         $res = $graby->fetchContent('http://www.ais.org/~jrh/acn/text/ACN8-1.txt');
 
         $this->assertArrayHasKey('html', $res);


### PR DESCRIPTION
- Convert hard coded Guzzle 5 test
- Update timeout in README, the full config might be at the end of the README
- Be Guzzle version agnostic
- Add a Travis build with Guzzle 6 (since Guzzle 5 is by default)