### PR TITLE
Fix wallabag#3825

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -265,8 +265,8 @@ class Graby
 
         // Remove empty lines to avoid runaway evaluation of following regex
         // on badly coded websites
-        $re = '/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/';
-        $html = preg_replace($re, '\n', $html);
+        $re = '/^[ \t]*[\r\n]+/m';
+        $html = preg_replace($re, '', $html);
 
         // Remove empty nodes (except iframe)
         $re = '/<(?!iframe)([^>\s]+)[^>]*>(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;|\s)*<\/\1>/m';

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -263,6 +263,11 @@ class Graby
 
         $html = $this->convert2Utf8($response['body'], $response['all_headers']);
 
+        // Remove empty lines to avoid runaway evaluation of following regex
+        // on badly coded websites
+        $re = '/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/';
+        $html = preg_replace($re, '\n', $html);
+
         // Remove empty nodes (except iframe)
         $re = '/<(?!iframe)([^>\s]+)[^>]*>(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;|\s)*<\/\1>/m';
         $html = preg_replace($re, '', $html);


### PR DESCRIPTION
Delete empty lines in retrieved HTML code to avoid runaway evaluation of empty node stripping regex on badly coded websites.