### PR TITLE
Avoid deprecated message to fail the build

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,10 @@
     bootstrap="vendor/autoload.php"
     >
 
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
+
     <testsuites>
         <testsuite name="Graby Test Suite">
             <directory>./tests</directory>


### PR DESCRIPTION
Mostly for the 7.1 build which fails because of:

The "PHPUnit_Framework_MockObject_Matcher_Parameters::verify()" method will require a new "PHPUnit_Framework_MockObject_Invocation $invocation" argument in the next major version of its parent class "PHPUnit_Framework_MockObject_Matcher_StatelessInvocation", not defining it is deprecated.