### PR TITLE
Keep the old way to remove conditional comment

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -165,7 +165,25 @@ class HttpClient
 
         $body = (string) $response->getBody();
 
-        // be sure to remove conditional comments for IE
+        // be sure to remove conditional comments for IE around the html tag
+        // we only remove conditional comments until we found the <head> tag
+        // they usually contains the <html> tag which we try to found and replace the last occurence
+        // with the whole conditional comments
+        preg_match('/^\<!--\[if(\X+)\<!\[endif\]--\>(\X+)\<head\>$/mi', $body, $matchesConditional);
+
+        if (count($matchesConditional) > 1) {
+            preg_match_all('/\<html([\sa-z0-9\=\"\"\-:\/\.\#]+)\>$/mi', $matchesConditional[0], $matchesHtml);
+
+            if (count($matchesHtml) > 1) {
+                $htmlTag = end($matchesHtml[0]);
+
+                if (!empty($htmlTag)) {
+                    $body = str_replace($matchesConditional[0], $htmlTag . '<head>', $body);
+                }
+            }
+        }
+
+        // be sure to remove ALL other conditional comments for IE
         // (regex found here: https://stackoverflow.com/a/137831/569101)
         preg_match_all('/<!--\[if\s(?:[^<]+|<(?!!\[endif\]-->))*<!\[endif\]-->/mi', $body, $matchesConditional);
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -666,7 +666,7 @@ class HttpClientTest extends TestCase
 <!--<![endif]-->
         <head>
                 <meta charset="UTF-8" />',
-                'removeData' => '<html lang="en-US" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">',
+                'removeData' => '<html class="ie ie7" lang="en-US" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">',
             ],
             [
                 'url' => 'https://edition.cnn.com/2012/05/13/us/new-york-police-policy/index.html',


### PR DESCRIPTION
Remove all conditional comment wasn't the best idea.
Some of these are used to define which `<html>` tag will be used by the browser. We need to keep at least one of these tag because it can contains valuable information like the language of the page.

Following https://github.com/j0k3r/graby/pull/150