### PR TITLE
Debug mode for graby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /build
 log/graby.log
+log/html.log
 composer.lock
 .php_cs.cache

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -112,7 +112,7 @@ class HttpClient
             $method = 'head';
         }
 
-        $this->logger->log('debug', 'Trying using method "{method}" on url "{url}"', ['method' => $method, 'url' => $url]);
+        $this->logger->info('Trying using method "{method}" on url "{url}"', ['method' => $method, 'url' => $url]);
 
         $options = [
             'headers' => [
@@ -148,8 +148,8 @@ class HttpClient
                     'status' => 500,
                 ];
 
-                $this->logger->log('warning', 'Request throw exception (with no response): {error_message}', ['error_message' => $e->getMessage()]);
-                $this->logger->log('debug', 'Data fetched: {data}', ['data' => $data]);
+                $this->logger->warning('Request throw exception (with no response): {error_message}', ['error_message' => $e->getMessage()]);
+                $this->logger->info('Data fetched: {data}', ['data' => $data]);
 
                 return $this->sendResults($data);
             }
@@ -157,7 +157,7 @@ class HttpClient
             // exception has a response which means we might be able to retrieve content from it, log it and continue
             $response = $e->getResponse();
 
-            $this->logger->log('warning', 'Request throw exception (with a response): {error_message}', ['error_message' => $e->getMessage()]);
+            $this->logger->warning('Request throw exception (with a response): {error_message}', ['error_message' => $e->getMessage()]);
         }
 
         $effectiveUrl = $response->getEffectiveUrl();
@@ -217,7 +217,7 @@ class HttpClient
         // remove utm parameters & fragment
         $effectiveUrl = preg_replace('/((\?)?(&(amp;)?)?utm_(.*?)\=[^&]+)|(#(.*?)\=[^&]+)/', '', rawurldecode($effectiveUrl));
 
