### PR TITLE
Add support of strip_attr

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -456,6 +456,13 @@ class ContentExtractor
             $this->readability->dom,
             'Date found (datetime marked time element): {date}'
         );
+        
+        foreach ($this->siteConfig->strip_attr as $pattern) {
+            $this->logger->log('debug', 'Trying {pattern} to strip attribute', ['pattern' => $pattern]);
+            $elems = $this->xpath->query($pattern, $this->readability->dom);
+
+            $this->removeAttributes($elems, 'Stripping {length} attributes (strip_attr)');
+        }
 
         // still missing title or body, so we detect using Readability
         $success = false;
@@ -665,6 +672,24 @@ class ContentExtractor
             if ($elems->item($i)->parentNode) {
                 $elems->item($i)->parentNode->removeChild($elems->item($i));
             }
+        }
+    }
+
+    /**
+     * Remove attribute from owners
+     * 
+     * @param \DOMNodeList $elems
+     * @param string       $logMessage
+     */
+    private function removeAttributes(\DOMNodeList $elems, $logMessage = null)
+    {
+        if (null !== $logMessage) {
+            $this->logger->log('debug', $logMessage, ['length' => $elems->length]);
+        }
+
+        foreach ($elems as $el) {
+            $owner = $el->ownerElement;
+            $owner->removeAttributeNode($el);
         }
     }
 

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -456,7 +456,7 @@ class ContentExtractor
             $this->readability->dom,
             'Date found (datetime marked time element): {date}'
         );
