### PR TITLE
Use own solution to parse cookie

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "monolog/monolog": "^1.13.1",
         "smalot/pdfparser": "~0.11",
         "wallabag/tcpdf": "^6.2",
-        "true/punycode": "~2.0",
-        "guzzle/parser": "^3.9"
+        "true/punycode": "~2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.0",


### PR DESCRIPTION
After using an old version of Guzzle to parse cookie, which wasn’t included in prod deps but only on dev deps (because of php-coveralls) (see https://github.com/j0k3r/graby/pull/172), then explicitely required it and finally got a conflict with event dispatcher (see https://github.com/j0k3r/graby/pull/173), use a dedicated solution without a deps.
Pfiou.