-        $this->logger->log('debug', 'Data fetched: {data}', ['data' => [
+        $this->logger->info('Data fetched: {data}', ['data' => [
             'effective_url' => $effectiveUrl,
             'body' => '(only length for debug): ' . \strlen($body),
             'headers' => $contentType,
@@ -289,7 +289,7 @@ class HttpClient
         }
 
         if (self::$nbRedirect > $this->config['max_redirect']) {
-            $this->logger->log('debug', 'Endless redirect: ' . self::$nbRedirect . ' on "{url}"', ['url' => $url]);
+            $this->logger->warning('Endless redirect: ' . self::$nbRedirect . ' on "{url}"', ['url' => $url]);
 
             return false;
         }
@@ -346,7 +346,7 @@ class HttpClient
         $ua = $this->config['ua_browser'];
 
         if (!empty($httpHeader['user-agent'])) {
-            $this->logger->log('debug', 'Found user-agent "{user-agent}" for url "{url}" from site config', ['user-agent' => $httpHeader['user-agent'], 'url' => $url]);
+            $this->logger->info('Found user-agent "{user-agent}" for url "{url}" from site config', ['user-agent' => $httpHeader['user-agent'], 'url' => $url]);
 
             return $httpHeader['user-agent'];
         }
@@ -368,13 +368,13 @@ class HttpClient
 
         foreach ($try as $h) {
             if (isset($this->config['user_agents'][$h])) {
-                $this->logger->log('debug', 'Found user-agent "{user-agent}" for url "{url}" from config', ['user-agent' => $this->config['user_agents'][$h], 'url' => $url]);
+                $this->logger->info('Found user-agent "{user-agent}" for url "{url}" from config', ['user-agent' => $this->config['user_agents'][$h], 'url' => $url]);
 
                 return $this->config['user_agents'][$h];
             }
         }
 
-        $this->logger->log('debug', 'Use default user-agent "{user-agent}" for url "{url}"', ['user-agent' => $ua, 'url' => $url]);
+        $this->logger->info('Use default user-agent "{user-agent}" for url "{url}"', ['user-agent' => $ua, 'url' => $url]);
 
         return $ua;
     }
@@ -394,12 +394,12 @@ class HttpClient
         $default_referer = $this->config['default_referer'];
 
         if (!empty($httpHeader['referer'])) {
-            $this->logger->log('debug', 'Found referer "{referer}" for url "{url}" from site config', ['referer' => $httpHeader['referer'], 'url' => $url]);
+            $this->logger->info('Found referer "{referer}" for url "{url}" from site config', ['referer' => $httpHeader['referer'], 'url' => $url]);
 
             return $httpHeader['referer'];
         }
 
-        $this->logger->log('debug', 'Use default referer "{referer}" for url "{url}"', ['referer' => $default_referer, 'url' => $url]);
+        $this->logger->info('Use default referer "{referer}" for url "{url}"', ['referer' => $default_referer, 'url' => $url]);
 
         return $default_referer;
     }
@@ -416,7 +416,7 @@ class HttpClient
     private function getCookie($url, $httpHeader = [])
     {
         if (!empty($httpHeader['cookie'])) {
-            $this->logger->log('debug', 'Found cookie "{cookie}" for url "{url}" from site config', ['cookie' => $httpHeader['cookie'], 'url' => $url]);
+            $this->logger->info('Found cookie "{cookie}" for url "{url}" from site config', ['cookie' => $httpHeader['cookie'], 'url' => $url]);
 
             $cookies = [];
             $pieces = array_filter(array_map('trim', explode(';', $httpHeader['cookie'])));
@@ -455,7 +455,7 @@ class HttpClient
     private function getAccept($url, $httpHeader = [])
     {
         if (!empty($httpHeader['accept'])) {
-            $this->logger->log('debug', 'Found accept header "{accept}" for url "{url}" from site config', ['accept' => $httpHeader['accept'], 'url' => $url]);
+            $this->logger->info('Found accept header "{accept}" for url "{url}" from site config', ['accept' => $httpHeader['accept'], 'url' => $url]);
 
             return $httpHeader['accept'];
         }
@@ -513,7 +513,7 @@ class HttpClient
         $redirectUrl = str_replace('&amp;', '&', trim($match[1]));
         if (preg_match('!^https?://!i', $redirectUrl)) {
             // already absolute
-            $this->logger->log('debug', 'Meta refresh redirect found (http-equiv="refresh"), new URL: ' . $redirectUrl);
+            $this->logger->info('Meta refresh redirect found (http-equiv="refresh"), new URL: ' . $redirectUrl);
 
             return $redirectUrl;
         }
@@ -526,7 +526,7 @@ class HttpClient
         }
 
         if ($absolute = \SimplePie_IRI::absolutize($base, $redirectUrl)) {
-            $this->logger->log('debug', 'Meta refresh redirect found (http-equiv="refresh"), new URL: ' . $absolute);
+            $this->logger->info('Meta refresh redirect found (http-equiv="refresh"), new URL: ' . $absolute);
 
             return $absolute->get_iri();
         }
@@ -559,7 +559,7 @@ class HttpClient
             return false;
         }
 
-        $this->logger->log('debug', 'Added escaped fragment to url');
+        $this->logger->info('Added escaped fragment to url');
 
         $query = ['_escaped_fragment_' => ''];
 

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -76,7 +76,7 @@ class ConfigBuilder
 
         $this->cache[$key] = $config;
 
-        $this->logger->log('debug', 'Cached site config with key: {key}', ['key' => $key]);
+        $this->logger->info('Cached site config with key: {key}', ['key' => $key]);
     }
 
     /**
@@ -147,7 +147,7 @@ class ConfigBuilder
         // is merged version already cached?
         $cachedSiteConfig = $this->getCachedVersion($host . '.merged');
         if (false !== $cachedSiteConfig) {
-            $this->logger->log('debug', 'Returning cached and merged site config for {host}', ['host' => $host]);
+            $this->logger->info('Returning cached and merged site config for {host}', ['host' => $host]);
 
             return $cachedSiteConfig;
         }
@@ -166,7 +166,7 @@ class ConfigBuilder
         // load global config?
         $configGlobal = $this->loadSiteConfig('global', true);
         if ($config->autodetect_on_failure() && false !== $configGlobal) {
-            $this->logger->log('debug', 'Appending site config settings from global.txt');
+            $this->logger->info('Appending site config settings from global.txt');
             $this->mergeConfig($config, $configGlobal);
 
             if ($addToCache && false === $this->getCachedVersion('global')) {
@@ -238,17 +238,17 @@ class ConfigBuilder
         $config = new SiteConfig();
 
         // look for site config file in primary folder
-        $this->logger->log('debug', '. looking for site config for {host} in primary folder', ['host' => $host]);
+        $this->logger->info('. looking for site config for {host} in primary folder', ['host' => $host]);
         foreach ($try as $host) {
             if ($cachedConfig = $this->getCachedVersion($host)) {
-                $this->logger->log('debug', '... site config for {host} already loaded in this request', ['host' => $host]);
+                $this->logger->info('... site config for {host} already loaded in this request', ['host' => $host]);
 
                 return $cachedConfig;
             }
 
             // if we found site config, process it
             if (isset($this->configFiles[$host . '.txt'])) {
-                $this->logger->log('debug', '... found site config {host}', ['host' => $host . '.txt']);
+                $this->logger->info('... found site config {host}', ['host' => $host . '.txt']);
 
                 $configLines = file($this->configFiles[$host . '.txt'], FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
                 // no lines ? we don't found config then
@@ -264,7 +264,7 @@ class ConfigBuilder
 
         // append global config?
         if ('global' !== $host && $config->autodetect_on_failure() && isset($this->configFiles['global.txt'])) {
-            $this->logger->log('debug', 'Appending site config settings from global.txt');
+            $this->logger->info('Appending site config settings from global.txt');
 
             $configGlobal = $this->loadSiteConfig('global', true);
             if (false !== $configGlobal) {

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -811,7 +811,7 @@ class ContentExtractorTest extends TestCase
     public function testLogMessage()
     {
         $logger = new Logger('foo');
-        $handler = new TestHandler();
+        $handler = new TestHandler($level = Logger::INFO);
         $logger->pushHandler($handler);
 
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -17,7 +17,7 @@ class GrabyFunctionalTest extends TestCase
     public function testRealFetchContent()
     {
         $logger = new Logger('foo');
-        $handler = new TestHandler();
+        $handler = new TestHandler($level = Logger::INFO);
         $logger->pushHandler($handler);
 
         $graby = new Graby(['debug' => true]);

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -18,6 +18,7 @@ class GrabyTest extends TestCase
         $graby = new Graby(['debug' => true]);
 
         $this->assertTrue($graby->getConfig('debug'));
+        $this->assertSame('info', $graby->getConfig('log_level'));
     }
 
     /**


### PR DESCRIPTION
Hello,

Here is my attempt at a better debug mode for Graby. The idea is to fully use the various levels of information possible that can be passed to the logger (`Logger::DEBUG` and `Logger::INFO`) to separate log messages. Graby's config is changed to `'debug' => false` to `'log_level' => false`, and expect `debug` or `info` as argument.

I chose the `Logger::INFO` level to store what was previously in the debug mode, as it is indeed information about the steps taken, without too much details. The `Logger::DEBUG` level stores in a separate log file `html.log` the data at various steps during the fetching/cleaning process. _Note that I put something to empty this file each time graby's called._

By default, nothing is stored ; if `'log_level' => 'info'`, only INFO messages are stored in `graby.log` ; if `'log_level' => 'debug'`, INFO messages are in `graby.log` and `html.log` contains debug messages of the last call to graby.

Most of the work is between lines 74-87 of Graby.php, but I also modified the logging calls to use the aliases offered by Monolog (i.e. `$this->logger->debug()` instead of `$this->logger->log('debug', ...)`). This is negotiable, I just found it nicer.