### PR TITLE
Handle "if_page_contains" for "single_page_link"

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -656,6 +656,18 @@ class Graby
         $singlePageUrl = null;
 
         foreach ($siteConfig->single_page_link as $pattern) {
+            // Do we have conditions?
+            $condition = $siteConfig->getIfPageContainsCondition('single_page_link', $pattern);
+
+            if ($condition) {
+                $elems = $xpath->evaluate($condition, $readability->dom);
+
+                // move on to next single page link XPath in case condition isn't met
+                if (!($elems instanceof \DOMNodeList && $elems->length > 0)) {
+                    continue;
+                }
+            }
+
             $elems = $xpath->evaluate($pattern, $readability->dom);
 
             if (\is_string($elems)) {

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -68,6 +68,10 @@ class SiteConfig
     // Test URL - if present, can be used to test the config above
     public $test_url = [];
 
+    // If page contains - XPath expression. Used to determine if the preceding rule gets evaluated or not.
+    // Currently only works with single_page_link.
+    public $if_page_contains = [];
+
     // Single-page link - should identify a link element or URL pointing to the page holding the entire article
     // This is useful for sites which split their articles across multiple pages. Links to such pages tend to
     // display the first page with links to the other pages at the bottom. Often there is also a link to a page
@@ -206,5 +210,20 @@ class SiteConfig
         }
 
         return $this->autodetect_on_failure;
+    }
+
+    /**
+     * Return a condition for the given name (if exists).
+     *
+     * @param string $name  Rule name (only single_page_link is supported for now)
+     * @param string $value Value of the rule (currently only an url)
+     *
+     * @return string|null
+     */
+    public function getIfPageContainsCondition($name, $value)
+    {
+        if (isset($this->if_page_contains[$name]) && isset($this->if_page_contains[$name][$value])) {
+            return $this->if_page_contains[$name][$value];
+        }
     }
 }

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -1634,6 +1634,42 @@ class GrabyTest extends TestCase
     }
 
     /**
+     * Validated using the site_config in "tests/fixtures".
+     */
+    public function testIfPageContains()
+    {
+        $graby = $this->getGrabyWithMock(
+            '/fixtures/content/timothysykes-keepol.html',
+            200,
+            [
+                'extractor' => [
+                    'config_builder' => [
+                        'site_config' => [__DIR__ . '/fixtures/site_config'],
+                    ],
+                ],
+            ]
+        );
+        $res = $graby->fetchContent('https://www.timothysykes.com/blog/10-things-know-short-selling/');
+
+        $this->assertCount(12, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
+        $this->assertArrayHasKey('authors', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('native_ad', $res);
+        $this->assertArrayHasKey('all_headers', $res);
+
+        $this->assertSame(200, $res['status']);
+    }
+
+    /**
      * Return an instance of graby with a mocked Guzzle client returning data from a predefined file.
      */
     private function getGrabyWithMock($filePath, $status = 200, array $grabyConfig = [])

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -43,6 +43,8 @@ class ConfigBuilderTest extends TestCase
             'http_header(Cookie): GDPR_consent=1',
             'strip_attr: @class',
             'strip_attr: @style',
+            'single_page_link: //canonical',
+            'if_page_contains: //div/article/header',
         ]);
 
         $configExpected = new SiteConfig();
@@ -59,6 +61,12 @@ class ConfigBuilderTest extends TestCase
         ];
         $configExpected->date = ['foo'];
         $configExpected->strip_attr = ['@class', '@style'];
+        $configExpected->single_page_link = ['//canonical'];
+        $configExpected->if_page_contains = [
+            'single_page_link' => [
+                '//canonical' => '//div/article/header',
+            ],
+        ];
 
         $this->assertEquals($configExpected, $configActual);
 

--- a/tests/fixtures/site_config/timothysykes.com.txt
+++ b/tests/fixtures/site_config/timothysykes.com.txt
@@ -1,0 +1,2 @@
+single_page_link: concat(substring-before(//link[@rel="canonical"]/@href, "_story.html"), "_print.html")
+if_page_contains: //link[@rel="canonical" and contains(@href, '_story.html')]


### PR DESCRIPTION
It was introduced in Full-Text RSS 3.5.

> XPath expression used to determine if the `single_page_link` rule gets evaluated or not.