### PR TITLE
Add support for cookie in site_config

### DIFF
--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -345,7 +345,7 @@ class ConfigBuilder
             } elseif ((')' === substr($command, -1)) && preg_match('!^([a-z0-9_]+)\((.*?)\)$!i', $command, $match) && 'replace_string' === $match[1]) {
                 array_push($config->find_string, $match[2]);
                 array_push($config->replace_string, $val);
-            } elseif ((')' === substr($command, -1)) && preg_match('!^([a-z0-9_]+)\(([a-z0-9_-]+)\)$!i', $command, $match) && 'http_header' === $match[1] && \in_array($match[2], ['user-agent', 'referer'], true)) {
+            } elseif ((')' === substr($command, -1)) && preg_match('!^([a-z0-9_]+)\(([a-z0-9_-]+)\)$!i', $command, $match) && 'http_header' === $match[1] && \in_array(strtolower($match[2]), ['user-agent', 'referer', 'cookie'], true)) {
                 $config->http_header[strtolower(trim($match[2]))] = $val;
             }
         }

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -40,6 +40,7 @@ class ConfigBuilderTest extends TestCase
             'replace_string(toto): titi',
             'http_header(user-agent): my-user-agent',
             'http_header(referer): http://idontl.ie',
+            'http_header(Cookie): GDPR_consent=1',
             'strip_attr: @class',
             'strip_attr: @style',
         ]);
@@ -54,6 +55,7 @@ class ConfigBuilderTest extends TestCase
         $configExpected->http_header = [
             'user-agent' => 'my-user-agent',
             'referer' => 'http://idontl.ie',
+            'cookie' => 'GDPR_consent=1',
         ];
         $configExpected->date = ['foo'];
         $configExpected->strip_attr = ['@class', '@style'];


### PR DESCRIPTION
[Some site_config](https://github.com/fivefilters/ftr-site-config/search?p=1&q=http_header%28cookie%29&unscoped_q=http_header%28cookie%29) have a cookie defined (mostly for GDPR consent) but graby wasn't updated to support that.

It's not done.
You can add a cookie manually in a site config using:

```
http_header(Cookie): cookiename=cookievalue
```