-        
+
         foreach ($this->siteConfig->strip_attr as $pattern) {
             $this->logger->log('debug', 'Trying {pattern} to strip attribute', ['pattern' => $pattern]);
             $elems = $this->xpath->query($pattern, $this->readability->dom);

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -676,8 +676,8 @@ class ContentExtractor
     }
 
     /**
-     * Remove attribute from owners
-     * 
+     * Remove attribute from owners.
+     *
      * @param \DOMNodeList $elems
      * @param string       $logMessage
      */

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -274,7 +274,7 @@ class ConfigBuilder
     public function mergeConfig(SiteConfig $currentConfig, SiteConfig $newConfig)
     {
         // check for commands where we accept multiple statements (no test_url)
-        foreach (['title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'date', 'author'] as $var) {
+        foreach (['title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'date', 'author', 'strip_attr'] as $var) {
             // append array elements for this config variable from $newConfig to this config
             $currentConfig->$var = array_unique(array_merge($currentConfig->$var, $newConfig->$var));
         }
@@ -333,7 +333,7 @@ class ConfigBuilder
             }
 
             // check for commands where we accept multiple statements
-            if (in_array($command, ['title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'test_url', 'find_string', 'replace_string', 'login_extra_fields', 'native_ad_clue', 'date', 'author'], true)) {
+            if (in_array($command, ['title', 'body', 'strip', 'strip_id_or_class', 'strip_image_src', 'single_page_link', 'next_page_link', 'test_url', 'find_string', 'replace_string', 'login_extra_fields', 'native_ad_clue', 'date', 'author', 'strip_attr'], true)) {
                 array_push($config->$command, $val);
                 // check for single statement commands that evaluate to true or false
             } elseif (in_array($command, ['tidy', 'prune', 'autodetect_on_failure', 'requires_login'], true)) {

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -29,6 +29,9 @@ class SiteConfig
     // Strip elements matching these xpath expressions (0 or more)
     public $strip = [];
 
+    // Strip attributes matching these xpath expressions (0 or more)
+    public $strip_attr = [];
+
     // Strip elements which contain these strings (0 or more) in the id or class attribute
     public $strip_id_or_class = [];
 

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -473,13 +473,13 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
         return [
             [['//*/@class'], '<html><body><div class="hello world"><i class="class">bar</i>class="foo"' . str_repeat('this is the best part of the show', 10) . ' <a class="hc" href="void">link</a></div></body></html>', [
                     'removedContent' => ['class="class"', 'class="hello world"', 'class="hc"'],
-                    'keptContent' => ['class="foo"','<a href="void"','<em>bar'],
-                ]
+                    'keptContent' => ['class="foo"', '<a href="void"', '<em>bar'],
+                ],
             ],
-            [['//img/@class','//p/@class'], '<html><body><img class="bar-class" src="void" /><a class="hello" href="void">link</a> <p class="yes">' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', [
+            [['//img/@class', '//p/@class'], '<html><body><img class="bar-class" src="void" /><a class="hello" href="void">link</a> <p class="yes">' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', [
                     'removedContent' => ['class="bar-class"', 'class="yes"'],
                     'keptContent' => ['class="hello"'],
-                ]
+                ],
             ],
         ];
     }

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -805,7 +805,7 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
 
         $config = new SiteConfig();
 
-        $res = $contentExtractor->process(
+        $contentExtractor->process(
             '<html>&lt;iframe &gt;&lt;/iframe&gt;</html>',
             'https://vimeo.com/35941909',
             $config

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -468,6 +468,50 @@ class ContentExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotContains($removedContent, $content);
     }
 
+    public function dataForStripAttr()
+    {
+        return [
+            [['//*/@class'], '<html><body><div class="hello world"><i class="class">bar</i>class="foo"' . str_repeat('this is the best part of the show', 10) . ' <a class="hc" href="void">link</a></div></body></html>', [
+                    'removedContent' => ['class="class"', 'class="hello world"', 'class="hc"'],
+                    'keptContent' => ['class="foo"','<a href="void"','<em>bar'],
+                ]
+            ],
+            [['//img/@class','//p/@class'], '<html><body><img class="bar-class" src="void" /><a class="hello" href="void">link</a> <p class="yes">' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', [
+                    'removedContent' => ['class="bar-class"', 'class="yes"'],
+                    'keptContent' => ['class="hello"'],
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataForStripAttr
+     */
+    public function testApplyStripAttr($patterns, $html, $assertions)
+    {
+        $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
+
+        $config = new SiteConfig();
+        $config->strip_attr = $patterns;
+
+        $res = $contentExtractor->process(
+            $html,
+            'https://lemonde.io/35941909',
+            $config
+        );
+
+        $domElement = $contentExtractor->readability->getContent();
+        $content = $domElement->ownerDocument->saveXML($domElement);
+
+        foreach ($assertions['removedContent'] as $removedContent) {
+            $this->assertNotContains($removedContent, $content);
+        }
+
+        foreach ($assertions['keptContent'] as $keptContent) {
+            $this->assertContains($keptContent, $content);
+        }
+    }
+
     public function dataForExtractBody()
     {
         return [

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -36,6 +36,8 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
             'replace_string(toto): titi',
             'http_header(user-agent): my-user-agent',
             'http_header(referer): http://idontl.ie',
+            'strip_attr: @class',
+            'strip_attr: @style',
         ]);
 
         $configExpected = new SiteConfig();
@@ -49,6 +51,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
             'referer' => 'http://idontl.ie',
         ];
         $configExpected->date = ['foo'];
+        $configExpected->strip_attr = ['@class','@style'];
 
         $this->assertEquals($configExpected, $configActual);
 

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -51,7 +51,7 @@ class ConfigBuilderTest extends \PHPUnit_Framework_TestCase
             'referer' => 'http://idontl.ie',
         ];
         $configExpected->date = ['foo'];
-        $configExpected->strip_attr = ['@class','@style'];
+        $configExpected->strip_attr = ['@class', '@style'];
 
         $this->assertEquals($configExpected, $configActual);
 


### PR DESCRIPTION
This PR adds the support of strip_attr, a new site config option which was added in FTR 3.8[1].

`strip_attr` will remove attributes matching the XPath. E.g. `//*/@class`, `//img/@style`.
 
[1] http://blog.fivefilters.org/post/165712503277/full-text-rss-38