### PR TITLE
Update Graby.php (regex modification)

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -254,7 +254,7 @@ class Graby
         $html = $this->convert2Utf8($response['body'], $response['all_headers']);
 
         // Remove empty nodes (except iframe)
-        $re = '/<(?!iframe)([^>\s]+)(?:[^>]*)>(?:\s*(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;)\s*)*<\/\1>/m';
+        $re = '/<(?!iframe)([^>\s]+)[^>]*>(?:\s*(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;)\s*)*<\/\1>/m';
         $html = preg_replace($re, '', $html);
 
         // some non utf8 enconding might be breaking after converting to utf8

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -254,7 +254,7 @@ class Graby
         $html = $this->convert2Utf8($response['body'], $response['all_headers']);
 
         // Remove empty nodes (except iframe)
-        $re = '/<(?!iframe)([^>\s]+).*>(?:\s*(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;)\s*)*<\/\1>/m';
+        $re = '/<(?!iframe)([^>\s]+)(?:[^>]*)>(?:\s*(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;)\s*)*<\/\1>/m';
         $html = preg_replace($re, '', $html);
 
         // some non utf8 enconding might be breaking after converting to utf8

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -254,7 +254,7 @@ class Graby
         $html = $this->convert2Utf8($response['body'], $response['all_headers']);
 
         // Remove empty nodes (except iframe)
-        $re = '/<([^>\s]+)[^iframe|>]*>(?:\s*(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;)\s*)*<\/\1>/m';
+        $re = '/<(?!iframe)([^>\s]+).*>(?:\s*(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;)\s*)*<\/\1>/m';
         $html = preg_replace($re, '', $html);
 
         // some non utf8 enconding might be breaking after converting to utf8


### PR DESCRIPTION
I propose this regex modification to actually clean empty nodes before using php-readability and/or Tidy.
This regex specifically exclude the first group to be an `iframe` (which was the intention according to the comment), but allows the deletion of empty attribute-containing nodes.

With this modification, will be detected and deleted the following examples:
```html
<h2></h2>
<p></p>
<h2 class="align"></h2>
<head></head>
```
but not
```html
<iframe></iframe>
<iframe src="xxx.html"></iframe>
```

You can test it here: https://regex101.com/r/uWjsOc/1

It fixes https://github.com/wallabag/wallabag/issues/3730 and make https://github.com/j0k3r/php-readability/issues/39 closable (as I had no proof it was a _php-readability_ issue).