### PR TITLE
Handle "if_page_contains" for "next_page_link"

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -221,6 +221,18 @@ class ContentExtractor
         // try to get next page link
         // @todo: should we test if the link is actually a link?
         foreach ($this->siteConfig->next_page_link as $pattern) {
+            // Do we have conditions?
+            $condition = $this->siteConfig->getIfPageContainsCondition('next_page_link', $pattern);
+
+            if ($condition) {
+                $elems = $this->xpath->evaluate($condition, $this->readability->dom);
+
+                // move on to next next_page_link XPath in case condition isn't met
+                if (!($elems instanceof \DOMNodeList && $elems->length > 0)) {
+                    continue;
+                }
+            }
+
             $elems = $this->xpath->evaluate($pattern, $this->readability->dom);
 
             if (\is_string($elems)) {

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -430,7 +430,7 @@ class Graby
 
         $res['html'] = $this->cleanupHtml($contentBlock, $effectiveUrl);
 
-        $this->logger->info('Returning data (most interesting ones): {data}', ['data' => ($res + ['html' => \strlen($res['html'])])]);
+        $this->logger->info('Returning data (most interesting ones): {data}', ['data' => ['html' => '(only length for debug): ' . \strlen($res['html'])] + $res]);
 
         return $res;
     }
@@ -681,7 +681,7 @@ class Graby
             if ($condition) {
                 $elems = $xpath->evaluate($condition, $readability->dom);
 
-                // move on to next single page link XPath in case condition isn't met
+                // move on to next single_page_link XPath in case condition isn't met
                 if (!($elems instanceof \DOMNodeList && $elems->length > 0)) {
                     continue;
                 }

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -377,17 +377,30 @@ class ConfigBuilder
         return $config;
     }
 
-    // Add if_page_page_contains
-    // TODO: Expand so it can be used with other rules too
+    /**
+     * Build `if_page_contains` rule based on other previous rules defined for:
+     *     - single_page_link.
+     *     - next_page_link.
+     *
+     * First one has priority over the next one.
+     *
+     * @param SiteConfig $config    Current config
+     * @param string     $condition XPath condition
+     */
     private function handleIfPageContainsCondition(SiteConfig $config, $condition)
     {
-        if (empty($config->single_page_link)) {
+        if (!empty($config->single_page_link)) {
+            $rule = 'single_page_link';
+        } elseif (!empty($config->next_page_link)) {
+            $rule = 'next_page_link';
+        } else {
+            // no link found, we can't apply "if_page_contains"
             return;
         }
 
-        $key = end($config->single_page_link);
-        reset($config->single_page_link);
+        $key = end($config->$rule);
+        reset($config->$rule);
 
-        $config->if_page_contains['single_page_link'][$key] = (string) $condition;
+        $config->if_page_contains[$rule][$key] = (string) $condition;
     }
 }

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -69,7 +69,7 @@ class SiteConfig
     public $test_url = [];
 
     // If page contains - XPath expression. Used to determine if the preceding rule gets evaluated or not.
-    // Currently only works with single_page_link.
+    // Currently only works with single_page_link & next_page_link (first one has priority over the second one).
     public $if_page_contains = [];
 
     // Single-page link - should identify a link element or URL pointing to the page holding the entire article
@@ -215,7 +215,7 @@ class SiteConfig
     /**
      * Return a condition for the given name (if exists).
      *
-     * @param string $name  Rule name (only single_page_link is supported for now)
+     * @param string $name  Rule name (only single_page_link & next_page_link is supported for now)
      * @param string $value Value of the rule (currently only an url)
      *
      * @return string|null

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -1637,7 +1637,7 @@ class GrabyTest extends TestCase
     /**
      * Validated using the site_config in "tests/fixtures".
      */
-    public function testIfPageContains()
+    public function testIfPageContainsWithSinglePageLink()
     {
         $graby = $this->getGrabyWithMock(
             '/fixtures/content/timothysykes-keepol.html',
@@ -1651,6 +1651,43 @@ class GrabyTest extends TestCase
             ]
         );
         $res = $graby->fetchContent('https://www.timothysykes.com/blog/10-things-know-short-selling/');
+
+        $this->assertCount(12, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
+        $this->assertArrayHasKey('authors', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('content_type', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('open_graph', $res);
+        $this->assertArrayHasKey('native_ad', $res);
+        $this->assertArrayHasKey('all_headers', $res);
+
+        $this->assertSame(200, $res['status']);
+    }
+
+    /**
+     * Validated using the site_config in "tests/fixtures".
+     */
+    public function testIfPageContainsWithNextPageLink()
+    {
+        $graby = $this->getGrabyWithMock(
+            '/fixtures/content/rollingstone.html',
+            200,
+            [
+                'debug' => true,
+                'extractor' => [
+                    'config_builder' => [
+                        'site_config' => [__DIR__ . '/fixtures/site_config'],
+                    ],
+                ],
+            ]
+        );
+        $res = $graby->fetchContent('https://www.rollingstone.com/?redirurl=/politics/news/greed-and-debt-the-true-story-of-mitt-romney-and-bain-capital-20120829');
 
         $this->assertCount(12, $res);
 

--- a/tests/fixtures/content/rollingstone.html
+++ b/tests/fixtures/content/rollingstone.html
@@ -1,0 +1,4911 @@
+
+
+<!DOCTYPE html>
+<html lang="en-US" class="fonts-loading no-js">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"><script type="text/javascript">window.NREUM||(NREUM={}),__nr_require=function(e,n,t){function r(t){if(!n[t]){var o=n[t]={exports:{}};e[t][0].call(o.exports,function(n){var o=e[t][1][n];return r(o||n)},o,o.exports)}return n[t].exports}if("function"==typeof __nr_require)return __nr_require;for(var o=0;o<t.length;o++)r(t[o]);return r}({1:[function(e,n,t){function r(){}function o(e,n,t){return function(){return i(e,[c.now()].concat(u(arguments)),n?null:this,t),n?void 0:this}}var i=e("handle"),a=e(3),u=e(4),f=e("ee").get("tracer"),c=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var p=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],d="api-",l=d+"ixn-";a(p,function(e,n){s[n]=o(d+n,!0,"api")}),s.addPageAction=o(d+"addPageAction",!0),s.setCurrentRouteName=o(d+"routeName",!0),n.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,n){var t={},r=this,o="function"==typeof n;return i(l+"tracer",[c.now(),e,t],r),function(){if(f.emit((o?"":"no-")+"fn-start",[c.now(),r,o],t),o)try{return n.apply(this,arguments)}catch(e){throw f.emit("fn-err",[arguments,this,e],t),e}finally{f.emit("fn-end",[c.now()],t)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,n){m[n]=o(l+n)}),newrelic.noticeError=function(e,n){"string"==typeof e&&(e=new Error(e)),i("err",[e,c.now(),!1,n])}},{}],2:[function(e,n,t){function r(e,n){if(!o)return!1;if(e!==o)return!1;if(!n)return!0;if(!i)return!1;for(var t=i.split("."),r=n.split("."),a=0;a<r.length;a++)if(r[a]!==t[a])return!1;return!0}var o=null,i=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var u=navigator.userAgent,f=u.match(a);f&&u.indexOf("Chrome")===-1&&u.indexOf("Chromium")===-1&&(o="Safari",i=f[1])}n.exports={agent:o,version:i,match:r}},{}],3:[function(e,n,t){function r(e,n){var t=[],r="",i=0;for(r in e)o.call(e,r)&&(t[i]=n(r,e[r]),i+=1);return t}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],4:[function(e,n,t){function r(e,n,t){n||(n=0),"undefined"==typeof t&&(t=e?e.length:0);for(var r=-1,o=t-n||0,i=Array(o<0?0:o);++r<o;)i[r]=e[n+r];return i}n.exports=r},{}],5:[function(e,n,t){n.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,n,t){function r(){}function o(e){function n(e){return e&&e instanceof r?e:e?f(e,u,i):i()}function t(t,r,o,i){if(!d.aborted||i){e&&e(t,r,o);for(var a=n(o),u=v(t),f=u.length,c=0;c<f;c++)u[c].apply(a,r);var p=s[y[t]];return p&&p.push([b,t,r,a]),a}}function l(e,n){h[e]=v(e).concat(n)}function m(e,n){var t=h[e];if(t)for(var r=0;r<t.length;r++)t[r]===n&&t.splice(r,1)}function v(e){return h[e]||[]}function g(e){return p[e]=p[e]||o(t)}function w(e,n){c(e,function(e,t){n=n||"feature",y[t]=n,n in s||(s[n]=[])})}var h={},y={},b={on:l,addEventListener:l,removeEventListener:m,emit:t,get:g,listeners:v,context:n,buffer:w,abort:a,aborted:!1};return b}function i(){return new r}function a(){(s.api||s.feature)&&(d.aborted=!0,s=d.backlog={})}var u="nr@context",f=e("gos"),c=e(3),s={},p={},d=n.exports=o();d.backlog=s},{}],gos:[function(e,n,t){function r(e,n,t){if(o.call(e,n))return e[n];var r=t();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,n,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return e[n]=r,r}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(e,n,t){function r(e,n,t,r){o.buffer([e],r),o.emit(e,n,t)}var o=e("ee").get("handle");n.exports=r,r.ee=o},{}],id:[function(e,n,t){function r(e){var n=typeof e;return!e||"object"!==n&&"function"!==n?-1:e===window?0:a(e,i,function(){return o++})}var o=1,i="nr@id",a=e("gos");n.exports=r},{}],loader:[function(e,n,t){function r(){if(!E++){var e=x.info=NREUM.info,n=l.getElementsByTagName("script")[0];if(setTimeout(s.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&n))return s.abort();c(y,function(n,t){e[n]||(e[n]=t)}),f("mark",["onload",a()+x.offset],null,"api");var t=l.createElement("script");t.src="https://"+e.agent,n.parentNode.insertBefore(t,n)}}function o(){"complete"===l.readyState&&i()}function i(){f("mark",["domContent",a()+x.offset],null,"api")}function a(){return O.exists&&performance.now?Math.round(performance.now()):(u=Math.max((new Date).getTime(),u))-x.offset}var u=(new Date).getTime(),f=e("handle"),c=e(3),s=e("ee"),p=e(2),d=window,l=d.document,m="addEventListener",v="attachEvent",g=d.XMLHttpRequest,w=g&&g.prototype;NREUM.o={ST:setTimeout,SI:d.setImmediate,CT:clearTimeout,XHR:g,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var h=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1118.min.js"},b=g&&w&&w[m]&&!/CriOS/.test(navigator.userAgent),x=n.exports={offset:u,now:a,origin:h,features:{},xhrWrappable:b,userAgent:p};e(1),l[m]?(l[m]("DOMContentLoaded",i,!1),d[m]("load",r,!1)):(l[v]("onreadystatechange",o),d[v]("onload",r)),f("mark",["firstbyte",u],null,"api");var E=0,O=e(5)},{}]},{},["loader"]);</script>
+
+        <link rel="manifest" href="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/app/manifest.json">
+
+        <!-- Responsiveness -->
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <!-- Browser shell -->
+        <meta name="theme-color" content="#df3535">
+
+        <!-- Add to home screen for iOS -->
+        <meta name="apple-mobile-web-app-title" content="Rolling Stone">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <link rel="apple-touch-icon" sizes="180x180" href="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/app/icons/apple-touch-icon.png">
+        <link rel="apple-touch-icon" href="images/icons/apple-touch-icon.png">
+
+        <!-- Tile icons for Windows -->
+        <meta name="msapplication-config" content="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/app/browserconfig.xml">
+        <meta name="msapplication-TileImage" content="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/app/icons/mstile-144x144.png">
+        <meta name="msapplication-TileColor" content="#eff4ff">
+
+        <!-- Favicons -->
+        <link rel="icon" type="image/png" sizes="32x32" href="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/app/icons/favicon-32x32.png">
+        <link rel="shortcut icon" href="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/app/icons/favicon.ico">
+
+        <!-- Safari pin icon -->
+        <link rel="mask-icon" href="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/app/icons/safari-pinned-tab.svg" color="#000000">
+
+        <!-- Titles -->
+        <meta name="apple-mobile-web-app-title" content="Rolling Stone">
+        <meta name="application-name" content="Rolling Stone">
+        <meta name="description" content="Music, Film, TV and Political News Coverage">
+        <!-- Titles:end -->
+
+                <!-- Hotjar Tracking Code for https://www.rollingstone.com -->
+        <script>
+            (function(h,o,t,j,a,r){
+                h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+                h._hjSettings={hjid:779614,hjsv:5};
+                a=o.getElementsByTagName('head')[0];
+                r=o.createElement('script');r.async=1;
+                r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+                a.appendChild(r);
+            })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
+        </script>
+        <!-- Start: Youtube Iframe API -->
+<script>
+    ( function(){
+        var tag = document.createElement('script');
+        tag.src = "https://www.youtube.com/iframe_api";
+        tag.async = true;
+        window.onload = function() {
+            document.getElementsByTagName('head')[0].appendChild( tag );
+        }
+    } )();
+</script>
+<!-- End: Youtube Iframe API -->
+<!-- BEGIN Amazon Apstag -->
+<script>
+    !function(a9,a,p,s,t,A,g){if(a[a9])return;function q(c,r){a[a9]._Q.push([c,r])}a[a9]={init:function(){q("i",arguments)},fetchBids:function(){q("f",arguments)},setDisplayBids:function(){},_Q:[]};A=p.createElement(s);A.async=!0;A.src=t;g=p.getElementsByTagName(s)[0];g.parentNode.insertBefore(A,g)}("apstag",window,document,"script","//c.amazon-adsystem.com/aax2/apstag.js");
+    apstag.init({
+        pubID: 3157,
+        adServer: 'googletag',
+        videoAdServer: 'DFP',
+        bidTimeout: 2e3
+    });
+</script>
+<!-- End Amazon Apstag -->
+
+<!-- BEGIN Krux Control Tag -->
+<script class="kxct" data-id="spjmkpi82" data-timing="async" data-version="3.0" type="text/javascript">
+  window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]);
+  (function(){
+    var k=document.createElement('script');k.type='text/javascript';k.async=true;
+    k.src="https:\/\/cdn.krxd.net\/controltag\/spjmkpi82.js";
+    var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s);
+  }());
+
+</script>
+<!-- END Krux Controltag -->
+
+<!-- GPT interchange code -->
+<script>
+ window.Krux || ((Krux = function() {
+   Krux.q.push(arguments);
+ }).q = []);
+ (function() {
+   function retrieve(n) {
+     var m, k = 'kx' + n;
+     if (window.localStorage) {
+       return window.localStorage[k] || "";
+     } else if (navigator.cookieEnabled) {
+       m = document.cookie.match(k + '=([^;]*)');
+       return (m && unescape(m[1])) || "";
+     } else {
+       return '';
+     }
+   }
+   Krux.user = retrieve('user');
+   Krux.segments = retrieve('segs') && retrieve('segs').split(',') || [];
+ })();
+</script>
+
+
+<meta name="description" content="Get the latest Rolling Stone news with exclusive stories and pictures from Rolling Stone." />
+<meta name="keywords" content="tv pictures, music country pictures, politics pictures, movie pictures, music country videos, music latin lists, culture pictures, movie videos, tv videos, music pictures, politics videos, culture videos, tv reviews, music latin, politics lists, music videos, tv lists, tv features, movie features, live reviews" />
+<title>Rolling Stone &#8211; Music, Film, TV and Political News Coverage</title>
+<script type="text/javascript">dataLayer = window.dataLayer || []; /* Google Tag Manager */</script>
+<script type="text/javascript">
+/* <![CDATA[ */
+var pmc_meta = {"lob":"rollingstone","page-type":"home","env":"desktop","primary-category":"","primary-vertical":"","vertical":"","category":"","tag":"","author":"","logged-in":"","subscriber-type":"","country":"us"};
+
+/* ]]> */
+</script>
+        <script>
+            (function(d,w){
+                var i, parts, name, c, rdecode = /(%[0-9A-Z]{2})+/g, rspace = /\+/g, ac = (d ? d.split('; ') : []);
+                for(w.pmc_cookies = {}, i = 0; i < ac.length; i++) {
+                    parts = ac[i].split('='), name = parts[0].replace(rdecode, decodeURIComponent), c = parts.slice(1).join('=');
+                    if(c.charAt(0) === '"') { c = c.slice(1, -1); } c = c.replace(rdecode, decodeURIComponent).replace(rspace, ' '); w['pmc_cookies'][name] = c;
+                }
+            })(document.cookie, window);
+
+            pmc_meta=pmc_meta || {}, pmc_meta.omni_visit_id = window.pmc_cookies.omni_visit_id || "rollingstone." + new Date().getTime() + '.' + (function(l,b,a,c,i,d){for(i=0;i<256;i++){l[i]=(i<16?'0':'')+(i).toString(16);}if(c&&c.getRandomValues){try{d=new Uint32Array(4),c.getRandomValues(d);}catch(e){d=0;}}d=d||[b()*a>>>0,b()*a>>>0,b()*a>>>0,b()*a>>>0];a=d[0],b=d[1],c=d[2],d=d[3];return l[a&0xff]+l[a>>8&0xff]+l[a>>16&0xff]+l[a>>24&0xff]+'-'+l[b&0xff]+l[b>>8&0xff]+'-'+l[b>>16&0x0f|0x40]+l[b>>24&0xff]+'-'+l[c&0x3f|0x80]+l[c>>8&0xff]+'-'+l[c>>16&0xff]+l[c>>24&0xff]+l[d&0xff]+l[d>>8&0xff]+l[d>>16&0xff]+l[d>>24&0xff];})([],Math.random,0x100000000,window.crypto||window.msCrypto);
+            var d = new Date(); d.setTime(d.getTime() + ( 60 * 60 * 1000 )); var expires = d.toGMTString(); var path = "/"; var domain = window.location.hostname;
+            document.cookie = 'omni_visit_id=' + encodeURIComponent(pmc_meta.omni_visit_id) + ( expires ? '; expires=' + expires : '' ) + ( path ? '; path=' + path : '' ) + ( domain ? '; domain=' + domain : '' );
+        </script>
+                <script type="text/javascript">
+        if( window.hasOwnProperty( 'pmc_meta' ) ) {
+            if( !window.hasOwnProperty( 'dataLayer' ) || !window.dataLayer.hasOwnProperty('push') ) {
+                window.dataLayer = [];
+            }
+            window.dataLayer.push( pmc_meta );
+        }
+        </script>
+
+                <script>
+            window.pmc_is_adblocked = false;
+        </script>
+        <link rel='dns-prefetch' href='//s0.wp.com' />
+<link rel='dns-prefetch' href='//s.swiftypecdn.com' />
+<link rel='dns-prefetch' href='//content.jwplatform.com' />
+<link rel='dns-prefetch' href='//d9etzk30b05yg.cloudfront.net' />
+<link rel='dns-prefetch' href='//z.moatads.com' />
+<link rel='dns-prefetch' href='//js-sec.indexww.com' />
+<link rel='dns-prefetch' href='//cdn.roiq.ranker.com' />
+<link rel='dns-prefetch' href='//www.lightboxcdn.com' />
+<noscript><link rel='stylesheet' id='fallback-wp-block-library-css'  href='https://www.rollingstone.com/wp-includes/css/dist/block-library/style.min.css?ver=5.0.3' type='text/css' media='all' />
+</noscript><link rel='preload' as='style' onload='this.onload=null;this.rel="stylesheet"' id='wp-block-library-css'  href='https://www.rollingstone.com/wp-includes/css/dist/block-library/style.min.css?ver=5.0.3' type='text/css' media='all' />
+<noscript><link rel='stylesheet' id='fallback-jetpack-email-subscribe-css'  href='https://www.rollingstone.com/wp-content/mu-plugins/jetpack/modules/shortcodes/css/jetpack-email-subscribe.css?ver=1.0' type='text/css' media='all' />
+</noscript><link rel='preload' as='style' onload='this.onload=null;this.rel="stylesheet"' id='jetpack-email-subscribe-css'  href='https://www.rollingstone.com/wp-content/mu-plugins/jetpack/modules/shortcodes/css/jetpack-email-subscribe.css?ver=1.0' type='text/css' media='all' />
+<noscript><link rel='stylesheet' id='fallback-pmc-swiftype-style-css'  href='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-swiftype/assets/css/style.css?ver=2.0' type='text/css' media='all' />
+</noscript><link rel='preload' as='style' onload='this.onload=null;this.rel="stylesheet"' id='pmc-swiftype-style-css'  href='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-swiftype/assets/css/style.css?ver=2.0' type='text/css' media='all' />
+<noscript><link rel='stylesheet' id='fallback-pmc-adm-style-css'  href='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-adm/css/pmc-adm-style.css?ver=5.0.3' type='text/css' media='all' />
+</noscript><link rel='preload' as='style' onload='this.onload=null;this.rel="stylesheet"' id='pmc-adm-style-css'  href='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-adm/css/pmc-adm-style.css?ver=5.0.3' type='text/css' media='all' />
+<style id='pmc-adm-style-inline-css' type='text/css'>
+div.admz, div.admz-sp { margin-left: auto; margin-right: auto; text-align: center; } #skin-ad-inject-container { display: none; }
+</style>
+<noscript><link rel='stylesheet' id='fallback-jetpack_css-css'  href='https://www.rollingstone.com/wp-content/mu-plugins/jetpack/css/jetpack.css?ver=6.9' type='text/css' media='all' />
+</noscript><link rel='preload' as='style' onload='this.onload=null;this.rel="stylesheet"' id='jetpack_css-css'  href='https://www.rollingstone.com/wp-content/mu-plugins/jetpack/css/jetpack.css?ver=6.9' type='text/css' media='all' />
+<script type="text/javascript" src="https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-global-functions/js/pmc-utils.js"></script>         <script type="text/javascript">
+            var pmc_do_analytics_pagecount = true;      //flag to allow analytics code to count a page view
+            var pmc_common_urls = {
+                parent_theme_uri: 'https://www.rollingstone.com/wp-content/themes/vip/pmc-core-v2/',
+                current_theme_uri: 'https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/',
+                fb_channel_uri: 'https://www.rollingstone.com/wp-content/plugins/pmc-plugins/partner/facebook/channel.html'
+            };
+            </script>
+        <script type="text/javascript">
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+            var pmc_ga_dimensions = {"dimension15":"home","dimension43":"anonymous"};var pmc_ga_mapped_dimensions = {"page-type":"15","page-subtype":"16","id":"17","author":"18","category":"19","tag":"20","vertical":"21","primary-category":"22","primary-vertical":"23","publish-year":"24","publish-month":"25","publish-day":"26","publish-hour":"27","publish-minute":"28","protocol":"29","paywall-entitlement":"30","paywall-sub-level-required":"31","paywall-sub-roadblock-hit":"32","paywall-acct-type":"33","paywall-acct-id":"34","paywall-org-name":"35","paywall-org-id":"36","paywall-auth-provider":"37","paywall-logged-in":"38","publish-timestamp-gmt":"39","publish-timestamp":"40","publish-day-of-week":"41","omni-visit-id":"42","user-type":"43","a-b-test":"44","experiment-name":"45","paywall-special-product-code":"46","paywall-product-code":"47","post-options":"48","child-post-id":"49"};           pmc_ga_dimensions["dimension29"] = document.location.protocol.replace(':', '');
+            (function(dim){
+                var ac = document.cookie ? document.cookie.split('; ') : [];
+                var i, parts, name, c, cookies = {}, rdecode = /(%[0-9A-Z]{2})+/g, rspace = /\+/g;
+                for(i = 0; i < ac.length; i++) {
+                    parts = ac[i].split('=');
+                    name = parts[0].replace(rdecode, decodeURIComponent);
+                    c = parts.slice(1).join('=');
+                    if(c.charAt(0) === '"') { c = c.slice(1, -1); }
+                    c = c.replace(rdecode, decodeURIComponent).replace(rspace, ' ');
+                    cookies[name] = c;
+                }
+                window[dim] = window[dim] || {};
+                            if( 'undefined' !== typeof pmc_meta && 'string' === typeof pmc_meta.omni_visit_id ){
+                window[dim]["dimension42"] = pmc_meta.omni_visit_id;
+            }
+                    })('pmc_ga_dimensions');
+
+            var pmc_ga_fields_obj = {"useAmpClientId":true};
+            ga('create', "UA-31650-9", 'auto', pmc_ga_fields_obj);
+            ga('set', 'forceSSL', true);
+
+                            ga('set', 'hitCallback', function() { if ( typeof pmc === 'object' && typeof pmc.tracking === 'object' && typeof pmc.tracking.do_call_events === 'function' ) { pmc.tracking.do_call_events(); } } );
+                        ga('require', 'linkid', 'linkid.js');
+                            ga('require', 'displayfeatures');           ga('set', pmc_ga_dimensions);
+
+
+            ga('send', 'pageview');
+        </script>
+
+        <script type='text/javascript' src='https://www.rollingstone.com/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+<script type='text/javascript' src='https://www.rollingstone.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-global-functions/js/pmc-remove-tracking.js?ver=5.0.3'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-global-functions/js/pmc-global.min.js?ver=5.0.3'></script>
+<script type='text/javascript' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-global-functions/js/pmc-hooks.js?ver=5.0.3'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var pmc_comscore_options = {"pageview_candidate_url":"\/\/www.rollingstone.com\/wp-content\/plugins\/pmc-plugins\/pmc-comscore\/xml\/comscore-pageview-candidate.xml"};
+/* ]]> */
+</script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-comscore/js/pmc-comscore.js?ver=5.0.3'></script>
+<script type='text/javascript' defer='defer' src='//content.jwplatform.com/libraries/zFOPDjEV.js?ver=5.0.3'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-video-player/js/script.js?ver=5.0.3'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var configuration = {"rendererBaseUrl":"\/\/renderer.qmerce.com","randomBaseUrl":"\/\/random.qmerce.com"};
+/* ]]> */
+</script>
+<script type='text/javascript'="async" defer='defer' src='//d9etzk30b05yg.cloudfront.net/js/sdk/v2.0/apester-javascript-sdk.min.js?ver=5.0.3'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var pmc_apstag = {"is_enabled":"enabled","is_gallery":"enabled","is_video":"enabled"};
+/* ]]> */
+</script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-amazon-apstag/assets/js/amazon-apstag.min.js?ver=1.0.0'></script>
+<script type='text/javascript' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-adm/js/sourcebuster/sourcebuster.min.js?ver=v1.1.0'></script>
+<script type='text/javascript' defer='defer' src='https://z.moatads.com/pmcprebidheader92389980944/yi.js?ver=3.1'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var pmc_adm_config = {"dfp_skin_main_content":["site_wrap"],"disable_gpt_single_request":"0","krux_header_bidder_active":"","lazy_load_override":"enable","page_level_referrer_targeting":"enable"};
+var pmc_header_bidder = {"active":""};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-adm/js/loader.min.js?ver=3.5'></script>
+<script type='text/javascript' defer='defer' src='https://js-sec.indexww.com/htv/htv-jwplayer.min.js?ver=5.0.3'></script>
+<script type='text/javascript' defer='defer' src='https://cdn.polyfill.io/v2/polyfill.min.js?features=IntersectionObserver,Promise,Fetch,Array.from'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/js/vendor/iolazy.js'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/js/main.js?ver=2.2'></script>
+<script type='text/javascript' defer='defer' src='https://www.lightboxcdn.com/vendor/f611bb46-e8d6-4b65-af04-d7801b2011c2/lightbox_inline.js?ver=2.2'></script>
+        <style type="text/css" id="web-fonts-css">
+                @font-face {
+                    font-family: 'Graphik Bold Subset';
+                    src: url( data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAII8AA4AAAABiOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABHREVGAABs+AAAADsAAABGBnUHVEdQT1MAAG00AAARSQAAQnRJzb8MR1NVQgAAfoAAAAO7AAAHsPDf9vJPUy8yAAAsmAAAAFUAAABgZq2eY2NtYXAAACzwAAAApAAAANzWgczLZ2FzcAAAbPAAAAAIAAAACP//AANnbHlmAAABRAAAJmQAAEdy+SSDlmhlYWQAACnAAAAANAAAADbw0KyJaGhlYQAALHgAAAAgAAAAJAdbBB9obXR4AAAp9AAAAoIAAAPoI0MdXWxvY2EAACfIAAAB9gAAAfY/TS12bWF4cAAAJ6gAAAAeAAAAIAFDAE9uYW1lAAAtlAAAPQAAAOsI3LkHrHBvc3QAAGqUAAACWwAAA3E65WEWeNrNXHdAVFfWf/cNUygCw1TaUAYYOlOYGepQpCoIUhREBZQq2MCCCBawErsmaoyYqLGs6aibaDSJMbt+0ZjNJiZudhOzJbtxjV+S3ajJbnh85973ZpihGHf/+gRmYN5955x77u+Ue859UjSVOnQPedFXKSHlSlHy4LB4k14u1fAMvA8rLJaKtDO+7/q6JpUkJ5e8jr5gAimKpiLQq+gY3MGDeygJjMRfqdITsmmykzK4JmHu4h8YqaHm0koY6UsFUFSoWS1Um9VGA/kxCMmPTE1+ePAXcpdZZCtk2TNcC2u9VnhZJCskeTNdi+pkPa4W17nbtm3bWrBhJfzbULB1G2osKAD+yqEVdAsvhlJRIVQkRfGNsUhjkCvgzRhvMhsNMrlCHaaRqZBMKhDKJPHwu4knhQECFLhqPf8155x1Sza0TfmT+IxLfPeaNd0T/TQTb/hrsjZ2O3c3FHnskjQ3VnWIKmdI3kl17/Oa01jbI+pGJT6+zuvd0TJff9EaN2BKeQ99zwumP6RcKDnlQ4VSOtCK3hQfpg4WyIBZcBgIY9DLQQYeMqBQvXGsS5/4qlS+fgEBvtMbWkumtjadRd/OYTzR1iSVn29AgM/0hvlTS1qa0EcReeHh6tCIpoaigoa5BcVNzB766qBxVqEafxzejD+eU1jcRIF2Aoe+p7+hP6IUoP0IikJChVojUGOeZhtfocLM15s1WBqJVGFiRaPvtC+/HVm8uH3TwejeuVWrts+IZ+5E+i3Wxhkicv2VPkFoyZ92xae316+fbEmrmFtR1G5Z0HBHtclPF65D2wK1wUZlQBAwxEihbhKkEJykSl/k8AHXwoZaUQVPSDlTlCJM7Gk2gAyKa8eObdm4cc8VxEeCKx8M/vQBpuI6NB9ZeCIy0iT2hBUWewpdN27ccvz47uuIooau/5r5F/Pjr/FYf9SGnqL/RrkDR41ZY1ZoDEKzQqgQap5trVwavEC5XTlfvayyJQG1Fc6YsNK4Er4nzChsx/eGUqW0jC7HdmA2AkYBP4BN2Y2XXtrx0kulb/a8Cd94nOfQBuRCncWzUmgkis55Zcc6I5AwGV8zUJ+iyagWXzMbg2QGpPx040b4PHboHjVIvUHmgG0MlC8V7IlOSoqOSUlxTS5Lhm+4f+gr0MppmCvcLwSwKFHqdubSHt5TP9VhywuBFX2VvkG5Ac6oUL0pFeH18kcESvAHJgt/CdCijKSUjO7UlL0vvrpr9y9P766p95875x1VXc2h88dVz75+5oTfyTdAKjBntBTWR0BRBrHQaDaIT2w6+jKNyk61DxrhugiY5gI/BVw3SiyIwEOotiAWsx7IIBP9KyVJE1rsdo6/d92aLVkT6771R87pVZGhUUvW9XU1ZC9Jr90PlPxA8iagFAwGEwgraAAriEJGg34ESSGxVZTDfOFy1qV69uxEY3VkeMmEM8IdPd070pLSCva6PZg7tWx1UVBY1fy182YkTxFPKE9vWoG14wUv22E2LtQEigoyBhmRQYwXEN7QAuYoinwwcybz9NObC9E9ZvLWzUiOfEEyH5CsnPgoih8cpjGoQBITJ5UkSBYkZNcKGTZtdToniIiNjDbEToru9EB/Yl5xMrbVLT3g1tMSEZkQozUZ0LNP9Bes+etm61r1Et0FEcrc8oBDAgsTclavwX6C+AJUfWTfmS0rHnN93S09KZ1nWtyw8eDmqHhDhdHodv6I5NQ7LU0pc6pKV7S2bd6ZNDMxMVqbhPGmBFYJ3ApKYM4y3qIrzBd04A906DHZ4CTAkQrkaAc5pJQfFUYkwb5x2AFgMcJYMaQmMnMsD8rre3piWt2B9mX76tccHphmMk4zp+VpdXlat4WNlip5TOOslnmzGmKjVzcu2aEr0+nKfowKUUdFqUPw3AOG7tGr6I9h7sGcVmHBTWbW+VhBSnNqxtwyV+2EiedZkmnj/JaNhzYe6D/yToXJGBNpdF3QmDpzdtmKBW19F55RvnAB9SRGaZOTY2MwHx3ELgp9BlYls7crnp1f3RuVnBwFNhbDvXO2hlRJUZHJyZFRSZiOC1i0AujwKA/WpjV2FJbMKz1WzlkqsfN9tlsRRJ1k9D6dj/Ufg4yhMqECvc9UoWcvXky+H3z/cN08EgWP0wL0VzZeYq8QCj8adIsJQreOd3ZeXrkSr6SOSkGf0JMwJbPRrDHyZbo33kDHUo7Mndd/P5jgG7TqDiuposLxmHgLbbbQxngMJ6v9CN15QpnQpoiTHiFyb7lclhoYyX/Baeey9lX5bjpvH15ZTFpaTLTFckfiGxerVMoVoZ4pcRELO+dWFuW6xXiHiT3uk5CfBFz9hubwuugBkC+VQ4+FZhWjDtbYVlRhNvAEhuEVJettcEc8u4/QtXfuTO46WnH69qoZ3fKIWZMq28pKfIW7g0XxsWmn9/b/9pcnSjZEVOlf7w2ODQoIjgrs//uLtccXpb97+LFNJWV105p6U+KZbzIbGnufuXb88Yt6TX45yskwBIWl6YMiQFKwevpzksm4EGuQqDVqIcSdCV8i5z//Luxu2MGigzhYrl9Ph0IIgvXIhjsegzsmAH4CsA8MItAU4pcgjUEPNkucFHG0USgbpXUuX7Gd+amzvLq+aIo2PDJ2Cn21brpTZ6Byu9OvN5c6lXQHa5xCg/F64uj7J7ABn9HWjx02px/0+C8vXj+04yW3D91ac4qL8825wmsup90unxQdeXdz3+J5NaLa5uSkTTvx+mNpr4C0zpQEvL9NKh4ntUCNJHFV5eWzYq4jpwuX3jnfX1snapg5+CF99cwJ0ckLIBOmMBEouJK5yoJIfAuSZaP/ZT7/29+Qnr7av3JXTz83MpzwshuZjf7M3PnsM/rqoX17B/EcA2CO38Mc/cefoxqwDt7ziVfe+ejI5nMuVz3aCqYVVeRk8zag4rNuV54VHb7au65hQa1o9qLUuO0V216mOO5XrXKyX2r4yr5+57337tBXmW+QeNCIfJi/wth8uEHJ5hh4XP77eInh86ChB+gIfO6GPYPGiCMOXJYKjhTrI2NmXe9xVu53n4uuM9q1vRzH6yR2ECoSgzNS84DhJx8z/0LSu3CJ+RL5MqeZtSiKuWGVMQju4LN3gBavI3fg/dEh7iqvieUO13xREIjPwxSR6+bNSHDtxazngWQv6oZ5XGAm4h+O5mWr1g0SPG0kzv7blwO/Yv4Nw+ej3TD8LSaN9bHf86QjcgFW7SNygScLKir3VczIPXXtkyPHbnzw+IIaUXXLvFpRzfxn3j0ieubq20dFx65Z8bWEaF0ybAuCKCQTc5aQjTx3btu5vjC5vi6FvrpyidOi5d+h7hlO01h5NhF5xOCfKD7xDMNSgFuUKswKTkgZXb8kSsvKsz6PUTW2p8eBiB1Lna0CXWjMQ01Ph8/LSGgiwnLS/YKz1WFLlah5am9kk0+59Ym1p27u1GY2NgDO2xc59emZm4gaotD66U5TQcMKQGwLl4fYoj3sC8iOwRDIYhen5mweMvnxJ/lvO+mTo3SxE/cu37sKCSUXXaeGR8Vm7Oh50q1zabROk+7r4lU/f073rcIgvwCVs2f1woZNGAEgJckrhFhabAVq8fXX6PTX6Jj+/sEP8Yh0kOV1GCFm/SpGJzYZFqaoe//R93RpFv37x932P45OMjVFubkl6CAzYx/OpwBX9DUu7vMMvsjA+/HuZzt3vfl3gIkLuk8sAHJg3sccBskYPEztik4fe39mzdmm2ovHP16wEMZnoouMBV0CaP2KwTFNDrQ/46wP3Cd27eBKhfLPrt1etOC3b3729/Xr0SJUdeMG8xyz+f59Lk8E14rfDWL2DvF3t2+tWHH5c6RH+7/7jmlkrsM47KFrOHwbEU5XUJBsAtIyD+ho5iPkr6AVB+WDt/uxdjIhE26HTBj0pxBj7RlkmUjX3Q3JcO/gPLDZIQZGvMvmynzIlVEKc2k7SmWTZURp4Op07n4jWQGxpqsLaff00k/0khEKtBn9xOoQNIOnqDh68Oj+qir4PJO5+NJLwGNoqBoNDJ0h+TgWF51+Zto0vHuhc5EHfZfsbDQGxfbm00Y699gxwClGmJj2ZvM+ssMLMjgkuSAKzvtSEUHalcI6JNf7h6eJTgg2LFjU9YI2RqOPM+vcphSdcouItMysqa1nnk/NXxERFOgdqMOWZiS59HeUJ2R0BMVYOWKrvYfZuQLUl1guHRgwt9Z0d/+2zmiaY3bTR02lv2Ouzdy2VtSzZXNWhmhidk6GKBNrHPaxtAEkt49YKmRz59aIFd25/1BHVksB/4Rbnja+MUzn9IzTRrfH1ohW79bUFRQAyb6YyPqlWFJfoFhIJPUnumBpKrBfM7ojs/0G5kFNV3ftQv3AgKxcoDcb9Y0mt74e0dodFUg76FEeZdqclSnKzN4kysgCulhSC0gqdYyu/igI2zPJOwxYamRc1X94RfteZodTorbI7YTbxt+/yZ8eEe+2rVu0cu+mDXHxiZbKGlQ4x0Cx9oIW0j8CVWKxBjaxkREBIfyJizMz59eERSt8UubNQzs7Y6trXXuFibGdzEI8V+WQhS4AmbxhHwkykZQ3Fbkjmx/EKCRZ7/DyRP5b8Yp7yUJ5ubl69erqRfqBx1+uSTDNMV26lLWgOMK8Yalo8WMVk5igpStQTYZZaE5LN4tMIKkRGKaBXr3Y2GPFlRjngjKxcUAx3VI0c2ByhBaW+lfRprpa5jmkrdDrmN+TrJmiqPv0fcAuF19pruqTNKAtS0goS6RdB+/RqfHFRmMxjB/611AeGe+MPZXQCNtA4qG8uLsEQQGvtKaSG1/toVUqmjf448wa+h53PyttKkjLxVazAby2RmYc2Hru1GtXtoKIk9+/w3zx5Zd4LKTj1NcwlovmSa/Q3w16sDR4baDdQPK5DM9YYbLOmvjs4V9g/mWJTWHp8wtnD4QEhEa9jF9o1+II4/TpddXML1CCJjw2kvnA+k7ZNOrNaVT2EI26ljkqlEVjOdzrindjbCTmEiD7EIgS9MZGvenPPxw+0rXy8IrcTNHm7EzRY+t3rBR1PbG7U9RNLHsqWLY3a9lgJjKrUauxlXvZQcfIGnUt2LeOGPaL9LkprFHrwn9C0cOGja1wKlihN2uFfPEISCJ7K0RPyqYlcJbI3Gbt8EVEhRtZW5w0mAOkbYbI6g3tpCVcxiIzgbn4I+OAdsVJ2rVpETrO7/gBRnkNfY++AQnAIzpZo67RFnX1jlEXtX3RzXuWHxiaHmVqmbmm5hPPwy6JfgEaXVu9W9V0lX+URCpyn1RcWnkyXi7xkgjc86dWYesFHk10B85d+MHgXG31G3BcZpkA8V9NSxtobDT6KpPcTt/unD+/86bZeRPGlg7WL4l2xehWcHGYC8Pgqf9YVDswKTJuYEDrNrcalTNXYNVRzOC9qbO4uDcJ7hyOwlfefGN+y6k3aFfmRTR18B6MAc3wsmHMyCh8vP98QcWOKeW/OHZqylQY/2uUiH8G76EQ5g+46gW0C+C+4SiMzUbo+sKR61OLXn32zPVZ1cgFob6+fzJfPfUUXgsRrDPmhCOembBCPdM/uNRad4r56sW/oI+Z20gxmINHgiXCeriycViCkxOeQeby5XvovTu3vFDbRgmzfSOb37eiLp4zyeiCw9KQKUxt1JviUJjJIHNHAUiO6zUeSCBXoK79G6QeAq3ZrBV4SNcdSNIIJwjN8A/eNEl7Fi0vD9V2x4WWrWzt4YUb6w3ZEybkGOpNUTRwyR1qpS6zcRyHhtxurt7F1gh7Wf4K8DuYsTkWYTk0Rr0cMzbIggVYjjBHhgfWDQuzASJ+lKnekDNhQrah3hjO62ldWRYa160NLV++CHPxoz5Gf0f9eP3NxPDZEAJWAkHbT1CSEjF3gkawxKksKXLuhDDRx/W10bHVjdGx2JemDD2GxHQt60sVEoPE6kszfff4JlakpVVYluK6Oe0Bu+mkEuItVtAZ9FKIEwFsxRqbIq5Vk1CrEZMgK5TxpAqxQIYki/q2LJgya4XwqEiXKjjIX9qwNz9/Y7fL5mWi9h1u1bOdW2pTvJi/eOXNbHPpRpsW+SJvn1ZicQ/olZDngpASo4ErZijUsQjbmQLMgpR+7CcK2YkZ9uqaYIPbgY4NG/nnBWF5UcKXDzq5FLonO73q1FqduEkczd/rZNKKRCigIzaqpXN1W0xkbHhQTEeI1F8lT65dER+VWi1VBvioKA7BKyG/khMZ2LQQGyT+UZMCa3rfG583Nb59dsvhw4ffO3wYheWi2bdvM4dzDXmnTuUZQFvD2BCy6OARhEAaiPdBtAjtYVrxOsiHltP5MN9wKt5acbJ5GLNt+jBPq5chdS8eLk7EIeJ6UEhju9MR/pLotMWLWmPW1De0OR0WJCSGp7cvbo1e7ROtSZkUHZW4uXaaJVah9PCdVlobHpNbVlc7LSVWCX+XlldHReeW1KFml1ClXKIUaeRKXJCkRHQW2kTfAZuDPyXWupJUoOeAMkut16tD9PobeTpdnp7O0gWrdbocrTYHXnGNInToa14YfYvU0mA1Qx332SQvI4ixFlo8HdoK6LnmlqVVpXMFawSmgikWwUqnxhmbzr+2qe/VcxuevvXFM0c+u7W3tVpUtXBKUXKTsDm1sLTj1R3bz/6S+eKs4XdP9//h0/5nPiWZHFj7efpDkCLQOotk+3KwfVYrk55ImTp/YbjMN0qwhz+/6vL+UF/f4JBsFJCWlpvq4esbnV/cz9yLS5rnq1BogvHekcpBl9Bl2Evj2rsGXJ3CQF4PdHW1L1+eQV5z3uD+QRCh/JE3+orsfqUQ1cIJwvRko6nWqGVGbkMo4OqZUqdhlTw/oypUnxfu5uHn55He39J8uAl5v7l+fU3terTl97koQlw5eXKHAsn/2VQ8tbHp8JbVs2f1rJ01G9fw6TpUS18hOT+4zFhkoOvqSF1ej7rRbvojWGMZ6f1wRVRuJchC/FkTb4CEKDy/qWlXYxN6OykyOjk5OjIppz47t6EhN7se04HMkVbQXaAFD8ceBB/4sX0I5k30j5ee7T16tPfZl5YtA6n4qBQV0L/BWavEaMY1enZNMFdcoOevCQkMCBZ00BX7igrVi1GpeH1otCwwPq8w02TJCa7GluqFClA10AjAa0syV2tx3q42z5bmzz0jXMIP18SoVDHBIYIl/KmTJ5VkBUeWo4INkVmTgv3DknPMOouEHx2UkAGU18I+aR63T4IFXWs83Uz2Sbgj8BT6I3gHd5yTqDlEkTIPRLLGpR11twsm1aHna2bV1v30Af3NoBivAPVHahCdwnHLPKqL8kdbF4UqHFKhbMgkFSSis9VnFqwYVSa8HtdMmcIyob+H2MtDMkGjzQuIS8/8kzbGTzzBXewalh/Dj4mN0WNaUlQKGSnZJUqMpEfSUNLQhkp/iG2ZyGzCq6YC2/gabMMZ80N6kv4BFEeUYQQ5OXm59T299XU9vWjPXMGcGkH90sVzBXXL2ucI6pZiOvZWkIZgWyk0mPGrqqOjvbs7g7w6WAHw4zkR2TDylDYJcZ8xCOAjYdGjMRibQebnae3swd+g0+efOqTV/k+hdQrM87hilqND6PfTcw72Yp+D6bqTmpoLjr0GIMdjKQPETHYAIy0gI6EbCRxursmyQk0Tpl6M6Q5zEa/PyjTmF040hqSGBFWD9GArvCCCOjWsrO7nsTd6WhfGQeMBdqrPWKc6BjiZ047TBv0PraV96DngT3C3VCYFp+pOy6z7XrZxauGZjWau+o0hi3qDggLkCllqUASusC9dsirf1aD04ZXHWCwx0WlpqFUSMjHEX6YM9UyJjVzUOXdGYb5rLFthj4hMSoqMSAItk8o1bzPpwbvb1a7x4tvVr1vrzumm2WrYD3bt+i1z9yF3mw0eyO7uKsP5xuyH3e2OMyDr3TyzQYErInYEpG1PLOhJTtLb09Dp7KnsACreeO9ikyE4zNad4OKUHcGvAguUYrqBn6VTFbp7C+v5OStttO8He3lMnhIUOHnKB7hW78RxOAgcPGDX7z/Mg+ICKX84ttpLjZJIYGWucnE2c5gFibFaLuBiNlYuvwEuYvCoAcNcvGyu3BXy9+H2vo3PzTm5OXU5PUUHs6Q+PlKZtzfH5avsOG1WljaO+YG5Syv9ov39FHI/QBvYOO9dsDEPUm1Fw9V4QDjuWohdUQa9gPny1i0UxYjeSft2WR9Xnt+1i47BJXC2y6AiXQadXZ/N6unY1HKsroMHIj4QrXRwgpH7D45qRby8Re7gGDM833jSoTWxYScdxPlKtkY7EbBE+mjYgSG7LgMSAXyZs7ZeA6Bn0NnacRhxL44V9vc+AOzC7mjMW+3uFZAci0Uuz+72TSxyL9kT0OmGSfA4CgdhVeTE49nLPTpnszVMmB0cqm6x2RtLj77vkMTR2K6QksxNyNY1eKCb/PePgEIwSrA4MAp3MkocRoEW8t8/DXMfHjV0D0a1kFFcPQWx881/n/mMnaZ1sA5AwRu6g3v8MDMe2Lecozt6Rvnv3xwxE6DhOA2QEKyO/pTU4H1JxmXrPAWJFbZ+FFabfzLiXbh0+Twz+D/xM8rLZuk7OlBwHwo4c0L0i9dR8DrSmVrbZ127y+A5xJgmGuUvkK0Pgj4Z5S4YC9cbGfYWgy4OjRIe2ych+vLEK4tRyXtIt2QWrMkkx44JgVv/2G2T0fRhzR5GvwBWM/G/oS8APxFkQ7dkfBYcCiyjmQDkx2Fj47OD9G+ix1qJh83qd6OWZuEI9nYrdGgcGZw4GQ6SvVIAFUOkGInUh4kR7oDht0eKYA/nwYXjSIGoEGo6LacncXsRjVnBHiBaP3vfgeon98/eD68zZu97suap/dX7nqw+QHT3BU9K/wUyGhWlwScIzNYCG9zKFfA0bLlbg+QaqQKR6FGVXDz1kyO9NfnJ2ZUfPN9Xfbew0pP5KapuAjUUkVpYGZhUXrsTBLMUJuVX7wHhJs4GmU3g+8PfM4Uh9yDSFyNdJII/GYfu0b2kDAD1ZFs/CUPhp8FRTaVRtDCSR9PSAoCT/gNaApKXcqgdRe4tFqypDgR1ujFI8jiKBwGhfrBGY/XMRqPFro3GPHBAx6iuGo8e4bVJVwtmIGK7uFxfCztlrrf1CqhiuL/FeXFrF5XrU0KqOrqPei1r11ZbH3Vp2xKnhcs2IkmFUzmuqA7dp+t4PLyn5bN9awx3jdEKe1KVtiIe8mIC/G5TpK+8Jj8zTqvJixrYu2x+d6axYO5qF9eNzksE6Ua0PjYQllIfPfgBHdi2eHYlrS/wFM8rEy5dibN90rG6SzpWoY/Ss8J56Xh9q8Dm08ZxelfoU9j4/Vf8QOXj8ZPDjvKR+H1N+IU/Cj8u9x2P5ZyVa5Z1p6aMx/UPR44kJAzz/YrwNTzSPIOHL7E+dzwRDgRMcvPh1/ItWtVk8Le1gozxpPk8KLCwKDhwcjHZLxKJ7hCJonGl7BF0MdqmxhPK06GSNZ5AnzhYGScTT0NkisB57M/L5MUdV5P/jEC54T4+4T7Vc7Kz52SPIw4t84v284ueOXF2VtZsds14S2hvcp6YVBK5I04O8ii4ZqPcoddoE49u32rJ7pvWimRGVXia8wnBuuYOXUZD2x5mn6im0O2427pPzglKw+OZexE6vUnnVlU1pegFZyKbxbJpQ+wC3JOcXBfPMOHBamWgke3Nqkhv9mF5/uherTXP93bI86PqOkY1cFcvUzjm+R4bFzs0dOe2O1nzfB7Xf71L+q+qh3Zgcf1ivC6sP3YVozqxn4DRDnPgQfRQsfsB3vhc/g5OYBwmuNo0+PwY/V4rj68hQvnaZ1bjs1nGGn7WOJzyseEPnhqDlxPHi60Ca3BmM0Yl+CETvOxgWufGEcChdjy4ZrQg9NC3FEXdJXq124kkDezB5xdw15c9w4CPliZYRxHdw8giUPLjA0Sfr+GxQO33MK6AaBD2IjzrvssgDmUV5TfA6eSXZDxvCB+cKiFakFHeDjowDP+KCURy832Be//rgG1y3Nvg66wMXPf1O8gJwsmZb2wcdmmXrVoeppHYtWa3Kufrc34VrpinzPlFf2/Xoa2zwmKVfsmBpEdLR1vCow3eYk2aT/+v5JsO7Vnt2r5FqkxOY3ysbVtyDoP0jL+CFQ0Zs2s82p3b9ZF3jvLgIzvL9GSb6+Zxs7xLesx+D+syY3tz6DQzx2Ftx2g3ozfZ6GiljPfdftxqj0f9HwCBJHviGA2MfoxetpXu12RPHjBi3zIG6VUsZNIcqBP0MNqH0P+KaCTyIRrhjVoFR/18PmohxlLWZdtaOHGcWVtWUVFj2/J44lxzsOQ3HKbrYL8Mf4xp434QFUUr6G7KGTJMBUWF2OpS+FRxmO0vlD3FbJ5iZk6if/yW/BZl1ISZwTrOdnW9AG9G+BPn+UO/g7kYHmnnIsQ7FzPZueTHZ1qOdM3MzYi3TDzcVZt/ymASHPdJdzqiCDOYNdqcnHkgcVS2NjO/VdS9O2Z6XqYoQPmKYotK8oIkJ5Oc3MY997uQy8vG6rpjrzTceZ+JA8WI7jtdSjyVlQ7ZsUjsdizDtL4D0O6w0WLjwchWvo3S1w77ldHEulmYKobpcV5/FEUeR5HFSciYKEGj6F91gAdzZ5jPCOc+xgzY/v9d9kku6wkAvF2xnQLIAFUMnwSg72MPYD118p3t1In4Pzh1wnvaepZsxLETmD8rzx2Qxwuf07JJNFoPNgEbHaZvJ+o/HbJG9pzQXdrVdk5ogIsG4Gl4r5AzlbhCBWzs6qrAN5SzyGQU8M5rNJ+5e/MmUg/eOf82ejawqqxsZgCqP3mB1PDOnPhNTb2oYSbraXhv0d4kwsTaZTuKEaEan4fX2Nl9KJsXmrvAujvy85faR+xl3Tk5y4nxo172SBox8qIia7wuKFhvtf8rELkR5UHnozUEn1Z0erBYZBEIcy+hM5EFMmlcIadG5sin7XJhusc+6QXaEnoyWgW+VEwqLiPdpWh0qBoOTaQr9y36BlVan3mKRW9929zMfs5bb/c5bzr7uQo9h9zom+zZSbPi9f7N9eg54wMNphUJ15TWaxLF9vrifvScBvGN5ETnE0hKXbI+d7WlvvjgPHKJ9OCeQ9+Q+4QsVSvl3VbqzL8xC5pw+PfwSEkA4vhU1ll5PbBSxRx/IByFhCcZi/nOqCs6NG94KAJPfAM0SM7MmsW2vq24p6VlZ0vLDcRbtXTpKoacmbeOlOAK6nCH13oogr0Dv6BTk9rq6trIC5499RQqQG/hTMva+8TtWEt5uSWttPSpaZ3l5amWcmx3sUP3eEXkWTMJd+5yOMka9Zu1e/rTiHfuORn7bwp3d4a+d3qB/pASAW12F5lAZdnQJpPadbxxty7E1gu3uxBq90yI/VmFcyZ/f5MqYVp969MtjdzzjwvsP0Pp+CFJn4AAn2kNrcVTW5rQzfAcjSY4ZEf9lMn1cyYXNTI7cOF6ZnhIsMPHTdwH4U3WT/BKqNGr1BfskwPkTJb0ZBr3dCKNr6HT1mdc8VWDhB0xTXbCYveMKyJnF2Ska8udXDjQ1dXZ0ZHD9mgR6epK2etsT1fV0bGC6+PiJ/4mwMsBVgo1aOyfpHPJPcOA98an6RuUmlTbiU2SLZ7QIATECNVsP4cGz6bBSFKkSY6t6nnc9YJ7ZZX0gNvuPrdOcbUuXvh6IPPPdQfFliTUnbvyid7VTctz43MXJSYz/7t7ZW482fX+yMPPAAdQYeQ52mDHJ/SG+73c43nDXWZ6/ogObMke0oAdfK6koe0MmYtwfURw0KRgVVhSboIuTUyar2iGfe+ZxIofeZmkFxwPiHoECcY46UDkOTiOPL6OxyA+fohoIw5IcDLyiZY8ieX6gTXGUnrueagRD9NprJ7XbMW5VB5qp7H60opsY+XEnGnGiZVTxUpFiFLp5SmTeXrI5YwXaO0iK1qiOVuuMOmTEuJNcmmWObVCHiyXhch2STw9JFKVZJGDAkE6GUiXABpkpYuiJj+6dHwSlR/ee6e3ji/24F+JyIJxmvE/N5U/k3MCY50f4VNymFWkTefp2Nc86qxCuDoJOxlzkEzNPXXpjFdh9UNWYU9/Ed3BD1KHqVwbXJH3RV5gpimN+dcjrUtzdqJ/RLjyy1nF2tTEDKaZww6eh+t/iR1yQNMVYalrHrII/2jYg5I2HX009CDPpgnM41b0ICoUedAKtN96tikU/QN59PVxp+Lp1+gf8bOjI07FQ44z6ow8/irOzGytiQxTePv771tQjQ/MJ8+bN7AP7ewMr65x6RUG+ITbnZ1HO9nz89ZT6SR7tZ4tx7WAC+Ro+esD3In0we0k1cNPWkA83A6IdyMZu549xYwTLxViUzSSxX5o9vX38/Zuf6Wm+VgzerlKFBcZqRXGRdfXVYkq66qrhFWPcsrn//c5K5pyA+mWW599ljickfm17byP9bDLOpLzgSyVcAfojhrPUhA9liWgAgeMcyvRDvOSsTOz5sckVHHBPcyWCbw3q7KxZIfrCic/A883NSG3ck6YXBEiRwV1Fa7TG5Z5T4tITEqdVOEtlSi9vaRE0lJUaH1OhxxWziBQh48JinHOg2fTTLyfL0aqZAzbsj7kbGdaF+3MaW6IAswpkrMmVJAEFiQ3GRITDCa5bKLZUinDFtSNDUiikmL8yYDnYvoDSo6fJpNwOhzxkLPGLtc5l1fK7+SrDLS/KSWvsqBq5uxKiVwu8cLcLIneZZqElNT8hmkuVXU3lF4yb6wA8jzRj2g76mZRbn4klM+uEmoB5KK4KA7kM4X4hLwUP1uBOshp9WGM2yEcV/OAEz6PMsYxL77j4a4Rx7nImeMfUTXcH0CeuHxo/D43dpQeKx5jTbsB+eUgOUG3YUx0251fA8SAJJUw3pt73oCtlo8Dbk+JDd0BE01pwuxEFeweFIDuuFRiW3gF2mFeMnZm/xW6hcPgTk7Nr1DC2iolUiIrvBRyqyKxR7dnkzvzBME28G8m6+JHajSPGDcujh8rfi48EHQD18XAlaBb8R+gW2VMzndAtxDAXarB867nwC31xgqwPnPV+jPPXFVHhkl9k63PXLn0CrhnrtjYdPa/jk3zayKAcFJz86jYZOXBxib8v3oMoTloqzU6GlAcNbRtG9n7Qm7/DeoePhP8FpLCJpe9Arvf4Su86eTK/wH34hAMeNpjYGRgYPjF4MPAzgACTEDMyAAScwDzGQAkpAGTAAAAAAAAAAAAAAAAABkALgBeAKEA7QEuATwBUQFnAYUBmQGnAbMBxwHWAf4CDgIzAmUCgAKsAt8C8AMqA14DggOfA7EDxAPVBBAEZQR+BKwE1QT2BQsFHgVKBWAFbAWDBZwFqwXGBdwGBQYkBlQGdwasBr0G2wbtBwkHIgc2B0wHXQdsB30HjwebB6gH2QgFCC4IWgiFCKQI2gj5CREJMQlHCVMJgwmhCcYJ8QofCjIKZAqBCp4KsArMCuUK+gsOC0ELTguBC58Lnwu4C+sMLQxPDGMMsAzQDRMNQg1bDZUNog3GDeAOAg4vDjwOVg5qDpAOoQ7FDt4PCg89D4UPwg/hEAAQIxBUEIcQvBDfESYRRBFiEYMRshHFEdgR8BIWEkAScBKgEtATBBNGE4kTohPgFAYULBRVFI0UqBTIFQEVORVxFa0V9hZAFocW0xcaF0sXfRezF/cYChgeGDYYYBidGNMZABksGVwZmRnYGf8aOxpfGoQarRrlGwEbLRtbG2cbkRvUG+UcAhwhHCEcLRw5HEccVRxjHHgcjhyjHLgc1BzpHRcdfR2LHaAdsB3AHc4eAh5DHpUe5B9PH7MgAyAQIEQgXSCDIJQgtiDjIPwhIiFRIWMhnSHQIfUiBSIlIlIiaiKRIsAi0SMMIz8jXiOSI58jrCO5AAB42mNgZGBgYGRwnCR1Wjae3+YrAzfzC6AIw7Hfxm9h9H/e/xIs61gKgVwOBiaQKAB1eA2DeNptk01I1GEQxp+ZN239zHbbr3R3LXX/aLqwih5WIzUWCdmiAvUQYbEQdMigqA4aaJRRHtaDB6+K1iE6eKqrYKeIIIqiiKCgyEsQEYi0Pf+3VUxceHZe3p2Zd+Y3s7ob9iMZfq3QHsdheYFG7YajkwiZToR1DbUCNEoWcapMniCiKTRIK6rkJtrkEBKylP+mH1Avy6jVC/DoFGp0EV69jv06h3rmC+k0ojqPmCSRlB6UqqBJW/iOIKnN8JpZxqyiQh8grb+Z5yttljqKtPEhZqqQlmEck484oG94f4T3j6kSqg0xvvnPPuVvkwjqRfh1Hd36FuXmCyr1JwK6wNquoEJm0cua/9A66kOQ57zkENdext1Cu/ax7wlU6wDCMsHYcdZ/Ge3isHYnv6Y9PMeRMvP05b1eor8bxxh5RGvglduMG2FvJ+ExGZToEMo0A4+so1TmyKEcfbRxLUaNqGXfpaeZZ5rc7pBzJfr0LAKsy2P6yfszc39if0WI8C4hK2i1cziHIrnG93IYV4e53HnkkJEo9mkpooyJmmoEjUOlyKSZc3A57yDznTW67LMF9gWR+17Lfjj/i1o1xYhscN8u7US9tS77rVqwe5HWUfJxOe8gM0Xrsh/4X2T+g+xTtO+p1+Qa3uS+XV1ooPVb9ltF9nZG7gyYy7xive+YO4c91CnKh0FAI0iYJTLsILsONEk7dyREZiHuawiOzHBfXF2FY8aQ2PUMYayhjv+bOmHfVBQP8xX6kv20UGc4P5f9CfhNDwLmIPfQrfE5Ku0+LTIXZ7U5x3solxH4hDssg7Sj9uy3fjH6nS/43S/43eX9EO2YPfvlBvdumbln0LbRy1/f7KBDAAB42mNgZGBgtvwfyJDCcuw/739elnUMQBEU8AsAizoGgXjaY2BhCmXaw8DKwMDUxRTBwMDgDaEZ4xiMGC2BotwczMxMTGxMzEA5dgYk4Ozvq8DYwKCgJMRs+T+QIYWlkOGFAgPDZJAcEzfTaSClwMADAOzcCwwAAAB42mNgYGBiYGBgBmIRIMkIplkYTgBpPQYFIIuPoY5hMcNqhi0M/xkNGYOZjjHdYrqjwKkgoiClIKegpKCmYKBgrGCl4KKwRkno/3+gPgWGBQxLGdYxbAOqD4KrF1aQUJBRUACrN1KwhKn///j/of8H/+//v+9/7//cv7//vvj7/MHuB5serH+w7sHaB6seLHyw4MHsB5MeaN87A3YdCQAA7XY8wHjaxX3LktxYdliONNKoQ+JY8sKyHbIDZjjcRQVYJHumZ7pFLyZZlUVmqFhVyqxii0sk8mYVppBACkBWdc4HOLz3wmH/gfwXXtsLhxThD/DCEVp76Y3P4577ApAPNiUPY7oyE8C95573614MBoPoR/9u8KMB/++fwP/5848GfwDf+PNvDX4yeKo///bgjwfP9Ocfwz2/0p9/Z/BvB+f68+86v/9k8O3g3+vPvzf4R4P/qj9/MfjHg/+hP//+4J8N/pf+/AeDPxn8X/35yfl/+NEf688/Hfyr9/9Ff/7DwU/e/zf9+Y8GP37/NwDVj378BXyL3/9P/flHg3968Vv6828Nfnrxz/Xn3x4cXxzpzz+Gez7oz78z+P6i0J9/1/n9J4Pq4n/rz783+JeXf6k/fzH415cP+vPvD766/M/68x8Mvrn87/rzk//0b65+rD//dPDm7/5Uf/7DwU//Ltef/2jwe3/3m7/+6uXLb6OTcrlUVZoleXS9Wanjt1WyusvuozdlPp+o23WeVK+OX7589frk8n30Wl99jlfdzx9UVWdlEfGtV9MI/tDHu7JJy+IBLxx//cvXy+Relc3iOM9mX8EvX7365tuvZcasjpKoqZK5WibVfVQuQtheTNO7x6RqfpOW0bhIj4PLJ3dVVjdZUkRy313TrP7sxYvU3NfgCuGrXJAnav0AXgtGjc7Koomm5aKBO1Q0KubRTa2q6DxLVVGraHhbKbVURfPkydX5aDgdRZPR8DS6fjeeRqeXJzfvRxfX0clwMjq7OT//GCXw/KOKKkVAwZfmLmmiTbmO7pVaAQLScrWJFmUVLdZVcwcTVWqhKlWk6jh68uT6DrDUD0N0BI9ET833p9HT0c35MIa/+l786FyGeZ62Rnn6jGmRq1tAQmIGn6nmUamCoMV1WHLERI84mr+YvUhCssVR8oIvTJvj6E2VzZVgdl3Mq010lJZ5rtIme1D5Jo6eBs8DODjbDFGmEK5ZVsyz4hZQVQC7pNsAO44IYxZBt+WDqoo6Qjw1qlrWyGdrWD3+4JM6IeqoaK7q7LbA++SeOlLLWTnPFN1QqaxorcEb6umzOGrKW0X0fMyaOxh7Ey3VPEviaFVlRQMjLROAB9Zcx5HCkaqyyNJoXqZrBDxpQLziaL2aw21wSzKfPy8L/FA1j2V1HwNXzSJgigegZk2w4xwlTSlDM7Mtkw1gLErqugQc49QEEi5uVZXzNSC0KB+RNWBd+Oti3awr1UKlEEQtFrzw6Ch5Fj3eaUI8HZ6cjK6uo/PxyegCxGL4djIaoTTExHZHM+CyBZMMkZ3+1TrTSE/SVK2aDoqAgiHuWiHRT7M6xYFOs9usgbV9AL4q8df76OjkNI5OP5wC2nGm1IGqXCleFMC+qlRdw/IddC+yXOGyH++y9K4DAkAAcl2SFWp+HI0Z/nkJCGsAizU8UkaAG4W4g4+Nh7FY7lytq/QuqVEyYKl1jRcei7xMkGjzF4T5GtaUI/hEQhhbdbPp8ZMnr46jmxXgZpVsiDAA/2Kd53EoiAAhDHlbJQVrnASAKZ6r79N8XSP5UB6yIpkBCkQn0BpCJBAXAeRIiCJTNS8TFc0x6iVXUjzM5dkyQ3aDQa/AXpRFQgscI77w8xsAowB08CBFvjmGMSpmzHW1KmtV89g+UgNZi+o7xNwMBXeBdAJO75VjXyrbUBMfxMw+a+SVW1WoCkWQNQhgdZGkQEj4VN6SIUv1RCSEMfJ4slrlWYp4RX4sEgS7NqSV24/3QAovbanAxvUiGm0HULeK0nXdlGBKN9HKGTiTgWcysMEtwQvsgMIHOEM9YZlvhczRIPlY48UaGORnAojGBlaaK5Ev4b05GNkqm61RheFtawbdAzvuINGi1HjSOq6tdfEaaDnkxLJA1qcL8PjCXhEoaFbSaXjBEY0rrfTwmTrJkehJU5cKDMV+DAha8y6bEWv789WCkTiabaJHxOcCEJwsVzALIo4kQqv26+f1XVY1NWIiq+bPV7DqTVQb/LhGQZGWj6Pl+hZNQJEt9SCqSY9Zh9ai58WPgPkUWtG8fDSaC/llXdRr4nQWBGIdxBWskXSV0D1mzQeICl3G6CM+s0iyHAcC6ZYb4WOt1D2PUdea/IjOPEnJw0uieqXSbAGLEiziXWR4PGNjmW2mmIdBe+OCShQguAeWDBgGNVbhTzIj6jLNbkj1e/AcCFxiYqAJOTes0NqSxHMK/shgoCSQdsmaZbIC3wxtiJhnZg6tEth96NYKjhZIK0UmGGChlVSwgnm0qMplh6oHC9wNIyk7QgKgXKQQF7xe3aJDXTueQ6VymhFNHXy1cr0E2QJC8FJYcRUb9wZwTTPyPWAFMornn4At+srjrUQkGjiiXudNUqQb9F2ASk1Wow+XgEJNae3aKOKPRPtcm6CF1hiMIWCOmYI1LxDX9TpFVwotbtZsWIXALCgNKkLneo1ecn1XrnNgj7wujeVF71aPD9q5KoGy+MyC2TNjNVnM1Vy4p0UMQhDfu95q8+7BIWSyPJT5g2K94EkWiCAQPuB4JrYASUbb6F6C0yh1nH5e6kHV9w1FFSXPA0hrFCjHCs0AfMjLjVI168G5WuESAWBxpMuqjtaaAi1vuHZWi6qFOQBnAvw9ZOSRw6eFIkEHuIwzisGMsXbeLQgj+Ay0fCJmmlXATzUyChkkgbkSx6ibxAQg0rdS5EYSAvam9boGLgTe/dme/kbbdojTQTCgNQQmX5aAEF4zjFCQomZowe9vyMvq8PNdhdBr4tk7zRA6jA3ntBbPymq/jb2VHJYzAxRER7g60MngtgO6Z7VqZHz/RvCbgcnO8gQdWnQcxQrZSVjzqu+14aMHbpOlZgLECdG9tiCrih0D4FDkNTIGXYvTFBB12bL52qzpYdT8tXEpAIKynNfWkCc1BdSGWhLewCjg5twlxS2zAVghBeaWuEIp65mh1oKoomLlFr0rH9EpQDoacrkIyUjPFYoXx3GeOz0AXNR66V6M4c2DdF0Xol+RXKTl7JRHC8I8eRE2fHSUKgJovLtcNQ3bxASzDipbsadjpAOJAJggU8n44wnBNuUlcS6HUfCD66/aeDXAQZqhTsHlliJKZiIeH8mjdUPsG3ZBBFnztpiBjP4c3Jtn0chzUmfKdcHEPRUbZNUsxmZG4mDWjQM5zPc3O/3vv3WIQD5DVnvMINKeFJ3gI7wmJpmVD+pZdJQ9i/RI5JlGNVrSNBKnAfQc8KhPcYD0Nlv87TPjzaKMqPncj2QFKDbXR1n2zKqNgGkTZIgluUCJmKWaAjAi4EOmHslUwzjEbfjlCL8h1UikQaEx3+XIE/hJFYCFlD4CmORabJCVjNnuXCguU9YiC9g/LkJwXOenV3/OJCSqdSxbKR3HwOQVKX1yg7Ml5WiAO8CFqNVdmc9jvpKsm7uyyn6DOBerSisNr6J/04CNGwJ8tG4zkswWO3aZPHd6wjp2ABi4ZWwRiKdrkSzOX+EzIDfzzLqgd25KEK9r68TObomjzjD3hkNmDRKVDUOfI3P8ZPZsS2RfRPX4bBIdTUGoyK6NiyVwJd01USvw9QkSyioaaXTUKdl0Hv1kvfiPFCT8CoO/5+RIG3WMXEoLxFQX8wmyIlzHH/ABdMhlOkBPeleUeXlLTuvR34TwRNfODShOVnpX84XRdxT9qu8pWZRvOuJglQBZtePR0njW99CuOOiwr4/bKVKUOOAPzAahF8YhHFnA2JkcQp4EBRaIWWW3d0xc8H05aZWw49eRsGllOdq5kLahbWcsTXK+5mSIb/DoObz3uK2f98MksTcxKWmWkpPhnS4Cu0kcMCWUfMQMATi8CQK2XjE8XevU/kUQWfXHhB1DSGY48JCNgyMJNXQ2FUbx7VqGHkPPsS4cleFI4Z7gU7oefYoFKl9m7vaUX9YOaMQ+Wnkk7PPjVBQAwtPgvAKrQcxwl1RL1l76CQ4yhIZBXIKwYEBcPbC5bWUK2iA5gFQYwWaUNWFEPuiFhGszuhEsxDpn8sMzRcJ56idPfuGyIGqdbvcAmVMyrQkXVfqyzoghkDLKD9P6OKbhTKW9npcplkyAOSNAICWtjp6eDy+ePmN7SolEnEJrUzIJLVpa/HIea+6mTvHpYo2mg/iibDiOqsisg8uG/M+PkN7pji5B4RyrY1a9PIQdkgd7vEPxw8C5M+0cG+Pf//iSVNRd8qB0nrtbO6EBxlJFAWNlS1SQv/xBGgQfQODIGSFd0atFtgYaOlMIpqxAJegkBSeKHaamO1Sm1L81WfCcSWJgzpIuoGJI6Pl6U0OIXvt0twwb5PZZGpI5m3tAPAYsZC1sDPNYIVIKp3IXKh9AEeUvIFqlm+axDuJVt30nVBY4tg7DXQDwZr3O3hyhDrP+al3qTBGoFHYVKbTASqjg0hr2GRpFsKQU51GlNq17Ey3duGsnzIQ7ZoptGFoZtiVuDM0OZFd8vqU4pHPOmLiVRHRMoIlLS7625qey6vS6fVdacnHsTRMta+tQS66Osjx3VFTOVpnmEtIs1of+6AjGfVGiQ59vOCKFeXtX22ltAGWyzo2OXihbxnklN+f19C5J7+OntCq9JLOY2C9ucYjQjVUwDOVDF2tSnhRhMQt98uQbu1jsNiC9cvTqGXgG6f3z9Yq1QVh+YP4Etw28idzJ/hRYzEXxsq5JU4obZq0plVrmG/HFAYsQrDwo5gdObMGsWpR1mc3NgDh6mTQYDId6CcZhjIBncJuhsEldl/6C1eKUbLfTTszveRZgNzk6y1neMBlcMLthvsRSpMMhAZ7Lasc18dBJ7QKmyjyryCVupc64+QFrkCCp67wRO2/DrBZq4HFdigTKfku55aI0KpTuU9+D0NZW9TdIdAjKsSxM4AvB2+xDCoA1EzJzlmK3ixM5wxX/AU+Si06JkWi+pi9lmICi0oWTAYlm4LIkazfLzYX4bTeCplsRJdmAydRahTt+Zf8wpnKhQ+BMvCphuz25jF1trI3kSsiGegxdn+PoomwwIMB8LvObI0YCo9ZBujyEEdNTAvsFAIiph6fR1emZo3+58rrIqrrRKQlskMGU0RLClXJOYGq9xgbW1YQ10yTABuGUUIXl9JcsOi3HoMft7/01CJmchgsTKn1S0IA5awaO0gecWrVFZp67opEgBtbJZM4zrjY2bmQpwlVT58qaE6Q8d548GnrfFOR6ThuuH3WOpQMVeYyHLsR8JZxqsBNWfIlyomB7M6wCDKlcu+J+At0TRTLX4e4BDUm3g6Ku1wkLmp/1IBWqWzXoUg1OhgU6toSJHWRwdYAjH8y7pAIMYFclVH2ybTGtNoxXbHn8CJZ8i5iC+brRUTp6UBh16Uo5oYCZ37frjqPl+c51SzPFOvFFQgb+i60uE7ZiPQlm8azn9qgo9nrdeZGqkSjT8DOpWOq4EmcMHjI5vV2XyUGsV0kqScR7oD98fs2+eUF5a30fi6frcM51ew87S7EeF4uIyYrJWNQ5obhC5xzjgwJspUJPY44dSqsMLRt4dkACEGXKoLIj4vkf4M2r5YpohnEUWW/im3Jdpcg5875iDIhxCRhnjVTOkONwOeKFO8VvcldaMfHYjXatM8iPgLq7Ba1AFR2QiNjTyz630K+GXSRGxh4tJwcIrpSRiFLriv11jxte1QpbjNCT8BHp+ZT78XPLtaQOCHYwj6NLEs1fryECmGcpP4xASMSy8OMRTiiwVAfNNwJ+yCnM7JpXOjMA7M7q8pWhU71ewOIyDguYQTXNKP58SDLOhy78qiJi14pcwRqRAkK82ZTMYH23VbKMjlCeCQQqbKE1k4FIc30ScMZXmG1alCaTLuyLiU1wCZ5xEsgxZyYJI6lA7Air5uja64whtfGh/jE9vSuq/KWuuoqoXGSYRGTM6QN+BDP3JUANCtzrL+s2rT2NXFkBlr4mnrfomqlCLbKuXBkmkV59Zabb3hMsbZJlnlNg1apic8jMjMj8C1S4uLx2LFqfFsGB3ao1Z3XwiuSTAdLkWfTF8Pzq3fDN6Dq6nETno+vr0eTscvL++WR0PrwenUZXk8vTm5Pr6ZMvvoDfo8loOjwf+fdGJ5PR8Hp8eWFuxuunow/jk9H0NZYAvhi9fzM6PR1fvI3GF9HofHRyPbm8GJ+Ym6Lh+Xn0dvge77iZjqbR8OL0hTtIGg4yvTy7/m44Gb1+ModL0+vLCV7Qj01Hkw/49frdKDq7vLg2d0e4Bvz16mZydYkTXZ5F74d/3nkzLHn4YTg+H76BFX8YD+mO8QWs+gLQdTPFh+iByejqfHhCParR9ejk3cXl+eXb8WgKtv1J9iw6p0oqShLqi2G+uktmqpHintvrtbYlJdcGo4uEVS7NEHVaJatZWd4TNblbDFtE8Cu65zSs1HSw5RkEFp203MCBbT214T/Xj5CpYBrOzLmFeTCV6xlm64BDlyvsPs3U83TdODfUIPpplju/gPfXlLCIBXYFcEF4fqfIamBi5h6DXUGJ2wFgu5Cl+q69MlZ+G6n8LTr7n7bVKbrcMKoOUXoGh8ZEBNUI9fMGwDTBNiKDZTUHEmOFdGSLSm6XKOVtvKBEcjd+RasV7nhFKh1Z+2W0WlIsIPw5FjRNC6OkHzmo4UVJlmivPorFjvRmX85sKDkLBFXXtWRKur/LtelxGKiHtDI+w95VskgHh+SjoD9Wmegy1NRIOSCd50VRSgjQPkvcRlvMy3ENkcwrfu3u7HJoJK2ngC27IQOThCnhSjJN4subbvx5laApMNrfQhN2qVDrTF7elppUMaeXQPaS9D651cwD96zKTKf2kly3kZHtTxaNqvYqPI4xfKFiQKlNTPs2JwPVl8tN2KP4VXtfDS1qWZJNNC7HXt2mfWldaQ+ldo3tHXP9Dapgy392rIUbHh7ZtM0pd9KK7q7dWnR3azWXKp4jR4IEAGuu8kQ6E4OUEI2Ngo09LX6NiPFy5rV16IYK2ynsdgeTQLZbgG2/Q3SflTUwnm7CMi3CIPdViT01G84CkYOyTNI7Uja3GBXjCjSbwfdZ7j2fVcDvK73Bg7Sr0nVybLtgf0fqsVpC/XSRVuHb1XbmdcI6BKjd5DpXOcVeOIPjmNliAavPFn6/QNKQK/fz410+XG0LZk4uzvQnw89Biet4a0cECQH1EmD++VaZNmChPoI521CzIKFKFxURlQq7MfPo5OrGMI+4vLJjieRGJNc1Qm4SUHFrAvUcYoarxOBAt6ZX7oqPzX4P6Rc2fVVao8w7Y9ctmgBl7ut9y3gCMiLereTZW7ycSkXCnivaQVNTxyJtbaNImUNSclBEYTtVnZ7KP+WNMW5dkBuTM351abpL1wAjaqeG+oiocYmakIMkLPd3KTO4Ujoskl6fCtt+gpYcBGB7f4+v9kyDF21Gkvzt9rytG4E5t9ZNWVkZXSpg4w1bk7ukmnMLKGkGpO8v2kIFd2BHQN3XUk/Z/5X2orEFFVwlZMl80xVBoqvjNZgTh4DnqADRR9++fBbNk03tBF5zleMOgE1fQUSnDROBcxOleZItHZunMm3jm3VVdCcoaP+CSDGJBTtntL1sxnvDMJ8e9M+YOgTxFtrw2jRklhX326e6exkMDDqD1qKRh8g/CofpcXvC/ErdAsEQJ9yRhiPXWb+3iP3SpEOkIRUC0aUXkdttfnOqlgblmdZuUGLLkD90i83oL68gAp2ef4xOx9OT8+H4/ZRCRwjXJsOLa4i5YrkHY8Fo/P7qfDw6hYEvTs5vMHaMozc31xRDn4/fjzHCvb6MObLje52xKDgcTU7ewdfhm/H5+PojjXo2vr7AGTCYHEZXw8n1+OTmfDiRqBLY+/I9PjgenkfXH69G0ekljIaT6sFhwuE1zXp5NZpw8AyTtePV78awujej6OaCAs/JzRWCDPPC58vJ87PJaBRHFNPq8fzHx1MY4frdJSz5dHQGYfcUrM/F6WgCwEQn48nJzfvp9fACQuxo+g4RGQIOU5+PKQC+vow+Xt7gXMOLj9ElzDWhpX+Mo+/ejegrhOUnMP1keELZBIjJr6Mjg/noYvT2fPx2BLM9w8s0xHfjKSzgTI86vRrh1DEOMx39xQ0E1PT1Esc+GZ/CdwDsdPh++BYpbYc+v5xeY/YBKAO/T4cY/VMW4g2G6Ugrgz5E9RC4A1MZN+fXgvab6aibAqMPo4tofIbUG58hf8Aqh6cfEGn4wPTm5F0ERJ+OmUH6OsJImlDV05YsSZyyDna6kfIsmWU52gPT2LSxGbOgm8e47RBiplayfAE1csa7JYoyyDLx4KEQfknhT7vrysLHeWXa9ofNrJlx7iq1WBduLJyWdXfAZLwHKtXb/srOe/UMJk43SEmaDjiD+A+tzi+PNdeeD7+LnhOL3QCvA5tcnAPZppjv9pPFetdtglbCLbax3bZeNudZpH+dlG+N2U92mtB7Rl8QNzQm6IOicwyuO7qG2pxkemtN+1fePeNummEDwJvlarBw6FCi7ATq66MRsWgyfvvumpN0cP3NR0LAmNcdjc5QLYw/2NQYaJoRPE5m8nT40Q4Immp8eXqMN4FcoGyAEnG15QSRejpGESPdiWD9+RgU5vAMhG/Pwb2EtLsdb0bVxVYpGLmgC3GVcftmrg0ygSb52FgvQJfgZ9olIJ9fN4KETqT2TDp2F86UPh7AVkzdOigVQPHLhXqEkTHKvzmeHg+PY0NezPFuZAckZmdq3g1OLhXVNjCTU+pYFq21k5Dh7ghOA+uYi/aNNbTnfAFeLokUgUQ+QC1FFTHZvbcsnDScKxshhsAjIxdA6yXpu3cfMYFZo9vBooWa096hFFRjY5o3u7A1Hca2iYY2a3KmRi1QfSCxeVMgYkCmoZhXz+vDUUUPqlhrGLSrb0aXAj88BYig5kOMtpIs9zR7D3MoN1sf1MEvdAr/BCuXhc1KCcGl2DP26txTzNnAfW8p9+Pl3kgbzSkH+epbXUJOsUcrV/Nba3a4kRKCZG5EoKiEMo1dXTb0EEXSUkQwgbTXyeTvBKg7Qw4GKcCw7hnR3Ri6/yMsJxKPuKagfZZIX5VRG4c18qCaUxWFYqtVWbMu5k0LiY2Cyoov6ORkHJyBgSHqujAFGFLEhBvmdeD8X6PAYVen7qwNtmNelNFDgkUYt0ol8XhAAp0nmme0P4/2IuCNFP2gGkNHPVVU7tPiksxqPONF93eGiVZqkDQ9SWSXqIfXhnDmVvOo3gutEU+KE5VNN8SUo9MoZq3RsSrcOaQgYKpYPyYs8ZzxWa4UaXpPRJnBsuIhyTMIyR/KjGrF68JBQKydjaUuCfhqq1NPo3LNUPL1QRcRDca8R+uMTVOOnttZllH12lPprIDqiM0+RfzOg9d64Mbh69Y0uBP6ZTs8dndyUMKHB+M+GrQPS11O192QKJKt43lq6ZjGbmnParBM8Iah1OzIfsXtTCEWkzWeDtHo1Kp03im/+Z5iWmZmvyGw0l1+WjLxcc2arDUi3FwKdAE8snlrVUfMcz0Nf/E+2HO7IVjOu/YTcAYHaw8NZUHBPoY4oUIFZtNnuhU1k35dFCzZHqEZv3CRUWL8zZLWzjt/9ZXbE8TygLYd9zlKZwApz8ypm8Na0ILHeFVhepM6rPCsHdwxF2ou02+KR0usysqWlExGCzEre502Xjo+3HR/7my6Z1+IsLOuuTmUEZm4l8TTiX3DskiWEF8kiCKKmcCOL2Qj0VxnbJh6tm+tWudKKHdLkVSXpu4ucujda3XYlZdwY5uuz2BhDaiCnQxZgbmWTDbdocN5q8VrUUoCyDkGQecvqa3zIUsi9RydCd7Y350BJQ5raRY1q7OG882YQ8K2wiZ6fHw8bo/w5MnDy29ffvPq695zzF7o5esj1PAktsFfD74avIR/3w6iwcmgHCzhnxpUg3SQDZJBDr9eDzaDFfx2PHgLvyfw+Q6u3cOVN3B/PpgPJnD1drCGzwnc8QruxBFfDV7DiJeD93Dn6+DZ5+bZvt8/EBQ1/FoOChjBHfVqMIVf+Jv99Q7ubABuvP/BPHE8+HrwS7i6hFnuYUy8ZwG/5jDyDNbO93wFd38DOPi6tcYMYIjglwiewytzGGNJ68SrJYy1C28vANoUxnukp5rBbwjGaDAGOFOYe/vTJ/BkRVA0dA1xEY53B/9t4O4/g7le0OjheI2hIV8NnwjnqIMZ5LntsEaDM8J+QzAibho9Bl4bwZU5/L2B0fH5aHAOI6TwuaBfosEQuAjvVTQDjvME/l3BfSO4NoX/RsBr+PmUZn0HOEROOAUuO4Fx38O1C/gdKTKkO8/g13P495FoyPM/0lw4j8UUX2lgzQlBv4Era/h7T9CsNAfg/Su4FsHKSlrBAu6q6DleEY66oM+KqIsYj2gV18RR9SfiIRoc6VmiwdOO60/p9xGtdjiI9Xd/XPm1+2lez9M9YHk6eObJRU7Sz5yQdEA+g08NYV0R9wpuhR5d0hE78oGf58ClM/h/slPaYhr5hffEFMY9Jn2FXD6ndfk8uyZYKqLtEUGQ07pSkogH+JTDtZgwtH1+xo6sbWa4TBl8zeAZvIr/vdVcVWjtkn4yxo4JBuGxLg66hbseCOqC7hF+aui3Jf3G+mytaS93bJPqxJEdRZRSpLVvCXIeLxwHZ0LIZvAd8aCcEXDUjJ7dRYd+qJAGMY1YAhzKkc9HGAW/MdxI7SXNjlTEJ1bEIQXhZE5XE40fpnNNdykDU0UwoMTgykv4uzYYTwhmvB4TTldwB49Way6dw7/ndIf8UtEqSrIusdZVM/jLmuJBy2bt4F3WUTqrDKF2NRte22gew6dr+FdqPpZVWywJ5Va00jmsgjm0gG+PRmswveRe1IkN6UW1B1eGEoL6c+FRHDkhIal6pBlciUBtdgL/RmAlrkmTjunbhbYWQ7DnaAdGxjbEjrY7gtlZly08KRPOTgd/Bb9kAafj7ylZhWZPGWEPxuqulZH0U8JMaiA6JcnJiHuQbh+0virNvfcE9wl8i+m3D/B/5nZZU9qDq5L0k0upVENTEe5rTf1u7l7A35yeYmo/ElVTj0u24YA5QHRdQqPgfMek6V38z2m1BXE082KtZykJukLzdqQltdQQ9PFY3BpzRdyZkkzUxmakWrZq88QjPJHD38RIGloVy/O1plNusG+lkOFWB2nTY/IUXhFObgBK5psVSayVGMb/gvztnGDd5ZU9Eu1ysgEVraPx+J0xU4AuUoPvYYScYBbpE/uA8yYgMcwFoZ9g6bCLE6wuYpyLRBRkCWqPmuLRHBt/qc+m9PMcevpLkimxMwjplY4vSlqVpeDY8Jf8/kZjo9Dc4UJSkD061nBUnsZEHkMa1npVFu5tnLrdrkUkC8JzM2NxF0aeWKcfbo+32cp9cG31Qexpn7XRK7f0iyIObBxKM08wry6IJ5S23hvC360TkaXBiqwljI0ex3tXRPXU8KvoR6SpYLvukNpw9OPPxCku1XB+juMO52iJO1h2K9Koa9JDpY5KN8R73RBnLYhnLYjbfGvxy9pBLB/zmfgTXZpvZTRHY6TP9fHiADOiny2GLNysleaeJk079d5cR7IVRfhr44XJaGsP6/3YjveUooUjRTyD78ft4+vKc+zLiU4siS6F42dU5AssHE7wnwlxYddq/TR5ottqXAWensxT03WR9ITWW8J3jig+pwZkX/OOqGe19rb11S0eiYm3NwSt8OdCc3BCuOW1CMdZG+F77ddgE2uCpaIVxwb+inz3lab1hjDU5p++SEE5vnxMHL8GXEgUUBA0PiSKclvHnh9at/z5MB/B61MmFs3Jq2n7XKJf1qT11o5Ody2C1TrCV0xH61eF8h57Ph9z1K4sYzT4aOZZkKeYG4jYdocj8q81cdK9B0ftZBB97szpaZvDS2iEFVErI3uadvCijGUjnv7IpkuzzYwHzXqYfW+hUGkskNJxKcP1SFh40FTgu8I1il/mazeR9Xudc7DYtZqY5cRmblwPbR+b5K4z5D8bYYhNsL4L4nNJ1przZhKHhNGzqzl8L8HNPhziK3T7AinNnzjysvFoUmkazGmdFa1sP6+eY+BD8Gg9O8sJzOWhLRQKY37h1mSo656cQ0U6wK5Rorpaa962vV5qu7XQ/pSliutxFTor0zUCZ00zJ+/BNAhh6c+fcFz01Ra9lbRsdKqhXFP2OyGsbUzehWWpIa6UPFyiPdTUobsfKcqdVu7zIApaBD6Gy0OsOZCyTOeF4euarK1kpSTGzYirXS+E15KZ/E5kMtdrk0uuqQ6yphpKpHNWZUfMK7lbH372nSuiWGVyQnZdDEnmeZMFYX7e0j27JcNykDvu+gfEefc6Q+hKywNlER8c7bjdZkU6G6zMivt0vCvZISZtpN32ey0+2566rH5O3pULKfoujVOrKL31zPSqlfYcKxMNKO3vlPBNGU9MKDgnzStUZAyHGemSYIxMrHC7d2647qGteC2uDpA1Mf89UOZLZuPfFjpKyRx8tTOjUplpx3b9owgeOc9gqW8lM6UVsH6qjUaxEVKI56qVMTpEii0GRX7xu81Gzh1sfW65XpOvf2vyUT/7zPmNfeKOMNNh8SCxIWvyJdHwNqAzw1A4HrWLW873N04ua798fp+HcHgU7+ZOM4M7qRvOHbr0x7J+vs3NreSaOjPNBZgTFtqVOk5Zao8D76rJAw3h3zbiM625C1pnTpx35/hn7VioayWuz4u6zY/47Ay3RGdfEwifWHmvO7GsnJyjMjpU9JqNDBZ7Z/KrnqzAfjUtP1rzocEnXndkKQpdu8Nx686IPDG1xe4oOazeZFpffa/1RkHUdnMKrFc5urW6Qjk4KAMvvyBMzE1+Tzy3aPCOYk7JFMTGWwulq49DMsefK0xlqNRVCFvP61t9oy1xHVC9v47Rvx6RV/QQQv9VpMv6cl2rPDJY9nMRXdXHbk81NnXkMHeXkyQ3XpyYmF4H5MGVl9Np2w6RBOYJG1W6/OeukOOmXHMDw+dWoxItod351a766nY+SDVNClMh8/Vg34pc+EV6fL8h3hqxhxxhY/N9rBnb0Z/r7M0zqmv0Z1JnTsU1zIKF2dMwDuryZqVu1rZxvNZND85pfdGf/PD8d/QveiTB5hkyx1K37wxtexLUU3flMBPNV2GdZKY7Ip4RNBn99WGyOdNIe32NtqlhpoH9uVtdr+6XccYpytYC8PKsIzcrdkRRf8C2mmyIKTe6xvVkphLsexvbNW1iNMTSyQIlrWipdipgVgIfyPY9OlE1w2N1m1w5MtdE1qyVnutsm9V3udET8huu+U774fbXUndASNZiY7RSO9ren6JCzZAuIQX+PupFgp2+zM/h/uesVSWqg7ps5WXHl2bllePp22xwpmVw7kQWnIWoKdvBHZ2x90xCfHdHuMkGvzF8Hsaqlqa7npX8TaPjuKHGn6V3G6ZwbXFPvGxz7rdOxrCdsWOMcbbMjRGsnq5bNsvtv5J52N7MnZxz3aJwV85ZnvdjJzezWxpYZ6bvTaDMtIxXNGcVZBn25zC0d9xZ8yk1+4LgH8NdE9ISU22pbLyGkrTUutKONSF7muvcsODE9iq2bWO3d2rjdBf2E/i+GPwfp5LwK1P5e+5kpNvesehSS0Hp6nL1SWbi2Mq5Y2FWV3WujrkHubsgji7JsojcHIGl2YUfzGB1jmCsU5ftxbzyosO/s7VftHy2syh3NM72erAi+O5aGY/dPl5X3sPPirMf9jXRfXcXaWakfO30BkkuzK3C2Rgw7lk5V3kSY2FZMit67s6TXM77up1WiZfx26/DZncvxz59IftEtPv0WLY752uvM2RbhGfnk3GP9/KfPydPWu1tNan1WUqvM3z/LIKbTXIrTInT+Sg9BJzhTQzG1qY77DB6+vmL7TWrT6kT7gdF2DO8PYfczuCEHWqS2VSmFr/PvgwfDn8da/LRuryMblv4ebFvu+slT7Ewnq/y4qLdq/xSZ6baWLPax/c8Ei/PL6uyFcBC+4TcndKYOsMdfVp6vpc/h1vJCOVwe71E8CIV4spUYln+dvcU7IOlboxUpgabOb0mLkc+BBTZRbe238gxxFrnk4RCPE9Bv9l+arRhv+jVguLrHJI9EM0Z9rQm3k6VQ3udhYdynT2U/mFLP7dOc+PlO9vP5xRpyS4T1pyR5kDbaXVEO1iGgwu9D8PGp7YjUVbh+6Y2Stgtl1386/ZjzXu7TmXugug9M5m6hb6j8epRlROtc5atNrGOncX6O4fULtnDOSaeir1oxELRBaUL2SNpR7Z+UnHev9s57oj8P2X2peNFoVw9mO791MTV+/tOibFQG80/SntlS+NB/vL/ow8iMwjmbGbE+hWH+yKfXtHwewo5KiuMJ9jdKTihTJzNMDUHVZVt139XlJVo7R12YkifpX1CPIbEmb+GVdS6il5vlfcuDbu9b9+1DYmO+RqvCi0VFhtbdNVhHsmmNLoXoHvP3S7Ph7nI9l9wbdWONHc6MR/Mnrn943fLlYWB26+G92FARvbpeXgfoV/NwjiyDHqK2Etxs4q2aiF7QkO+7IrYZyZSTLUPJPU8u6c27cjffJqd6eO7fTrMQt0xc/IccyeWceOSvjq0m4Hct37+aTuH/D5n6bgNO6JjB2thltbmtX39VLY0x7Zc97asdNgX5+amldNl2JWhDvvqbC/PnbNTOdM9dK4usT5LVx76Y4/FuNe798S72ng10qXOAh5K2/1jm0brGp+em6D2YnvL3H6lvj6vp/RkSrsmnzq08qnUpky8deeWW0U4hFc5YijN/ql99nVIP6ngpU1R9Dy+6aSsnG1g/ZWjwSvyf2caK88pY+D6Brt2P7j6k7NtnJvIe3p/CrMzV6xXV9akMb1MNhvWFZvaXS1znXVw8+LMi1xZeXB6rTZBxxav1bfK/m62vh6Qbn/Z+mAMnfhLDI/LI6WOJTNj2cL9uvY7x1pul+whmXar+ftzFrW2S1Zz5Z59k87gwtNu0l8Sd2a198mQVNo7r3uyJv3caU8XaO9lnmn7xFTe3XXmnvyQmbyEMr3BYTzfVc3azTU8u78rkmX2W6dvuWj5rSXFDzIeygJb2rrT62+MpCfaKt9qm/Qbr9t6c5C3YT0A12cSzZyRNPLZLt01Z35m2wz9Nrk4wMaEtfnauVLu7IDKnJ3DXT0g3FHDvLXu7eV2d8R/6ogrXc1JHM/TRmDhqn0vvDtf+SnQtPdc1AGOw1xVqO0+ry5zs9qyb4Q7mnxpE39Msj4oXRckU1IhkP5cV791W6MQj74f5O8ekhrTUwfbLzQGpevhKdX/T2GV3f5v7e0bzCiT0QRdEnKCTGV2YCitZecONn1/zY1g+3zC2pOT7bxh+dRylexOf+lZnd0Zg8Oy/Yffu73K1H3CRbuq9A9XaZA+axdztvvA7Vrt2snsrrtyYGq0BnW7Dtx+RrQJXfVG1xYJre2ZK2uvg9RdN9qDxw75viH9LXBMdcwtFen94fIrKuFspbfHMYy+Eq+roWuFlfeU7RNV+ldlekjs7tqVdz5BEpyhUB2U3Wt05lKsOXvUNeHbtWjbej2sF+qfqmGfqnUmowvTcafExD2c4e4dcGs+0u+StjDDvKu011AGu7kPOQ3jlRfzbKvB2rxF7FTma8fH83NQUuvy95RbLnA1/7Z4vTuj1Z93rvfwmeKg48taMs6/dO1dtrwVByuRXryunNsjaSSpe70+4Em7N1LsNN9tvVh7xlWYGeOZ2n16P/Rpm0Gs9Tk7YSfivZZ//v21lzcvnH5rf7zay1x0Zzjnwek9bmYpDuCVnYgJ+f+xZ9Nzh4srkzmvzV6hW90zKDmNuTlDaaWrbLHJ2SX6ZJ+lcxKGnxHpz38kWmMtzVlHpVOPsrG31Tel7s0RnTM/eGdMpn2dtc4CWx+phBWIjhPqhLnw7p3fNruyu0487q3tdmUG3VnYu7vVvoLdo8M2It7iL2/TLfbetnYJ68ip2dnT1QdYaT0f2ogy8Cv+PvyevupVrb0NNyexjSP785SfUz/vzlraMyDcDCbyz6VjNX9N0oCwzwkqd2bBRFhjWWytj7gdCq6t3n7yTYj9XTrF1ey+Xtm/B8DNzvq7r9ryVFNvJVMu86oFrgb15czWPx/0GRHWQ15s3asovNtl5QrPR7QVwpnpXQjXyvTj7pWlPlNurfVVEfQG2NgshMj6XP9wmGvnFWZbzoWxMm2j9FD7SscmZwmeeZ1A3dFZuxMm7AqUM8IqspWFti1u1GZP4xP/p31O78rZ85f2eleRs7uorUlCO9Z9HvCjjua+1LhOdN9AXy/0IVHrYSdyZdRBUWnPXPR8F3fN9F7Phdap++h26UR6pc9luAm6pT/9nODwNEk+A7R09pTs2ovtVpldjejqX5aFC9DX1z0x2qG+iEDct9fa7dWRZ8L+ZMYp7xH7AmTnfHA1eAd/3wxGBOcl9cSf07dr+O8EMIm/vR88p3MusfcJfz+lPNQErp0CZU7gtymM+wX8O9Nj4N1TmmG0dVykJZ+5fA2+0SVgrD2yPH8K933QJ3BOwbOWXQBf0PmbbwiuU7h+MXhLntYFddHgrDjOhEbHp9sjRQTpOfx9C5/emzFu6JzPKV2/gKde9EKS7oRkCs+eARzf6bOj8am5fmoKv+PI8oQ/25Qw9sFcxZOpR8Tll/o86nDsyNBB7r2CtUzgv5dmRZeURXwPT/z5ASMzlYcAzRCeOifeYRojfENnjDGNgJBfaO5CbMpMdoYJna56Tietjpwztq+Jbu9Ihs7h/2/hWYSc4/YnevfZubMnVWyS+BdoG1ZkAWZ6D/pVa3d317le685dSn1xsGSRZC+XryFq8gNQZme0R/TekU33bDE5RUSuSvbcQhvu05FTntnCSiYt78CHnNZTd+i/vnxEuKpS58Jsz1zfjnmOKnE3/8ycctHoXYq1iRwVaJRUY7prhFpb/ZR8r+57Gh1BlpoSC3NWQOx55Xc61/egfSy20vemshtySd8ZAF1nIYd73/1cmev5bVp7/hYHnP/0qfsp9s2G2b1DtntGoJaOCLuP0J+/jcFU+7oz02Hi4ol7iliGM71fuWunUt9Zorbfpr9SEvbdbNujtbu607+Tyq9Zb9uNVre6WNjy52aHZvsUxrD70a3UuJQKe4k+33kUix/YvXlon9mw1WchWPX3a4WrtOPvm7U5LMNgzyGtOvIMn38vWRRUDm0eRfJjVUftcpdPLTLHUtefi7JdQsztM9P32uZ66Zdz9yHa6FWuHnJmV7cchaeeZroPt/2GDOkkTB2+Cnuawrx8+2z8OdHi0Zz0E1r2LtzsOkvFnjrDOyHLQKpir3sp1xhEW5XoDMptUOfAWDkLuvYS76xGfx99QthWHfmLT9/xODbVF7szoAyimH1G6+6BOrQvN/FyFL/a6301llJL+qt6sxyf72zTQ7t1w9ND7ekaP+SMuU85QZXj8p/pXQph582os9vm1DuTNvS769590YecWu3uqnhudCTbANaavD85PDNxe5eQcroY2GLXJpvav4/I5ZezLad1+CdUdJ0p3Hd2sLWQ+5wC3HW+A5/bWtJbH+LWSVjtU4TZ3lekcZi3Nl4vkM2gLHX/nPVsbk2tWGjgazO+PtPeUPf8me5aEUmwO9ms76qC/eTKnFn5GMzYF/ls6y7yvfAf4m1nW86E7ZaAurdz3d3LGcYX3ZALnBlld2NdV1psPV8g0X3fLP0/32PX476navo7zLr74trnJystOdt2cX3qex0KzxLYcwmk//mWPPTwRJdQ9gWbM+O9J14E7+9UFK5U5mzMnDCMmZu25gmzvOE7lqy9CW1uXyTU1wmovFMT7DmH0sNVmspBFuwu7KPxccf7PcLzhdvnVfk+yvyAuuun+QRi577+7LvxQiwLx/ftyesapb9PpXIse06Uk3fQ1M4Zi/atbbam7FZJY2f/iu9hd+/VOWzPv+03lnrrwsnG5B7/+rum9/VrWCP6mRp7HpE9ccmehLy9E9Y9v0t1QK68XaGrYI+3pVa985ScxFS0Pv38nm3eXvsEL/tmpLD/9of02/bVwLpHrfU5wF12dKn3u1SOV5SYEwHm3img1mcQ+f3FXpaKx5AzAuqDT6m3vf+rIBctp6A2euzM8dz3q0FKVqf/BHOrQwrtczX6XYPfDl4SjeckcXVPxYt7rOQdAJuDd4j43YZJC58bfY5jQh5Kd5yn9HptHM+nEhQHdVDY9y+EtthaCzdzZt9eNvPeGyb96dvPn2nvh7B6S+LwuuOEzFL3RklfRRqcvcwRjGQG4853UtyZXgh7Z6jDfHgPq+ZX+r2blSO77hlpAnPtvblify9Lzpe2fkh4QipXRJdbauRdb/ObO3tLt++e2f1uUKstd+kP/xSb0eAvqYqJ9aqpfj/sKb1N9oQqXePBe11V5KojV9cmVPe71nWuuDWO1AUjev6K3kY40m/qw7oajn1j6o4xnQB4Q7U0qUOf05NjU8PFqmPs1ezccbvhspVDrO2dUP0Yr2IlcEzPXtN6BdYz+uXCrEEqk0Oqx+H411RJ5TexTVq1Stbe+J5nmXFMeItoniuCG9/Qy7DJSn3IeYVD84lr0lc0nlt55pXtU1/9jtZ6TjgeUZRx4VQ8J/D9ymCZ18u/4+fndPYcvjUyNlfb8G2bnd9L/B1h9h1cZSqf0huJR7pqfqyhOqWZGTMRYW+i32Y8Japd6Co2zvPOcOQujPOqz+mKVICvaYaPBE9kqHxB3HCp1zVxqP6R1v8d/W6vcrX8RK9+QnXhawdPl/Qs2rY2z0fEZ28JrrdUSca1PTNPWyi+IxwyBc4CWKe0Rll1bKDB+/8CZhtpaZCrlwZufOZUX2eMnVI/wZCgmfZIakT17SmtinsfWGb4/ilV2/lO2wvxxlTTRa7a3CdcPdS6Q7oyUNKuW9x+o99pur8MYA/EiGYY0zMse2OCfqT1FM9/Sv0CTA2ZYUr9He9ozZe0hrGnQQ49I8zaJvHq7Vuywo7T2POlu85GyknHz8irk/igfWLTprPHbPvZPO1s+0pXK7ps1jYL2rZn7rslCr1rob+XyYV8lyX80qn+7HPWVRf+3H5l+7Y/OZk168jc8W61tXdWhu8BpJS/bA7yPMLcg91V33V+5f7j+mto19PbnJLskW//0uuv667/SazzS90jbLUp2tTv4O9zR4vdaL3O2uSC/JNjvSLO0W7rLPbfdZuYWKJvZ5sbb3flst1+lvD89dg5G116P91Mk+SeJS8ob2hMTB5UMsdL3acnvXdudJIFb63Z51733TN9b5pxIwD3zXK1juEqswuM7c527+tjhxWLqGfsLXy79jrp+Pk39IxwwNijd0S+gngLY9Lk7a6xC21heHYbTaJV+9gJIftUY+rfOzYjTfTbsid61MstvuXEcOopWYKx5lqxG4It7lo7pV/OtOX7vJD3d0j3vR1v5uxd3L0rWHTBvhxXdWT7Zr1xULuiafPYjXnnJGcJfhZkCWye3z8RZFcm0s+Z7Pfuwpl5A8SD3u/Utce0bz+o3QEqVy50/89Hp5Z/A6tAj3ioT6MLpVf6eDetd0BK70ztvRvcZqnsvo25OTPOr8tKbN3dIeOeHeF2A/t1Lvu+scZ5z/lC53Ibp1YoWLJ5gLq1UyWMsg8fZdHTDddnN3bxEOfIlk7OxfWXwvPu+2ZpV8ya4HQwPgNt7rx3KNVeY9Nx8ua+vIUeetx5Eo19s6bbU8M78AvnDciV96bA0uzw8Fdj67z+erfho6J3Jiiqk/l48LP6bdjDHfw8F3OEPflwZk4IQk+v32c/THOo3t767fvBL4Iu/BOz57Lo7JUKJTzc2TPesp97avpseLy3Tt9Pf9+b9Y3mTh/kK32Ki92FnJpztHK677Yz2nFPpORKsnsigq2V2J7Gfc+ysTPZmnS4E6Fdke4/k2nbOwHqA6ocLpa287B/zoh/NoZ//seu3YlWj/RFBV1nJM702bHSgXLoXkY/clgbPahMhdSecca7QUrtcfrna5QBbsKTddwn/M7JuOMUjLL19t0lUbS9A8Z6xJZvSo97UOf/2li4pdkPXO1Vy5LO3Yh26MlOmL69VGF9fLsU+P1Ec90noUxt1R/R1n5mZr8ja5KUZHLmnbdveWamT8ZJgzcq7+5otSdIts9JsvGSPYe3qwrXHrU9q/9eaJ/jrccpns0hOLZ9dD4Xu77GfrTKzNuXUn2KlPKqqa6Nd3t8liRR1qfvt6KuBuO9GgnZJa6SP+h+KPtmvaKHA+Igs7EMdgls87b296fFc82MzZd3wq7NW7RLs4ve6j1Lz7jjpBx/3d3Uanv1fk5l/z2gfo2tay6r313I6wDipkdf716NvBP65V7V4753ctgOn9qjvT2PRuKHZbA73T8bUqxkmLlq80LdOmNazpbujzVcO+G+YSjteEf2K+90pl28yCf4laaG53athmfeqa0n39s6beWddNB/QmAVnOXn20yZ3deac6+WKW8uZXlp9DuebPS2e+9Ie77DTviLPxvv9Z0NUXo19/3eT+D24Mi+h8bpBeX4cRef2B0V0ps+C05FzVrn64rFCt8e4Wv8opczSlP/dm3aPv3OX+l9yB93eLgSt8v7HMMzA6znmfXsN8/1Pj6OwWPzrDLdm/YMK87X1uYdc7t8rvb5pgvDQaWJgv0YqN2jJTwbvtdps6U7fteb7s973nTv5oUs76yNdFibOzdRQN9TYU4n3hqxLHQ3NFNKuMjWmTgeX7TeSDQPemxc2es6b60iu6xaMnfr1KT29akP2cnhv3ut3nlWXuKd2Obvn5EdaywrQ5PXLExfS9Z6051kOG8D67Vw6jHSAVR73TKFPt/I77+0p3U+EMUi2mO6NDtpJIN2WA+o1WG7fRZFHn1mbFnt9SHJaYUN3ftIGnIfGBCjD+CHYAb7G+pHvSOffTX4s8EL+LfPGC8C6r91OpfvB2/4bYX/D8cZsbl42m2PR2zTYBxH378rSZsOdqELWvYooWWVXaDsvTeUxKkN1CmJ08XeSyAQEjcQ4wSIPYUQSOw9xEaCM3vDgQvYTrjxSdbv2Xp6n0wM9vmTQwH/O7/NR4ghljjiScCBExeJJOEmmRRSSaMOdalHfRrQkEak05gmZJBJFtnk0JRm5JJHc1rQkla0pg1taUd7OpBPRzx0Mu8upDNd6Eo3ulNED3rSi970oS/9KKY/AxhICYMYzBCGMozhjGAkoxjNGMYyjvFMYCKTmMwUpjKN6cxgJrOYzRxKJYZ9rGYNO3jDWrawiZ3sZyMvWcV2vvGdzaznMq/5yi4O8JMf/GIvh7jJdQ4zFy9b8XEbhRvc4j53uMs93uLnEQ94yBHK+MI2nvKYJ6i85yMbmIfGfMpZgM5uAiykgiAhwhhUUsU7qqmlhkUsYTFn2cMylrKcFXzgE+d4xlGO8ZxXvJBYjnOC05zhCic5xVVWcol1HOSaxEk8F7jIeUkQhzjFJYmSJG4+S7KkSKqkSR2pK/WkvjSQhtJI0qWxNJEMyZQsyZYcaSrNJFfypLm0kJbSyhHWNY+n2GNtgcdTFNnCgugWxpWEgwFnQFcMVQv6XEZVwIaQy/ykaGWqoboNNahEOZTk1yr/sTukVCp69CXWP9ufqPkCRqnXq+iGs1YJBvL1cLnD7Nhrlq112TWLnP5AOBgBs2k7Ia3aduywTXbdlnQtEoqUfYpul621yuZGyyZFyjZYZcuxypYTKVsUKVuSXbYkf35IDQQNl/krUVJrKlTTD3tdiu4rDak2lUfpL7WW3NoAAAAAAf//AAJ42iWHQQrAIBDEMnsT/HBL+0692PYTKt464ISBBAGZvSAhDv/kct0Ue6XZHyNeE3x0+zDBZKEfSa4NygB42t1ce4xU1Rn/9nF3Zi4sCzIuLOCKu6A8BUXAdUWkIsqj+ATcgqYPbIyKpMY01qhttbHWltiYCqalLZiGpAKGpl3SbDXTNNvWsWZiuimZf8bWSelUe31cNLdpbtLp7/vOua/Zee0yq6T35Jv7OOd+5zvf63znO3eXmojIpHl0OTWv37Dldppy/xceeoCmUCueU7FIXN90390PPkBxvhJopWacm8k0n8OdJW2/0vRK06kmq+m/zXObtya6m63mMy1zWm5tebTld63x1rtaX2g9Y9xsPGO8EF9gvJSYarwR3x7f3tbcFm/rlKu5bZti17Td0/YArg+15ds+ju+KXRy7MrY+sTV2TWx9bFPs5thXY4/Gfhg7FDsSOxb7Q+xvcTO+ICiJqV5hfLpcHr/Sv94VfyJ+KD4UfzP+Flp1S1mQ2Jq4I/HFxD2JBxMPJ55KfD/xUuLXidcT2cRbiX8mHJPMTnOeudXcbT5iPoIR91AbxTDaBEozTUJpoXaUVupAMWgazUGLbpTzqJfm03RaQAupkxbTZTSTVtAaupDWoiyiG1AW00aUJbSVbqKltA1lGQ3QnbScvoSyku6mL9Mq2otyJT1G36I+eor20Tp6FmUjPU8/pk10nF6m2+gkyjZKoWynNMoOegPlDnoTZYBOoXyO/oqyk96mv9Mu+gc59HlQmgTN5wM6iw7NKBZoFq5nF238zgDMBHQVXZoFmANopb5iivpxNVC0aCfOcUqiNWOYgTO3nwU+zEZNH64HcJ5E01ET7ScFrLbfVz/6HcA147uEzsfdPFzN5zvAAsBCwGLAEsClgGWA5YDLACsAKwH9wHR18SFag/NOULereJQex/OvA74B+CbgCcCTgG+ht6dw/jbgacB3AM8Avgv4HmAf4FnA/mKeDuL8G+B6FdBELxdzsJZWPGtHP504y7iFRwUZN/NpL+A0+minyWjdjrukjFvV3ictHHoY57fBrdOAAtq9A3gXYIJj/Iar+er4MmD8u0P4p0GChuCfrvvo1P2oNxzpa49+Q/rjNwEFwDuAdwHTZDwKU0HJU962qAewG8/vA6Y9eL4X8DDavI3704ACQGFxQGsrftvxhqKFsTiaQ65wqAv3s8DROTj3AEsUqwWsNrDawGoDqw2sNvsh4bUb8ATgYVUYbZ/vPbjfq0fYSW3AORm8nY4+1ZtMTwFvDml68loHC5om5m5KeMa8el7kYyh+4fwOgOUzQ/ELMFnrQUCbE6LNFh4q2hyhTY3Yk74dGnEgjSmaj45gVPIMa5gj2Hb7eqRoZW1oEUtag9qdeINtNY8nI2KF/CQOn2XCgxE8UxK1DmotqdmDt4+DU+2UwDuis9LSoF60YktWNu+IZe1By5dQfwyYjsNvNcm7LbAWG1cmnUS7Zrk7ibdMwanwmeiVLTXr2zvjOia9J+FXE5qfLIlePO2DtfUXM2jpSC8GaPtJcZgOAQ4X0/Qi4OeQWEDNavolpPsr1A/h3VeBayqwpvCeobCi7z607gfGAdC1E61YIi+iF8GE66Pg4jG0OU5dgqkVTyw8SQqVr4pWtQJzArja8X4PeNwLXH2oGUB74Sgo2w88TPNJnFtx54DOpMazGuPZL6M6qceWxG83YxXtSgCvaBfe7+Y+RBY2+GYKz7htHhxTdBTEQtT4bPFRJ3FukjebRApNog1t0FRHexVlPbNxPUesf7ror+fTtM8JvBH7b9/ysiF7drVOuqDG91l4i71PH2TRL/PAiGiEpWmZJa1XS4sCXSVzwAi8d4HW4vpHODeJJiUg5UHIJgXZnIBsHEgir2WTpBPFI5DPCWCarH1ELzjDGJXOKL1u0/ZUEJ8zABAdxjODrgeWzYCtgJsArwBaBNuAzCIFSLoHV2shVU/7d+F8p8wJDnTBoT/i2Wug6nWc/4Qz24ErunNSYiSea3geSdC/gO891L0PjB9gTB+ixkbNGYznI9R9jOfNenRLcXUKz04Lv07hGe5Bnb7Hbwt+ledgr9Hs37XhKqM9tKU9tCNtWuQ9741W3OUFn+d5WkCZC8pcOiO9WIL3PVD5gdRaQruqbZY7vjLkisdlyxMH4/Ba27qNibE7frv3cf0BaPtQWjgYv4Hxq/dKsbn6aZiyj/TTFm33XWJPzSt2cxy64rWVQ4h1NiJ2dcA/U942cI07AEc2oVJ0UWx9dmmCj2IaGmsWU6DDlWjRwMMO9GwJdS4gBRlzS4wezywZgSUUOlL4eQa8axRFmeJBUHBUKOF7i3vQ/dsoVvE51Jl+vcN9M22gP8AyzONoEEVZeAKCZnJfeXBkGDTkpH+PhhzoYjoMTRHT6wb1fCUcMhpGUYF75REKfzKgSu4E0AvXq371G54udfg0mHijcRSdKCJCxS84IR4a2sE9QL9GwK9UcQhS6xCtGgEP8xhBGm1SqHfQyhHO5tCKOVloCEWuSMIBb3KiN7boEN8N4pwCHazdGVBg4TfFtfLGkOgYv+mCRhJqxRbOniK2fE0Xj/RElPvgWHDNXDCq9RluPW6Khop78XuQRw6Zkdcfa4bAiN/S0r4pX6pXvn43xFdh3DnWE+mtgJIW2qpKOUpRxftGes0cc1/AFQtk/ShEJe37AD2uklqlYfZEUjlma3FLOHqWPiosCeGVrXXfDvmj0PgbN4fUpM3xtc3+VLjtiJ7XIZPQYUY92wRRZpfqOfxkuprfCUtN+3Gl2XQOabbTUM22opotPMqOZRYAj9xSXp8b1t8wjNmoH4Z/zPIzntcCaYT7VFHcRPrsyGgznieqaG9UKlNf802ic0dyE8OzcMRdbU6N9N4h0afJ64dGxd6NGEeDDlOvjkJYA18o0eLovno/kTGmx6wVyU+M/2mfImdCpUMRPZS1mcQZaYmzK2mjgdpcaC1ZEpMIhsIEsSap13DKFx3AvRWxtQ5em4T75zVKaIyc2eoSnew4hzyR4UXFDcGZD88Uko8oWR2qmLJyDOnPNedcnN0wjFb0TtYWVXW2hIOu+PlPINc0Nh41kp5gZRNA1B+N8k8VPQada0ejMjhiXWoFjvh0ULI4pszkpl7j2tC1jhDHRiY2FuKsovhIzuGMqLwo59mCfAOeZEOzcUFykhMZQxZGxZA1VpClq7xQHu7/IYY0tL/P6YzaUdyrHF5WVjkWNGiweBSFc8TDfn40H/Qp+WRbov9smawiS31IaMwAU7qu/JGpZCIrs6zKD+tsrWSVSuzGGB3Ve/mwct5WU6my+Gb9K3HZ3Ynmzrw8cZeilSMWX5uM8MwmudRqUgrnomuuKiWfbYplyVyBGKmAmTaMIyv5bMlOReaGgCdm5Xw2pJtRc+7oOHl8s6XnvwPPXZ4X9WpybXokw19qvUZkfsqHc30iv1F08GxckdZI5KJ8b30RtcoeaOtT+WyH8+zKJ+Pewt2waAL7w5Teo+ECC4Rsc5W0hC1WIghExZFos+rMIzPHCbF+xKgyU3g7MklY/kHEtoTajK/ZhdC6yRUay8bZmIP496DknXkPobb15yRizqmdNtmpyZfs1IxEdmqCLK0ZXhNU1OwcMLqeXYwlZym+yFJZPx3HWmo3TWzQlfWj2qNQ2lUIxSy2nzu1y81IgklhqEOL0DrvRelCUZZlrte2ykPa8lztQTqVtLeSJclOlHg7ZRPKt1elKMWShgYVxEdy1OFg9VOQ3aEhlMHiPtwzB4eFY7wnaXKdWIPKOWZRl61g2aZovrffZQqFZg0PmVHzUdSDaT6zPSlrc/QTOyQj1y/ZClkBJQU7FJk6dfCI59BB4ZEpo2Ae5cVS4c9RBnFvCy+YR3lQaEiNl5FVuyn5Cn0xjzKBFcp+RtXIUizbAUXDwk3O+jBFw3h+AuUwypOyA5jneZs9Eu93FY/gOUuWI7k0zilto+XW5jxetnxHsoZoXV+sK7ZjaI1OastydYTP3scST5fzfagV2aepvPNuBLu6fhZ3zNF3qV8VWeVq2UnVncC8b8vjyihHKZL4Pyc+QnxUGZsyamprXvswWyTn1syrqUyMDVmzlDt8D9Md9nmSZ8+FVyByWufTnVfrgRJahkruRzTXLXlDWQ+vHLJVsn5G2NdFsn7l/GNXDZkZFXIU3lg7KqxfHT3/s/24vjUYeheiIBpkyKxSTi+r7NDqmKDgZwNq+yPdQqhO4/0jlaOEEs0us+ddZl5LlazP7dDKnXV9ZNQKPidfFMiuudjUcEVrKI1q69o5Bv5MSaxpefua/kzslERTWRVNyH7/CHu+ijyywlFRfR5AzYClaxOduWctGCxdn+qvLnKiJZIZPZs91zIUjaiYrXy0zbGGt+qp0x8pScksJ3pUUPFi/ZodrMJ1zGXxDDj2XK3OJjuCYVhyIqZ4B1PHOiWRl3gTo0oeoUNoTqrsytizAaWxcNUMnlFvnqjePEC4L4kpUmeDtYwe5Ublcd1wXtCLkyO2FkS1ytbsyMrYCNFeUN9vjGV9yJHKaG/gr0t5d1NnqMc4UrcR3xU16l3NP/ds841nRVFOvpIkWYUW9FzjeTFPwrlQZG5Vz/rpDKI7/jyEfEsYjdgs5fvH6z39iG2c30mEvKyh/L7kdAyJaMpHbDX6kfUMv80+dqQGn0zNTV5b7EOM/mSwJlTfQ8nd08UDEsEPlf8KSufqQt+Y+c+fK9HKQf2VlayfsYJIFTMS62VCEknzilFWMVm1vihv/Sq6r67NZf1RusRqC7UkhPG74IAtGfQOb73pf1mXDfFEzSK5ChSZZXW7o0Sipm+/KdkRTKqvDSNcvVekklY9eTOWZG0QvRUPB/qu1iRedKHXtrbit2RQ8uUszv82MIh+SCT1uOQTeSWXEe3KFh8SiT4tFD0OaWWDiIoplf1Qwqrfw3VY4vR08WCw5yUUDesZyEJ9Gb9VsjeWk6wYx8/3yneqLCWmjzPXd1fyIKJVjr+uH1b7IsHcr2fecPY4U21fxJ/7Tb2zMmZfKRZleNkzbRmWl0cr84VWzR78XLArkaNbo/cD8puT3aAOPRqJ2gQGI5FBFhweCkmN1xZpkWhGss7lvItd4m0lF4M3j8r8mhRvZ1X/fi76tU+Qa6zf5s8mjvqU9nHYBg5KdrJDvlN3avAoO9ZopB4undXcn/e/wuZs1aD+ktzVtlZuDzJTNc7O69jAUN8mjcPWsqN2RY0IRWq3vcOPRtwa1p/TOzvGuK0/F+Qk9Z6S7EMFeQq1X1Si9WYN3WUcyQDDGHcBJyCqrfNopqnUKhQkaBLu2qmb/66O1tIMWk930Ur5u+Wb6V6UW+h+lFvpayi30WP0A7qd9tNv8ez39AYdkL9M/in9mf5Ch+gtepd+Rv+m/9Av5K/LHWD+rO4zhquZOMdpC21GT5uB82LqRK9zaRrk2k1zhJtrUNQxC9QtwHkhLadFwLeYlqAspUtpmVwtB+UtdBldTivoCtC/ktpoFa2mfrrKH+mV1EdX0wCto8/QdbSRNtANdCPu+e+1N6GuC6O8BePaRvNoO82nHXQH3veOKRGuXQNYX5Gn1+vzbNAclEWgfpEuS3RZLuAVAlyhyyrwbDpoDso6UL9Olw26TBbavbIFsE2XHRjRDpwXefk9HPxX6vx36Zv1rzr4fDvKep/u4NgCXm2gS6ALvXQRnQdduZAugJ6cX3Hs10pREl+FEfCxBFLhq36MqxdYLgDMQ2/Xos/rwMs16IVHtxZyn6PxrIYMmyAfA3Cjf27Vd+qegf92fwEkH4fsE2Klk8B3T2sWQp/aAd3QqoXQrovwuxB61oNnPajpgdZdDFn3YYRXQSe7tNz42BAZ12TAVEih/HEhNHIxtPEG0ByUZp/6oLQI3YbvbQxfPxKouQQ0h8s0v8zVZZrQ7pVewHxdZmJkM+WvSqf5dF2AkhRpJUMyOw8SWYbC0uRjMfSOqV8Ei+oFr+bqZ5fivAiwtKK0+b8iTOHyP4HVHjwAAAB42m1VXWhcRRT+zszcm82mxritaQhBQgihD4toEBGpEjFdXBp1CSGUIsGYoKlsUwhRQixS+iR9EiniQ5E+SPFBfPCh+CBaRMvSB4kgi02tjTXW+hfbmtYoxfrN2Zu9k2T3Y37uOd85M3POmVkIgCxG8DHMYGFoBK3l8dlp5NBJeTvsE/v3dKPvyeER9iPDe9kDd+4golZgYP2M33H921EST4yXZ9E3OX3oIPIvzoxPoL984KVxDJcPTZSxb/qVgzMYU4uc9nezbw3t0YQMmrmvFmzDXdR51j3aQ/s27MQDeNlUzGXzn+2yu+2YPWrftwv2X5d3o27G3Y6yUUc0EA/Fx+JP42XdoaHHXq5BD25FV/f+tuvKQ1iqaegbdblQ7i134iGMYg7vME5VrEqb5KUgz8ucvCmn5BNZkGW5ZTKmw+wyD5tBemqJjm2F6YWw+Z+uZQx5U1tBuWdko8JmyBKEre5BzpDVtxmUen1zFG+EnKTFycD6KJrd1Y2gzGsz7lwImSR7MrB8iowPQ1DidU3urRSSJzMfWOWon0shOdXEbmwdWGPM11ILZiV2hXVgSeWRu78GVMioBOyPqOuogXMvdc544AS1JwLmG3B2xYMzL7N20S5ilprZgPUC5RVb4eglxp5GidJSwBig9BR7/y2sSd9SbY821dl5znck43p15ZKbk6nx7T7GaDTRb9Q8znW6ZXdDXQ936ayT7oZaB2eueIhppDfLiMzZGnC5IeNzxOa9deBMQ867aDJHUmi8t7LmkDH7Q+DVhrwSmk3/RuCZhsw+ZHnvNoG3PI1xNbDQOy+ryQ3fwXtvqK9y/htWKQuYco7ej3P8IOG6ROcrJOIr8SgKeA5TlGf1vezBIu2q+Avf6riC13T8A/M6/klLh/OJznCtVlxILA4HjO8SmZ9frM8j5uZHLOMKrup+dCfSy7XSr3Z8FezSt1aNQFFX24ZbHG/iEvuinrSJpxrg2z/Fd+00vklq1r+Kner1Xn0Zi7QQcvdgL1/Dp5mHZ/WtFPhqLCejZ3vZLjZWMY4HsiNsg7XqV5nhLnvxGOevk9eJt1ktD+Iz4hHllxJuqb4Ly3h/ibOq7We7XffWDl/VP+DX5AZ66fds9wXa7ejSk7UwJvPMymF8zbidZ74uMNoX6xE06Oa/TZXearH+idH+mfH+hd5v8sz+/ymnvopEC6MxxKim1l2UfcFK+p05X2E2r+E6bjB7q1pnVuPr9yKBTRsz+ze9r+Ef5ke0sop61ktpZpmtBbWy/wNYrv7DAA== ) format( 'woff' );
+                    font-weight: 700;
+                    font-style: normal;
+                }
+
+                @font-face {
+                    font-family: 'Graphik';
+                    src: url( 'https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/fonts/Graphik/Graphik-Semibold.woff2' ) format( 'woff2' ),
+                    url( 'https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/fonts/Graphik/Graphik-Semibold.woff' ) format( 'woff' );
+                    font-weight: 600;
+                    font-style: normal;
+                    font-display: swap;
+                }
+
+                @font-face {
+                    font-family: 'Graphik';
+                    src: url( 'https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/fonts/Graphik/Graphik-Bold.woff2' ) format( 'woff2' ),
+                    url( 'https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/fonts/Graphik/Graphik-Bold.woff' ) format( 'woff' );
+                    font-weight: 700;
+                    font-style: normal;
+                    font-display: swap;
+                }
+
+                @font-face {
+                    font-family: 'Graphik Super';
+                    src: url( 'https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/fonts/Graphik/Graphik-Super.woff2' ) format( 'woff2' ),
+                    url( 'https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/fonts/Graphik/Graphik-Super.woff' ) format( 'woff' );
+                    font-weight: 800;
+                    font-style: normal;
+                    font-display: swap;
+                }
+
+                        </style>
+        <link rel='https://api.w.org/' href='https://www.rollingstone.com/wp-json/' />
+<meta name="generator" content="WordPress 5.0.3" />
+<link rel='shortlink' href='https://wp.me/a2tH9' />
+
+<link rel='dns-prefetch' href='//v0.wordpress.com'/>
+<style type='text/css'>img#wpstats{display:none}</style>
+<script src="https://tagan.adlightning.com/penske/blacklist_script.js" defer></script>
+<script src="https://tagan.adlightning.com/penske/blocking_script.js" defer></script>
+<script src="https://tagan.adlightning.com/penske/op.js" defer></script>
+        <script>
+            try {
+                // Don't rely on jQuery being loaded yet.
+                document.addEventListener( 'DOMContentLoaded', function() {
+                    // Record in GA event if ads are blocked.
+                    if ( true === window.pmc_is_adblocked ) {
+                        ga( 'send', 'event', 'ad_blocker', 'blocked', 'ads_blocked', {
+                            nonInteraction: true
+                        });
+                    }
+                });
+            } catch( err ) {
+                // Do nothing...
+            }
+        </script>
+        <link rel="canonical" href="https://www.rollingstone.com/" />
+<link rel="next" href="https://www.rollingstone.com/page/2/" />
+<style type="text/css">
+.vvqbox {
+    visibility: visible !important;
+    display: block;
+    clear: both;
+    width: 100%;
+}
+.vvqbox div {
+    margin: 10px auto;
+}
+.vvqbox img {
+    max-width: 100%;
+    height: 100%;
+}
+.vvqbox object {
+    max-width: 100%;
+}
+</style>
+        <script>
+            !function(n){"use strict";n.loadCSS||(n.loadCSS=function(){});var o=loadCSS.relpreload={};if(o.support=function(){var e;try{e=n.document.createElement("link").relList.supports("preload")}catch(t){e=!1}return function(){return e}}(),o.bindMediaToggle=function(t){var e=t.media||"all";function a(){t.media=e}t.addEventListener?t.addEventListener("load",a):t.attachEvent&&t.attachEvent("onload",a),setTimeout(function(){t.rel="stylesheet",t.media="only x"}),setTimeout(a,3e3)},o.poly=function(){if(!o.support())for(var t=n.document.getElementsByTagName("link"),e=0;e<t.length;e++){var a=t[e];"preload"!==a.rel||"style"!==a.getAttribute("as")||a.getAttribute("data-loadcss")||(a.setAttribute("data-loadcss",!0),o.bindMediaToggle(a))}},!o.support()){o.poly();var t=n.setInterval(o.poly,500);n.addEventListener?n.addEventListener("load",function(){o.poly(),n.clearInterval(t)}):n.attachEvent&&n.attachEvent("onload",function(){o.poly(),n.clearInterval(t)})}"undefined"!=typeof exports?exports.loadCSS=loadCSS:n.loadCSS=loadCSS}("undefined"!=typeof global?global:this);      </script>
+                <style type="text/css" id="home-css">
+            .wp-caption .wp-caption-text{font-family:Graphik,sans-serif}.fonts-loading .wp-caption .wp-caption-text,.wp-caption .fonts-loading .wp-caption-text{font-family:Graphik Bold Subset,Graphik,Tahoma,Verdana,Segoe,sans-serif;font-weight:700;font-style:normal;font-display:swap}.c-card--featured-home .c-card__wrap{position:relative;transition:transform .1s ease-in;will-change:transform}@media (min-width:60rem){.c-card--featured-home .c-card__wrap:before{content:"";position:absolute;bottom:0;left:1.25rem;z-index:-100;width:calc(100% - 2.5rem);height:1.875rem;box-shadow:0 1.25rem 1.5rem 0 rgba(0,0,0,.1);opacity:0;transition:opacity .1s ease-in;transform:translateZ(0)}.c-card--featured-home .c-card__wrap:after{content:"";position:absolute;top:0;left:0;z-index:-100;width:100%;height:100%;background:#fff}}.c-card--featured-home .c-card__wrap:focus:before,.c-card--featured-home .c-card__wrap:hover:before{opacity:1;transition:opacity .3s ease-out}.c-card--brand .c-card__image,.c-card--coverage .c-card__image,.c-card--featured-home .c-card__image,.c-card--grid .c-card__image{transition:opacity .24s cubic-bezier(.455,.03,.515,.955)}.c-card--brand .c-card__image:focus,.c-card--brand .c-card__image:hover,.c-card--coverage .c-card__image:focus,.c-card--coverage .c-card__image:hover,.c-card--featured-home .c-card__image:focus,.c-card--featured-home .c-card__image:hover,.c-card--grid .c-card__image:focus,.c-card--grid .c-card__image:hover{opacity:.8}.c-card__tag{order:-1;display:-webkit-box;display:-ms-flexbox;display:flex;align-items:flex-start;margin-bottom:.3125rem;font-size:.6875rem;letter-spacing:1px;line-height:1.2;color:#000}.c-ad,.c-author__thumb,.c-badge,.c-features,.c-hamburger,.c-icon,.c-slider__nav,.c-social-bar__link,.c-trending__heading,.c-trending__number,.l-header__block,.l-header__content--sticky,.l-header__link,.l-header__menu,.l-header__menu-link,.l-header__nav,.l-header__toggle,.l-mega__block,.l-mega__menu{display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;justify-content:center}.c-card--brand .c-card__heading,.c-card--featured-home .c-card__heading,.c-card--grid .c-card__heading,.c-reviews-card__headline,.c-the-list{transition:color .24s cubic-bezier(.455,.03,.515,.955)}.c-card--brand .c-card__heading:focus,.c-card--brand .c-card__heading:hover,.c-card--featured-home .c-card__heading:focus,.c-card--featured-home .c-card__heading:hover,.c-card--grid .c-card__heading:focus,.c-card--grid .c-card__heading:hover,.c-reviews-card__headline:focus,.c-reviews-card__headline:hover,.c-the-list:focus,.c-the-list:hover{color:dimgray}html{line-height:1.15;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-size:1rem;line-height:1.5rem;font-family:Georgia,Times,Times New Roman,serif;overflow-x:hidden}h1,h2,h3,h4,h5,h6{font-family:Graphik,sans-serif;font-weight:400}*,:after,:before{box-sizing:border-box}a:focus{outline:none}a{-webkit-text-decoration-skip:objects;transition:color .24s cubic-bezier(.215,.61,.355,1);text-decoration:none}b,strong{font-weight:700}svg:not(:root){overflow:hidden}svg path{fill:inherit}button,input{overflow:visible;border:0;-webkit-appearance:none;-moz-appearance:none;appearance:none;font:inherit}input[type=radio]{-webkit-appearance:radio;-moz-appearance:radio;appearance:radio}input[type=checkbox]{-webkit-appearance:checkbox;-moz-appearance:checkbox;appearance:checkbox}textarea{overflow:auto}select{font-size:.8125rem;padding:.1875rem .375rem;border:1px solid #ccc;border-radius:.1875rem;outline:none;box-shadow:inset 0 1px .125rem rgba(0,0,0,.15)}blockquote{color:#666;font-size:1.125rem;font-style:italic;line-height:1.875rem;overflow:hidden}blockquote cite{display:block;font-style:normal;font-weight:700;margin-top:.625rem}cite,dfn,em,i{font-style:italic}abbr,acronym{border-bottom:1px dotted #666;cursor:help}ins,mark{background:#eee;text-decoration:none}small{font-size:80%}big{font-size:125%}[type=search]{-webkit-appearance:textfield}[type=search]::-webkit-search-cancel-button,[type=search]::-webkit-search-decoration{-webkit-appearance:none}button{overflow:visible;border:0;font:inherit;-webkit-font-smoothing:inherit;letter-spacing:inherit;background:none;cursor:pointer}img{height:auto;max-width:100%;transition:opacity .3s;opacity:1}img.lazy[data-src]{opacity:0}img.lazy[data-src].visible{opacity:1}address,blockquote,button,dd,dl,dt,fieldset,figure,h1,h2,h3,h4,h5,h6,input,legend,li,ol,optgroup,p,select,textarea,ul{margin:0;padding:0}fieldset{padding:0;border:none}legend{display:block}iframe,table{border:none}table{border-top:1px solid #ccc;border-collapse:collapse;margin:0 0 1.25rem;width:100%}thead th{border-bottom:.125rem solid #ccc;padding-bottom:.625rem}th{padding:.5rem 0;text-align:left}td,th{border:none}td{padding:.5rem}tr{border-bottom:1px solid #ccc}.hidden,.is-hidden{display:none!important}embed,iframe,object{margin:0;max-width:100%}.screen-reader-text{clip:rect(1px,1px,1px,1px);-webkit-clip-path:polygon(0 0,0 0,0 0,0 0);clip-path:polygon(0 0,0 0,0 0,0 0);position:absolute!important;white-space:nowrap;height:1px;width:1px;overflow:hidden}.screen-reader-text:focus{background-color:#f1f1f1;border-radius:.1875rem;box-shadow:0 0 .125rem .125rem rgba(0,0,0,.6);clip:auto!important;color:#21759b;display:block;font-size:.875rem;font-weight:700;height:auto;left:.3125rem;line-height:normal;padding:.9375rem 1.4375rem .875rem;text-decoration:none;top:.3125rem;width:auto;z-index:100000}.alignleft{display:inline;float:left;margin-right:1.25rem}.alignright{display:inline;float:right;margin-left:1.25rem}.aligncenter{clear:both;display:block;margin-left:auto;margin-right:auto}img.aligncenter{float:none;margin:.9375rem auto}img.alignleft{float:left;margin-top:.9375rem;margin-bottom:.9375rem;margin-right:1.25rem;max-width:calc(50% - 2.5rem)}@media (min-width:48rem){img.alignleft{max-width:66%}}img.alignright{float:right;margin-top:.9375rem;margin-bottom:.9375rem;margin-left:1.25rem;max-width:calc(50% - 2.5rem)}@media (min-width:48rem){img.alignright{max-width:66%}}.gallery-caption,.wp-caption{margin-bottom:1.25rem;padding-top:1.25rem;max-width:100%;border-bottom:1px solid #dddee4}.wp-caption img[class*=wp-image-]{display:block}.wp-caption .wp-caption-text{padding:.625rem 0;font-weight:600;font-size:.875rem;line-height:1.25rem;color:#000}#wpstats{width:0;height:0;overflow:hidden;display:block}[data-collapsible].is-expanded [data-collapsible-toggle]:not([data-collapsible-toggle=always-show]),[data-collapsible]:not(.is-expanded) [data-collapsible-panel]{display:none}@media (min-width:60rem){[data-collapsible]:not(.is-expanded) [data-collapsible-panel][data-collapsible-breakpoint=mobile-only]{display:block}}[data-collapsible-toggle]:focus{outline:none}@keyframes ripple{0%{opacity:0;visibility:visible;transform:scale(1)}5%{opacity:1;transform:scale(2)}50%{opacity:.6;visibility:visible;transform:scale(20)}to{opacity:0;visibility:hidden;transform:scale(40)}}[data-ripple]{position:relative;overflow:hidden;-webkit-tap-highlight-color:rgba(255,255,255,0)}[data-ripple]:after{content:"";position:absolute;bottom:calc(50% - .3125rem);left:calc(50% - .3125rem);width:.625rem;height:.625rem;background-color:rgba(0,0,0,.2);border-radius:99%;opacity:0;visibility:hidden}@media (min-width:48rem){[data-ripple]:after{content:none}}[data-ripple][data-ripple=inverted]:after{background-color:hsla(0,0%,100%,.2)}[data-ripple][data-ripple-location=left]:after{left:calc(25% - .3125rem)}[data-ripple][data-ripple-location=right]:after{left:auto;right:calc(25% - .3125rem)}[data-ripple][data-ripple-trigger]:after{animation-duration:.6s;animation-name:ripple}[data-line-menu] .line-menu-indicator{position:absolute;z-index:1000;left:-1.875rem;bottom:0;width:3.75rem;height:.125rem;pointer-events:none;background-color:currentColor;transform-origin:50% 50%;transition:transform 195ms cubic-bezier(.4,0,.2,1)}[data-list-autofocus]{position:relative;opacity:0}[data-list-autofocus] input{position:absolute;z-index:1;width:0;height:0;transform:translateY(40vh)}@-moz-document url-prefix(){[data-list-autofocus] input{transform:translateY(-10vh)}}.t-copy{font-family:Georgia,Times,Times New Roman,serif}.t-bold{font-family:Graphik,sans-serif;font-weight:700}.fonts-loading .t-bold{font-family:Graphik Bold Subset,Graphik,Tahoma,Verdana,Segoe,sans-serif}.t-bold--upper{text-transform:uppercase}.t-bold--condensed{letter-spacing:-1px}.t-bold--loose{letter-spacing:.125em}.t-semibold{font-family:Graphik,sans-serif;font-weight:600}.fonts-loading .t-semibold{font-family:Graphik Bold Subset,Graphik,Tahoma,Verdana,Segoe,sans-serif;font-weight:700;letter-spacing:-.0285em}.t-semibold--upper{text-transform:uppercase}.fonts-loading .t-semibold--upper{letter-spacing:-.013em}.t-semibold--condensed{letter-spacing:-.0221em}.fonts-loading .t-semibold--condensed{letter-spacing:-.0345em}.t-semibold--loose{letter-spacing:.1em}.fonts-loading .t-semibold--loose{letter-spacing:.088em}.t-super{font-family:Graphik Super,Graphik,sans-serif;font-weight:800}.fonts-loading .t-super{font-family:Graphik Bold Subset,Graphik Super,Graphik,Tahoma,Verdana,Segoe,sans-serif;letter-spacing:.0125em}.t-super--upper{text-transform:uppercase}.t-align--center{text-align:center}.c-ad--boxed{padding:.75rem 0;border-top:1px solid #dddee4;border-bottom:1px solid #dddee4}.l-home-top .c-ad--boxed{border-top:none;padding:2.5rem 0 0}.c-ad--wide-bg{position:relative;padding:1.5625rem;margin:1.25rem 0}.c-ad--wide-bg:before{content:"";position:absolute;top:0;left:50%;z-index:-100;width:100vw;height:100%;transform:translateX(-50%);background:#f4f4f7}.c-ad--320x50{min-width:20rem;min-height:3.125rem}.c-ad--728x90{min-width:45.5rem;min-height:5.625rem}.c-ad--mobile-header{padding:.3125rem 0;background-color:#d32531}@media (min-width:60rem){.c-ad--mobile-header{display:none}}.is-mega-open .c-ad--mobile-header{display:none}.c-ad--desktop-header{margin:0 auto;padding:1px 0}.c-ad--admz{text-align:center;margin-bottom:1.25rem}@media (min-width:60rem){.super-marquee{min-width:62.5625rem;margin-top:-1.5625rem}}.super-marquee a{margin-left:auto;margin-right:auto}.super-marquee-container{width:100%}.blockbuster-ad{position:relative;background-position:50%;background-size:cover}@media (min-width:60rem){.blockbuster-ad{max-height:15.625rem;min-width:62.5625rem;margin-top:-1px}}@media (min-width:48rem) and (max-width:51.1875rem){.blockbuster-ad{margin-top:3.75rem}}@media (min-width:48rem){.blockbuster-ad-body{-moz-flex-direction:row;flex-direction:row;flex-wrap:nowrap;-webkit-box-pack:justify}}@media (min-width:48rem){.blockbuster-ad-body,.blockbuster-ad-content{display:-moz-flex;display:-webkit-box;display:-ms-flexbox;display:flex}.blockbuster-ad-content{-moz-justify-content:center;justify-content:center;text-align:left;flex-direction:column;order:1;-webkit-box-ordinal-group:2;-webkit-order:1;-moz-order:1;-ms-flex-order:1}}.blockbuster-ad-video-wrap{overflow:hidden;margin-left:.5rem}@media (min-width:48rem){.blockbuster-ad-video-wrap{max-width:22.5rem;max-height:13.75rem;margin:1.25rem;order:2;-webkit-box-ordinal-group:3;-webkit-order:2;-moz-order:2;-ms-flex-order:2}}.has-side-skins div[id^=attachment]{max-width:29.375rem}.pmc-crown-leaderboard{display:-webkit-box;display:-ms-flexbox;display:flex;max-width:118.75rem;margin-left:auto;margin-right:auto}@media (max-width:30rem){.pmc-crown-leaderboard{position:relative}}.pmc-crown-leaderboard__item{width:50%;position:relative;overflow:hidden}@media (max-width:30rem){.pmc-crown-leaderboard__item{width:100%}}.pmc-crown-leaderboard-picture{width:100%}@media (max-width:43.75rem){.pmc-crown-leaderboard-picture{position:absolute}}@media (max-width:30rem){.pmc-crown-leaderboard__item--mobile-hide{position:absolute;top:0;left:0;z-index:-1;padding-bottom:56.25%}}.adw-300{width:18.75rem}div.adma{display:-webkit-box;display:-ms-flexbox;display:flex;justify-content:center}.pmc-adm-goog-pub-div.ad-flex-left{margin-right:auto}.pmc-adm-goog-pub-div.ad-flex-right{margin-left:auto}.c-author{display:-webkit-box;display:-ms-flexbox;display:flex;flex-flow:row wrap;width:17.5rem;padding:.75rem .5rem .375rem;border-top:1px solid #dddee4;background-color:#fff;box-shadow:0 .125rem .25rem rgba(0,0,0,.5)}.c-author__thumb{flex:0 0 auto;width:5.75rem;height:5.75rem;overflow:hidden;border-radius:99%}.c-author__headshot{object-fit:cover;width:100%;height:100%}.c-author__meta{flex:1 1 auto;width:calc(100% - 5.75rem);padding:.1875rem 0 1.25rem .75rem}.c-author__meta-link{color:#000}.c-author__meta-link:hover{color:#d32531}.c-author__meta-link--post{display:block;padding:.625rem 0 .625rem 1.25rem}.c-author__meta-link--post:before{content:"";display:inline-block;width:.4375rem;height:.4375rem;margin:0 .3125rem 0 -.9375rem;background-color:#d32531}.c-author__meta-link--all{display:block;text-align:right;padding:.3125rem 0}.c-author__heading{margin-bottom:.3125rem;font-size:1rem;line-height:1.1875rem;word-wrap:break-word}.c-author__role{font-size:.875rem;font-style:italic;line-height:1rem}.c-author__twitter{display:-webkit-box;display:-ms-flexbox;display:flex;align-items:flex-start;margin-top:.3125rem;margin-bottom:.625rem;word-break:break-all;line-height:1.2;color:#6f6f6f;transition:color .24s cubic-bezier(.215,.61,.355,1)}.c-author__twitter:hover{color:#1dadeb}.c-author__twitter .c-icon{padding-top:0;padding-bottom:0}.c-author__posts{flex:0 0 auto;width:100%;list-style:none;font-size:.75rem;line-height:.875rem}.c-author__post{border-top:1px solid #dddee4}.c-author__post:first-child{margin-top:-.375rem;border-top:none}.c-author__view-all{flex:0 0 auto;width:100%;font-size:.625rem;line-height:.75rem;text-align:right}.c-badge{color:#fff}.c-badge__icon{fill:currentColor}.c-badge--gallery{padding:.5rem;background:rgba(0,0,0,.7);border-radius:.3125rem}@media (min-width:48rem){.c-badge--gallery{padding:.5rem .625rem}}.c-badge--gallery .c-badge__icon{width:1.125rem;height:1rem}@media (min-width:48rem){.c-badge--gallery .c-badge__icon{width:1.3125rem;height:1.1875rem}}.c-badge--gallery .c-badge__label{margin-left:.3125rem;font-size:.6875rem;line-height:.6875rem}@media (max-width:47.9375rem){.c-badge--gallery .c-badge__label{display:none}}@media (max-width:47.9375rem){.c-badge--mobile-full{padding:.5rem .625rem}.c-badge--mobile-full .c-badge__icon{width:1.3125rem;height:1.1875rem}.c-badge--mobile-full .c-badge__label{display:block}}.c-btn{font-size:.6875rem;color:#fff;letter-spacing:.08364em;line-height:.6875rem;border-radius:0;transition:background-color .24s cubic-bezier(.215,.61,.355,1),color .24s cubic-bezier(.215,.61,.355,1);cursor:pointer}.c-btn,.c-btn .c-btn__icon,.c-btn .c-btn__main,.c-btn .c-btn__secondary{display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex}.c-btn .c-btn__icon,.c-btn .c-btn__main,.c-btn .c-btn__secondary{align-items:center}.c-btn__inner{display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex;pointer-events:none}.c-btn__icon-wrap{padding:.625rem 0 .625rem .625rem}.c-btn__icon{height:.875rem;width:.9375rem;fill:currentColor}.c-btn__main{padding:.625rem}.c-btn__secondary{padding:.625rem;border-left:1px solid currentColor}.c-btn--block{padding:.4375rem}.c-btn--outline{padding:.6875rem 2.5rem;font-size:.9375rem;letter-spacing:0;color:#d32531;border:.125rem solid #dddee4;background-color:#fff;transition:border-color .24s cubic-bezier(.215,.61,.355,1),color .24s cubic-bezier(.215,.61,.355,1)}.c-btn--outline:focus,.c-btn--outline:hover{color:#000}.c-btn--dark{border:1px solid currentColor;background:#000}.c-btn--dark:focus,.c-btn--dark:hover{color:#000;background:#fff}.c-btn--red{border:1px solid currentColor;background:#d32531;color:#fff}.c-btn--red:focus,.c-btn--red:hover{color:#d32531;background:#fff}.c-btn--large{font-size:1rem;padding:1rem}.c-btn--pagination{padding:1em;font-size:.875rem;line-height:.875rem;letter-spacing:0;border-radius:.3125rem;background-color:#d32531;box-shadow:0 .125rem .25rem 0 rgba(0,0,0,.3)}.c-btn--pagination:focus,.c-btn--pagination:hover{background:#e04b56}.c-btn--twitter{border-radius:.25rem;background-color:#1dadeb;transition:background-color .24s cubic-bezier(.215,.61,.355,1),color .24s cubic-bezier(.215,.61,.355,1)}.c-btn--twitter:focus,.c-btn--twitter:hover{background-color:#fff;color:#1dadeb}.c-card{width:100%}.c-card__header,.c-card__wrap{display:-webkit-box;display:-ms-flexbox;display:flex;flex-flow:column nowrap}.c-card__wrap{height:100%;color:#000}.c-card__image{position:relative;width:100%}.c-card__badge{position:absolute;top:50%;left:50%;z-index:1;transform:translate(-50%,-50%)}@media (max-width:47.9375rem){.c-card__badge{pointer-events:none}}.c-card__byline,.c-card__tag{font-size:.6875rem;line-height:.8125rem}.c-card__byline{order:1}.c-card__paywall-icon{display:inline;fill:#000;width:1.9375rem;height:.9375rem;margin-right:.1875rem}.c-card__featured-tag{border-bottom:1px solid #d32531;text-decoration:none}.c-card--brand{display:-webkit-box;display:-ms-flexbox;display:flex}.c-card--brand:focus .c-card__image:before,.c-card--brand:hover .c-card__image:before{opacity:1}.c-card--brand .c-card__wrap{position:relative;display:-webkit-box;display:-ms-flexbox;display:flex;height:auto;width:100%;padding-bottom:1.5625rem;transition:transform .3s ease-out}@media (min-width:48rem){.c-card--brand .c-card__wrap{padding-bottom:2.5rem}}.c-card--brand .c-card__heading{margin-top:.125rem;font-size:.8125rem;line-height:.9375rem}@media (min-width:48rem){.c-card--brand .c-card__heading{margin-top:.625rem;font-size:1.0625rem;line-height:1.4375rem}}.c-card--brand .c-card__timestamp{position:absolute;bottom:0;font-size:.8125rem;color:dimgray}.c-card--brand .c-card__brand{order:-1;margin-top:.3125rem;font-size:.8125rem;color:#d32531}@media (min-width:48rem){.c-card--brand .c-card__brand{margin-top:.625rem}}.c-card--coverage .c-card__heading{padding-top:.625rem;font-size:.9375rem;line-height:1.25rem;color:#fff;transition:color .24s cubic-bezier(.215,.61,.355,1)}.c-card--coverage:focus .c-card__heading,.c-card--coverage:hover .c-card__heading{color:#a7a6a6}.c-card--coverage .c-card__badge{left:.625rem;bottom:.625rem;top:auto;transform:none}.c-card--excerpt .c-card__heading{position:relative;left:0;margin-bottom:.4375rem;font-size:.875rem;line-height:1.1875rem;transition:color .24s cubic-bezier(.215,.61,.355,1)}.c-card--excerpt .c-card__heading:focus,.c-card--excerpt .c-card__heading:hover{color:dimgray}.c-card--excerpt .c-card__tag{margin-bottom:.4375rem}.c-card--excerpt .c-card__timestamp{font-size:.6875rem;font-weight:400;font-family:Helvetica,Arial,sans-serif;line-height:1;color:dimgray}.c-card--featured-home{height:100%}.c-card--featured-home .c-card__wrap{background:#fff;box-shadow:0 .125rem .75rem 0 rgba(0,0,0,.08)}.c-card--featured-home .c-card__header{padding:.9375rem .9375rem .9375rem 1.125rem}@media (max-width:68.75rem){.c-card--featured-home .c-card__header{padding-bottom:1.25rem}}.c-card--featured-home .c-card__heading{word-wrap:break-word;-ms-word-break:break-all;word-break:break-word;-ms-hyphens:auto;-webkit-hyphens:auto;hyphens:auto;font-size:.9375rem;line-height:.9375rem}.c-card--featured-home .c-card__tag{margin-bottom:.4375rem}.c-card--grid{height:100%}.c-card--grid .c-card__wrap{position:relative;height:100%;padding-bottom:1.875rem}.c-card--grid .c-card__badge{top:auto;bottom:.625rem;left:.625rem;transform:none}@media (max-width:47.9375rem){.c-card--grid .c-card__badge{display:none}}.c-card--grid .c-card__tag{margin-top:.9375rem;margin-bottom:0}.c-card--grid .c-card__heading{margin-top:.625rem;font-size:1.0625rem;line-height:1.4375rem}.c-card--grid .c-card__lead{margin-top:.625rem;font-size:.875rem;letter-spacing:.47px;line-height:1.4375rem}.c-card--grid .c-card__byline{position:absolute;bottom:.3125rem;font-size:.75rem;font-style:italic}.c-card--grid-sponsored .c-card__byline{position:static;order:-1;margin-top:.9375rem}@media (max-width:47.9375rem){.c-card--grid--secondary .c-card__wrap{padding:0}.c-card--grid--secondary .c-card__heading{margin-top:.3125rem;font-size:.8125rem;line-height:1.1875rem}.c-card--grid--secondary .c-card__tag{margin-top:.625rem}.c-card--grid--secondary .c-card__byline,.c-card--grid--secondary .c-card__lead{display:none}}@media (max-width:29.9375rem){.c-card--overlay{border-radius:.3125rem;overflow:hidden}.c-card--overlay--home{border-radius:0}}.c-card--overlay .c-card__wrap{position:relative;z-index:0;color:#fff;background:#fff;box-shadow:0 .125rem .25rem 0 rgba(0,0,0,.2);transition:box-shadow .3s cubic-bezier(.55,.085,.68,.53)}.c-card--overlay .c-card__wrap:before{content:"";position:absolute;top:0;left:0;z-index:1;width:100%;height:100%;background-image:-webkit-gradient(linear,left top,left bottom,color-stop(44%,rgba(15,22,30,0)),to(#0f161e));background-image:linear-gradient(180deg,rgba(15,22,30,0) 44%,#0f161e)}.c-card--overlay .c-card__wrap:hover{box-shadow:0 1.25rem 1.5rem 0 rgba(0,0,0,.1)}.c-card--overlay .c-card__header{position:absolute;left:0;bottom:0;z-index:1;width:100%;padding:1.25rem}@media (min-width:30rem){.c-card--overlay .c-card__header{padding:1.875rem}}.c-card--overlay .c-card__heading{font-size:1.125rem;line-height:1.1;margin-bottom:.3125rem}@media (min-width:30rem){.c-card--overlay .c-card__heading{font-size:1.875rem}}@media (min-width:48rem) and (max-width:75rem){.c-card--overlay .c-card__heading{font-size:1.5625rem}}.c-card--overlay .c-card__lead{font-size:.875rem;line-height:1.16;font-family:Graphik,sans-serif}@media (min-width:48rem){.c-card--overlay .c-card__lead{font-size:1rem}}.c-card--overlay .c-card__tag{margin-bottom:.625rem;font-size:.75rem;line-height:.75rem;color:#facd42}.c-card--overlay .c-card__tag:before{display:none}@media (min-width:30rem){.c-card--overlay .c-card__tag{font-size:.75rem;line-height:.75rem}}@media (min-width:78.75rem){.c-card--overlay,.c-card--overlay .c-card__image,.c-card--overlay .c-card__wrap{display:-webkit-box;display:-ms-flexbox;display:flex;height:100%;width:100%}}@media (min-width:60rem){.c-card--overlay--home,.c-card--overlay--home .c-card__image,.c-card--overlay--home .c-card__wrap{display:-webkit-box;display:-ms-flexbox;display:flex;height:100%;width:100%}}.c-card--overlay .c-card__featured-tag{color:#000;background:#facd42;padding:.25rem;border-bottom:none}.c-card--video .c-card__wrap{display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center}@media (min-width:60rem){.c-card--video .c-card__wrap{flex-direction:row}}.c-card--video .c-card__image{padding:1.25rem;cursor:pointer}@media (min-width:60rem){.c-card--video .c-card__image{order:2;width:60vw;max-width:50.9375rem}html:not(.has-side-skins) .c-card--video .c-card__image{flex-shrink:0}}.c-card--video .c-card__image:hover .c-play-btn__border{stroke-dashoffset:0;stroke:#fff;transition:stroke-dashoffset .5s cubic-bezier(.445,.05,.55,.95),stroke .2s cubic-bezier(.445,.05,.55,.95)}.c-card--video .c-card__header{width:100%;padding:0 1.25rem 1.25rem}@media (min-width:60rem){.c-card--video .c-card__header{padding:5.625rem 1.875rem;max-width:27.8125rem}}.c-card--video .c-card__tag{width:-webkit-max-content;width:-moz-max-content;width:max-content}.c-card--video .c-card__tag,.c-card--video .c-card__tag a{color:#fff;border-bottom:1px solid #d32531}.c-card--video .c-card__heading{margin-top:.625rem;margin-bottom:1em;font-size:1.125rem;letter-spacing:.53px;line-height:1;color:#fff}@media (min-width:48rem){.c-card--video .c-card__heading{font-size:1.875rem;letter-spacing:.88px}}.c-card--video .c-card__heading a{color:#fff}.c-card--video .c-card__lead{font-size:1.125rem;color:#fff;letter-spacing:.53px}@media (max-width:59.9375rem){.c-card--video .c-card__lead{display:none}}.c-card--video .c-card__badge{top:auto;left:0;bottom:0;padding:1.25rem;transform:none}@media (min-width:48rem){.c-card--video .c-card__badge{padding:2.5rem}}.c-card--video .c-card__social-bar{width:100%;max-width:20.625rem;margin-top:.625rem;margin-left:auto;margin-right:auto}@media (min-width:60rem){.c-card--video .c-card__social-bar{max-width:24.0625rem;margin-top:2.5rem;margin-left:0;margin-right:0}.c-card--video .c-card__social-bar .c-social-bar__link{width:auto}}.c-card--video--image-first{margin-top:1.25rem;width:100%}@media (min-width:60rem){.c-card--video--image-first{margin-top:2.1875rem;margin-bottom:2.5rem}}.c-card--video--image-first .c-card__image{order:-1;align-self:flex-start}@media (max-width:59.9375rem){.c-card--video--image-first .c-card__image{width:calc(100% + 2.5rem);margin:0 -1.25rem}}.c-card--video--light .c-card__image{padding:0;box-shadow:0 .25rem .3125rem 0 rgba(0,0,0,.2)}.c-card--video--light .c-card__header{padding:1.875rem 0;text-align:center}@media (min-width:60rem){.c-card--video--light .c-card__header{padding:3.125rem;text-align:left}}@media (max-width:59.9375rem){.c-card--video--light .c-card__tag{display:none}}.c-card--video--light .c-card__heading,.c-card--video--light .c-card__heading a{color:#000}.c-card--video--light .c-card__lead{color:#333}@media (max-width:47.9375rem){.c-card--video--light .c-card__badge{left:50%;bottom:50%;transform:translate(-50%,50%)}}@media (min-width:48rem){.c-card--video--light .c-card__badge{padding:1.25rem}}.c-card--video-thumb{height:100%}.c-card--video-thumb .c-card__image{position:relative;border:1px solid transparent;transition:border-color .36s cubic-bezier(.25,.46,.45,.94);margin:-1px}.c-card--video-thumb .c-card__image:after{content:attr(data-active-text);top:50%;left:50%;padding:.3125rem .625rem;transform:translate(-50%,-50%);color:#fff;font-size:.8125rem;line-height:1;white-space:nowrap;border:1px solid #d32531}.c-card--video-thumb .c-card__image:after,.c-card--video-thumb .c-card__image:before{position:absolute;z-index:100;opacity:0;transition:opacity .24s cubic-bezier(.455,.03,.515,.955)}.c-card--video-thumb .c-card__image:before{content:"";top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.7);pointer-events:none}.c-card--video-thumb .is-active .c-card__image,.c-card--video-thumb:hover .c-card__image,.is-centered .c-card--video-thumb .c-card__image{border-color:#fff}.c-card--video-thumb .is-active .c-card__image:after,.c-card--video-thumb .is-active .c-card__image:before,.is-centered .c-card--video-thumb .c-card__image:after,.is-centered .c-card--video-thumb .c-card__image:before{opacity:1}.c-card--video-thumb .c-card__wrap{height:100%}.c-card--video-thumb .c-card__heading{margin-top:.625rem;font-size:.6875rem;line-height:1;color:#fff}@media (min-width:48rem){.c-card--video-thumb .c-card__heading{font-size:.9375rem}}.c-card--video-thumb .c-card__badge{top:auto;left:0;bottom:0;padding:.625rem;transform:none;transition:opacity .24s cubic-bezier(.455,.03,.515,.955)}.c-card--video-thumb .is-active .c-card__badge,.is-centered .c-card--video-thumb .c-card__badge{opacity:0}.c-card--video-thumb--light .c-card__image:before{border:.125rem solid #d32531}.c-card--video-thumb--light .c-card__heading{color:#000}.c-cards-grid{display:-webkit-box;display:-ms-flexbox;display:flex;flex-wrap:wrap;width:calc(100% + 2.5rem);margin:0 -1.25rem}@media (max-width:47.9375rem){.c-cards-grid{padding:0 .625rem}}.c-cards-grid__item{width:50%;padding:0 1.25rem 1.25rem;margin-bottom:2.5rem}@media (max-width:47.9375rem){.c-cards-grid__item{margin-bottom:.9375rem;padding:0 .625rem 1.25rem}.c-cards-grid__item:first-of-type{width:100%}.c-cards-grid__item:last-of-type{display:none}}@media (min-width:48rem) and (max-width:59.9375rem){.c-cards-grid__item:not(:nth-of-type(odd)){border-left:1px solid #dddee4}}@media (min-width:78.75rem){.c-cards-grid__item{width:33.33333%}.c-cards-grid__item:not(:nth-of-type(3n+1)){border-left:1px solid #dddee4}}.c-close-button{position:relative;display:block;width:2.25rem;height:2.25rem;border-radius:99%;background-color:#d32531;box-shadow:0 .125rem .25rem 0 rgba(0,0,0,.2);-webkit-tap-highlight-color:transparent}@media (min-width:60rem){.c-close-button{width:3.125rem;height:3.125rem}}.c-close-button:focus,.c-close-button:hover{outline:none}.c-close-button:focus:after,.c-close-button:focus:before,.c-close-button:hover:after,.c-close-button:hover:before{transform:rotate(1turn)}.c-close-button:after,.c-close-button:before{content:"";position:absolute;top:calc(50% - 1px);left:.5rem;width:1.25rem;height:1px;transform:rotate(45deg);transition:transform .6s cubic-bezier(0,0,.2,1);background-color:#fff}@media (min-width:60rem){.c-close-button:after,.c-close-button:before{left:.6875rem;width:1.8125rem;height:.125rem}}.c-close-button:after{transform:rotate(-45deg)}.c-columnists{position:relative;padding:1.25rem;background:#fff;border:.125rem solid #d32531}@media (min-width:60rem){.c-columnists{padding:2.5rem}}.c-columnists:after,.c-columnists:before{background-color:#fff;border-bottom:1.5625rem solid #d32531;border-top:1.5625rem solid #d32531;content:"";display:block;height:100%;padding:.625rem 0;position:absolute;width:.125rem;top:0;z-index:1}@media (min-width:48rem){.c-columnists:after,.c-columnists:before{border-bottom:1.4375rem solid #d32531;border-top:1.4375rem solid #d32531}}.c-columnists:before{left:-.125rem}.c-columnists:after{right:-.125rem}.c-columnists__label{background:#fff;color:#000;font-size:2rem;height:3.0625rem;left:50%;letter-spacing:-.42px;line-height:2.375rem;padding:.25rem .8125rem;position:absolute;top:0;transform:translate(-50%,-50%);white-space:nowrap}@media (min-width:78.75rem){.c-columnists__label{font-size:2.375rem;letter-spacing:-.5px;line-height:2.875rem;padding:0 .6875rem}}.c-columnists__badge{vertical-align:text-top;letter-spacing:-.25rem;margin-right:.25rem}@media (min-width:78.75rem){.c-columnists__badge{margin-right:.5rem}}.c-columnists__badge .c-columnists__icon{fill:#d32531;height:2rem;width:2rem}@media (min-width:78.75rem){.c-columnists__badge .c-columnists__icon{width:2.5rem;height:2.5rem}}.c-columnists__list{display:-webkit-box;display:-ms-flexbox;display:flex;flex-wrap:wrap;list-style:none}.c-columnists__item{width:100%;padding:.625rem}@media (max-width:47.9375rem){.c-columnists__item{margin-bottom:1.5625rem}.c-columnists__item:last-child{margin-bottom:0}}@media (min-width:48rem){.c-columnists__item{width:33.33%}}.c-cover{display:-webkit-box;display:-ms-flexbox;display:flex;position:relative;overflow:hidden;height:100%}@media (min-width:60rem){.c-cover{padding:.625rem 0 .625rem .3125rem}}.c-cover__image{display:block;width:6.875rem;margin:.5rem;transform:rotate(6deg);box-shadow:0 .125rem .25rem 0 rgba(0,0,0,.5);transition:transform .2s cubic-bezier(.6,-.28,.74,.05)}.c-cover__image:hover{transform:rotate(6deg) translateY(-.625rem)}@media (max-width:59.9375rem){.c-cover__image{display:none}}.c-cover__cta{-ms-grid-row-align:center;align-self:center;padding:0 1.25rem;color:#d32531;font-size:1rem}.c-cover__cta:focus,.c-cover__cta:hover{color:#000}@media (max-width:59.9375rem){.c-cover__cta{font-size:.75rem;padding:.4375rem 0}}@media (min-width:60rem){.c-cover__cta--mobile{display:none}}@media (max-width:59.9375rem){.c-cover__cta--desktop{display:none}}.c-cover--mega{padding-left:0;padding-right:1.875rem}.c-cover--mega .c-cover__cta{order:-1;padding:0 .9375rem 0 0;font-size:.9375rem}.c-cover--mega .c-cover__cta:focus,.c-cover--mega .c-cover__cta:hover{color:#fff}.c-coverage{width:calc(100% + 2.5rem);margin:0 -1.25rem;padding:0 .9375rem;background-color:#0f161e}@media (min-width:48rem){.c-coverage{width:100%;margin:0 auto;padding:0 1.25rem;border-radius:.3125rem}}.c-coverage__title{display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;padding-top:.625rem;color:#fff}.c-coverage__badge{position:relative;z-index:0;margin-right:.625rem}.c-coverage__badge:before{content:"";position:absolute;top:1px;left:1px;z-index:-100;display:block;width:2.3125rem;height:2.375rem;border-radius:50%;background-color:#fff}.c-coverage__icon{display:block;width:2.5rem;height:2.5rem;fill:#d32531}.c-crop{position:relative;overflow:hidden;width:100%;margin:0;padding:0;background-color:rgba(0,0,0,.05)}.c-crop:after{content:"";display:block;width:100%;padding-bottom:75%}.c-crop__img{width:100%;height:100%;object-fit:cover;position:absolute;object-position:0 top;top:50%;left:50%;width:calc(100% + .125rem);max-width:calc(100% + .125rem);height:calc(100% + .125rem);transform:translate(-50%,-50%)}.c-crop--ratio-2x3:after{padding-bottom:150%}.c-crop--ratio-11x14:after{padding-bottom:127.27273%}.c-crop--ratio-5x6:after{padding-bottom:120%}.c-crop--ratio-1x1:after{padding-bottom:100%}.c-crop--ratio-4x3:after{padding-bottom:75%}.c-crop--ratio-3x2:after{padding-bottom:66.66667%}.c-crop--ratio-7x4:after{padding-bottom:57.14286%}.c-crop--ratio-video:after{padding-bottom:56.19632%}.c-crop--ratio-2x1:after{padding-bottom:50%}.c-crop--size-related:after{padding-bottom:100%}@media (min-width:48rem){.c-crop--size-related:after{padding-bottom:65.78947%}}.c-crop--size-featured:after{padding-bottom:50%}@media (min-width:78.75rem){.c-crop--size-featured:after{padding-bottom:66.66667%}}.c-crop--size-featured-home:after{padding-bottom:100%}@media (min-width:60rem) and (max-width:68.75rem){.c-crop--size-featured-home:after{padding-bottom:63.04348%}}@media (min-width:68.75rem){.c-crop--size-featured-home:after{padding-bottom:100%}}.c-crop--size-features-main:after{padding-bottom:69.33333%}@media (max-width:51.25rem){.c-crop--size-features-main:after{padding-bottom:66%}}@media (max-width:47.9375rem){.c-crop--size-domino:after{padding-bottom:100%}}.c-crop--video .player-container{width:auto;height:auto}.c-crop--video.c-crop--landscape .c-crop__img{height:calc(100% + .125rem)}.c-crop [id^=jwplayer_][id*=_div],.c-crop iframe,.c-crop video{position:absolute}.c-crop iframe[data-src*=youtu]{width:100%;height:100%}.c-crop .player-minimize [id^=jwplayer_][id*=_div],.c-crop .player-minimize iframe,.c-crop .player-minimize video{position:relative}.c-features{width:100%;background-image:-webkit-gradient(linear,left top,left bottom,from(#f4f4f7),to(#f4f4f7));background-image:linear-gradient(#f4f4f7,#f4f4f7)}@media (max-width:51.1875rem){.c-features{width:calc(100% + 2.5rem);margin-left:-1.25rem;flex-wrap:wrap;padding-top:2em;padding-bottom:1em}}@media (min-width:51.25rem){.c-features{background-position-x:13.125rem;background-repeat:no-repeat}}@media (min-width:48rem) and (max-width:78.6875rem){.c-features:after{content:"";position:absolute;top:0;right:0;z-index:100;height:100%;width:5.625rem;background-image:-webkit-gradient(linear,left top,right top,from(rgba(244,244,247,0)),to(#f4f4f7));background-image:linear-gradient(90deg,rgba(244,244,247,0),#f4f4f7);pointer-events:none}}.c-features__main{position:relative;z-index:100}@media (min-width:51.25rem){.c-features__main{margin-right:.3125rem}}.c-features__main-wrap{position:relative;z-index:0;display:block;color:#fff}.c-features__main-image{position:relative;z-index:0;display:block;width:calc(100vw - 2em);max-height:18.3125rem;margin-bottom:1em}.c-features__main-image .c-crop:before{content:"";position:absolute;top:0;left:0;z-index:1;width:100%;height:100%;background-image:-webkit-gradient(linear,left top,left bottom,color-stop(44%,rgba(15,22,30,0)),to(#0f161e));background-image:linear-gradient(180deg,rgba(15,22,30,0) 44%,#0f161e)}@media (min-width:51.25rem){.c-features__main-image{margin-top:1em;max-width:31.25rem}}.c-features__main-image .c-crop--size-features-main{max-height:18em}.c-features__tag{position:absolute;top:0;z-index:100;padding:.3125rem .625rem;transform:translateY(calc(-2em - 50%));font-size:1rem;letter-spacing:.55px;background-color:#d32531}@media (min-width:51.25rem){.c-features__tag{transform:translateY(-1em) translateX(1em)}}.c-features__main-header{position:absolute;bottom:0;left:0;z-index:10000;width:100%;padding:.625rem 1.25rem;transition:transform .3s ease-out}@media (min-width:51.25rem){.c-features__main-header{padding:1.875rem}}.c-features__main-headline{font-size:1.5625rem;letter-spacing:-.5px;line-height:1.875rem}.c-features__main-lead{font-family:Graphik,sans-serif;font-size:1rem;line-height:1.1875rem;padding-bottom:.1875rem}.fonts-loading .c-features__main-lead{font-family:Graphik Bold Subset,Graphik,Tahoma,Verdana,Segoe,sans-serif;font-weight:700;font-style:normal;font-display:swap}.c-features__slider{position:relative;padding:.9375rem 0;margin-left:.9375rem}@media (min-width:51.25rem){.c-features__slider{width:100%}}.c-features__item{width:15.5rem;padding-right:1em}@media (max-width:51.1875rem){.c-features__item:first-child{margin-left:0}}.c-features__item-wrap{position:relative;display:block;color:#fff;overflow:hidden}.c-features__item-wrap:before{content:"";position:absolute;top:50%;z-index:100;height:100%;width:100%;background-image:-webkit-gradient(linear,left top,left bottom,from(rgba(15,22,30,0)),to(#0f161e));background-image:linear-gradient(-180deg,rgba(15,22,30,0),#0f161e);transition:transform .3s ease-out}.c-features__item-wrap:focus:before,.c-features__item-wrap:hover:before{transform:translateY(-30%)}.c-features__item-header{position:absolute;bottom:0;z-index:100;width:100%;padding:1.25rem 1.875rem}.c-features__item-headline{font-size:1.09188rem;text-align:center;line-height:1.3125rem;transition:transform .3s ease-out;font-weight:700}@media (min-width:78.75rem){.c-features .c-slider__nav{display:none}}.c-form__group{display:-webkit-box;display:-ms-flexbox;display:flex}.c-form__field{flex-grow:1}.c-form__input{height:2.5rem;width:100%;padding:0 .9375rem;font-size:.9375rem;color:#000}.c-form__input::-webkit-input-placeholder{color:#909090}.c-form__input:-ms-input-placeholder,.c-form__input::-ms-input-placeholder{color:#909090}.c-form__input::-moz-placeholder{color:#909090}.c-form__input::placeholder{color:#909090}.c-form__input:focus{outline:none}.c-form__button{flex-shrink:0;padding:0 1.25rem;font-size:.75rem;letter-spacing:.05em;color:#fff;background-color:#000;transition:background-color .24s cubic-bezier(.215,.61,.355,1)}.c-form__button:focus,.c-form__button:hover{background-color:rgba(0,0,0,.7)}.c-form--faded .c-form__input{border-radius:.3125rem 0 0 .3125rem;box-shadow:inset 0 .1875rem .5rem 0 rgba(0,0,0,.5)}.c-form--faded .c-form__button{border-radius:0 .3125rem .3125rem 0;color:#fff;background-color:#d32531}.c-form--footer .c-form__input{font-size:.875rem}.c-form--footer .c-form__button{width:25%;margin-left:1.5rem;font-size:.6875rem;background-color:#d32531}.c-galleries{width:100%}@media (max-width:47.9375rem){.c-galleries__slider{padding-bottom:1.875rem;margin-bottom:-.625rem}}.c-galleries__item:not(:last-of-type){padding-right:1.25rem}@media (min-width:78.75rem){.c-galleries__item:not(:last-of-type){padding-right:3.75rem}}.c-gallery-card{width:47.5rem;max-width:60vw;overflow:hidden}.c-gallery-card__wrap{position:relative;display:block;color:#000}@media (min-width:48rem){.c-gallery-card__wrap{color:#fff}}.c-gallery-card__image{position:relative;z-index:0}.c-gallery-card__image:before{content:"";position:absolute;top:0;left:0;z-index:1;width:100%;height:100%;background-image:linear-gradient(-117deg,rgba(15,22,30,0) 44%,#0f161e)}.c-gallery-card__badge{position:absolute;bottom:.625rem;left:.625rem;z-index:1}@media (min-width:48rem){.c-gallery-card__badge{top:1.875rem;left:1.875rem}}@media (min-width:48rem){.c-gallery-card__header{position:absolute;bottom:0;left:0;width:100%;padding:1.875rem}}.c-gallery-card__headline{font-size:1.125rem;line-height:1;margin-top:.625rem;margin-bottom:.625rem}@media (min-width:60rem){.c-gallery-card__headline{font-size:1.875rem}}.c-gallery-card__lead{font-size:.75rem;line-height:1.2}@media (min-width:60rem){.c-gallery-card__lead{font-size:1.125rem}}@media (min-width:48rem){.c-gallery-card__headline,.c-gallery-card__lead{padding-right:12.5rem}}.c-gallery-card__thumbs{position:absolute;bottom:1.875rem;right:-4.375rem;display:-webkit-box;display:-ms-flexbox;display:flex;justify-content:space-between;width:17.5rem;transition:transform .24s cubic-bezier(.215,.61,.355,1)}@media (max-width:47.9375rem){.c-gallery-card__thumbs{display:none}}.c-gallery-card:hover .c-gallery-card__thumbs{transform:translateX(-1.25rem)}.c-gallery-card__thumb{width:5.625rem}.c-hamburger{padding:0 .9375rem;color:#000;transition:color .24s cubic-bezier(.215,.61,.355,1)}@media (min-width:60rem){.c-hamburger{padding:.1875rem .625rem}.is-header-sticky .c-hamburger{padding:.625rem;font-size:.875rem;color:#d32531}.is-header-sticky .c-hamburger:focus,.is-header-sticky .c-hamburger:hover{color:#000}}.c-hamburger:focus,.c-hamburger:hover{color:#d32531;outline:none}.c-hamburger__icon{display:block;fill:currentColor;width:1.375rem;height:1.375rem}@media (min-width:60rem){.c-hamburger__icon{width:1.25rem;height:1.0625rem}}.c-hamburger__label{margin-left:.3125rem}@media (max-width:59.9375rem){.c-hamburger__label{display:none}}.is-header-sticky .c-hamburger--sticky-collapsed .c-hamburger__label{display:none}.c-icon{padding:.3125rem;line-height:0}.c-icon svg{width:.9375rem;height:.9375rem;fill:#000}.c-icon--white svg{fill:#fff}.c-icon--large svg{width:1.125rem;height:1.125rem}.c-icon--inline{display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex;vertical-align:middle}.c-icon--round{width:1.5rem;height:1.5rem;border-radius:99%}.c-icon--inverted{background-color:#fff;transition:background-color .24s cubic-bezier(.215,.61,.355,1)}.c-icon--inverted svg{fill:#000}.c-icon--twitter svg{fill:#1dadeb}.c-icon--rs-pro{padding:0 .3125rem 0 0}.c-icon--rs-pro svg{width:1.3125rem;height:1.3125rem;fill:#d32531}@media (min-width:60rem){.c-latest-list{display:-webkit-box;display:-ms-flexbox;display:flex;flex-direction:column;height:39.6875rem;justify-content:space-between}}@media (max-width:59.9375rem){.c-latest-list{text-align:right;height:auto}}@media (min-width:78.75rem){.c-latest-list{height:41rem}}.c-latest-list__header{margin-top:1.875rem;margin-bottom:.625rem;text-align:left}@media (min-width:60rem){.c-latest-list__header{margin-top:0;margin-bottom:1.25rem;background-color:#d32531}}@media (min-width:78.75rem){.c-latest-list__header{margin-bottom:2.5rem}}.c-latest-list__heading{font-size:1.625rem;line-height:1.625rem;color:#d32531}@media (min-width:60rem){.c-latest-list__heading{color:#fff;font-size:2.1875rem;line-height:1.875rem;width:3rem;letter-spacing:0}}.c-latest-list__item{text-align:left;padding-bottom:1.875rem}@media (min-width:60rem){.c-latest-list__item{margin-bottom:0;padding-bottom:0}}@media (max-width:59.9375rem){.c-latest-list__item{margin-bottom:.9375rem;padding-bottom:.9375rem}}.c-latest-list__cta{font-size:.75rem;color:#d32531;letter-spacing:1px}.c-latest-list__line{color:#d32531;display:block;height:1px;border:0;border-top:1px solid #dddee4;margin:1rem 0;padding:0}.c-mega-nav{border-top:1px solid #303030}@media (min-width:60rem){.c-mega-nav{display:-webkit-box;display:-ms-flexbox;display:flex;flex-flow:row wrap;align-items:flex-start;border-top:none}}.c-mega-nav,.c-mega-nav__submenu{list-style:none}.c-mega-nav__submenu{flex:0 0 auto;width:100%;box-shadow:0 -1px 1px 0 rgba(0,0,0,.5)}.c-mega-nav__item{display:-webkit-box;display:-ms-flexbox;display:flex;justify-content:space-between;overflow:hidden}@media (max-width:59.9375rem){.c-mega-nav__item{flex-flow:row wrap;border-bottom:1px solid #303030;background-color:#000;transition:background-color .24s cubic-bezier(.215,.61,.355,1)}.c-mega-nav__item[data-collapsible=expanded]:not(.c-mega-nav__item--sub){background-color:#d32531}}@media (min-width:60rem){.c-mega-nav__item{flex:0 0 auto;width:33.33333%;flex-flow:column nowrap;padding:1.25rem .9375rem}}.c-mega-nav__item--sub{display:block}@media (max-width:59.9375rem){.c-mega-nav__item--sub{border-bottom-color:#dddee4;background-color:#fff}}@media (min-width:60rem){.c-mega-nav__item--sub{width:100%;padding:0}}.c-mega-nav__link{flex:1 1 auto;width:calc(100% - 3.4375rem);padding:.8125rem 1.25rem;display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;font-size:1.25rem;color:#fff}@media (min-width:60rem){.c-mega-nav__link{position:relative;width:100%;margin-bottom:.3125rem;padding:0 0 .625rem;font-size:1.75rem}}@media (min-width:60rem){.c-mega-nav__link:before{content:"";position:absolute;bottom:0;left:0;width:100%;height:1px;background-image:-webkit-gradient(linear,left top,right top,from(#d32531),to(rgba(211,37,49,0)));background-image:linear-gradient(90deg,#d32531,rgba(211,37,49,0))}}.c-mega-nav__link--sub{width:100%;padding-left:2.1875rem;font-size:.9375rem;color:#000}@media (min-width:60rem){.c-mega-nav__link--sub{font-family:Helvetica,Arial,sans-serif;margin:0;padding:0;font-size:.9375rem;font-weight:400;color:#dddee4}}.c-mega-nav__link--sub:focus,.c-mega-nav__link--sub:hover{color:#d32531}@media (min-width:60rem){.c-mega-nav__link--sub:before{content:none}}.c-mega-nav__expander{position:relative;flex:0 0 auto;width:3.4375rem;height:3.125rem}@media (min-width:60rem){.c-mega-nav__expander{display:none}}.c-mega-nav__expander-icon{display:block}.c-mega-nav__expander-icon:after,.c-mega-nav__expander-icon:before{content:"";position:absolute;z-index:1;width:1rem;height:1px;top:50%;left:50%;margin-left:-.5rem;background-color:#fff;transition:transform .6s cubic-bezier(0,0,.2,1)}[data-collapsible=expanded] .c-mega-nav__expander-icon:after,[data-collapsible=expanded] .c-mega-nav__expander-icon:before{transform:rotate(540deg)}.c-mega-nav__expander-icon:after{transform:rotate(90deg)}.c-newswire{display:-webkit-box;display:-ms-flexbox;display:flex;flex-wrap:wrap;width:calc(100% + 1.25rem);margin:.625rem -.625rem -2.5rem;list-style:none}@media (max-width:47.9375rem){.c-newswire{padding:0 .3125rem}}.c-newswire__item{display:-webkit-box;display:-ms-flexbox;display:flex;width:50%;padding:0 .625rem .625rem}@media (max-width:47.9375rem){.c-newswire__item{margin-bottom:.9375rem}}@media (max-width:47.9375rem){.c-newswire__item:first-child{width:100%}}@media (min-width:60rem){.c-newswire__item{width:20%;padding:0 .625rem 2.5rem}}.c-newswire--dark{margin-bottom:0}.c-newswire--dark .c-newswire__item{padding:.3125rem .9375rem 1.25rem}@media (max-width:59.9375rem){.c-newswire--tablet-scroller{width:calc(100% + 3.125rem);margin:.625rem -1.25rem -2.5rem;padding:0 .625rem;flex-wrap:nowrap;overflow-y:auto;-webkit-overflow-scrolling:touch}.c-newswire--tablet-scroller .c-newswire__item{width:25%;padding:0 .625rem 2.5rem;min-width:13.75rem}}.c-page-nav{position:relative;height:2.75rem;color:#fff}@media (min-width:48rem){.c-page-nav{height:auto}}@media (max-width:47.9375rem){.c-page-nav{overflow:hidden}.c-page-nav.is-expanded{overflow:visible}}.c-page-nav__list{position:absolute;z-index:1;display:-webkit-box;display:-ms-flexbox;display:flex;flex-flow:column nowrap;width:100%;list-style:none;color:#fff}@media (min-width:48rem){.c-page-nav__list{position:relative;flex-direction:row;justify-content:center}}@media (max-width:47.9375rem){.c-page-nav__item{position:relative;overflow:hidden;display:block;margin-top:.3125rem;transform:translateY(100%);opacity:0;visibility:hidden;transition:transform 0ms linear 225ms,opacity 225ms cubic-bezier(.4,0,.2,1),visibility 225ms cubic-bezier(.4,0,.2,1);color:#fff}.c-page-nav__item.is-active{order:-1;visibility:visible;transform:none;opacity:1;margin-top:0}.c-page-nav__item.is-visible{transform:none;opacity:1;visibility:visible;transition:transform 225ms cubic-bezier(.4,0,.2,1),opacity 225ms cubic-bezier(.4,0,.2,1),visibility 225ms cubic-bezier(.4,0,.2,1)}}.c-page-nav__link{position:relative;z-index:1;display:block;padding:.625rem .9375rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:#fff}@media (min-width:48rem){.c-page-nav__link{padding:0 .9375rem}}@media (min-width:48rem){.c-page-nav--1-column .c-page-nav__list{flex-flow:column nowrap}}@media (min-width:48rem){.c-page-nav--2-columns .c-page-nav__list{flex-flow:row wrap}}@media (min-width:48rem){.c-page-nav--2-columns .c-page-nav__item{width:50%}}@media (max-width:47.9375rem){.c-page-nav__list:after{content:"";position:absolute;width:.75rem;height:.75rem;top:1.375rem;right:.9375rem;transform:scaleY(.85) translate(-50%,-75%) rotate(45deg);border:.125rem solid;border-left:none;border-top:none;transition:transform 225ms cubic-bezier(.4,0,.2,1)}.c-page-nav.is-expanded .c-page-nav__list:after{transform:scaleY(-.85) translate(-50%,25%) rotate(45deg)}}.c-page-nav--footer{overflow:hidden;border:1px solid #6f6f6f;transition:height 375ms cubic-bezier(.4,0,.2,1)}@media (min-width:48rem){.c-page-nav--footer{border:none}}.c-page-nav--footer .c-page-nav__list{position:relative;justify-content:flex-start}.c-page-nav--footer .c-page-nav__list:after{right:1.5625rem}@media (min-width:48rem){.c-page-nav--footer .c-page-nav__item{font-size:.875rem}.c-page-nav--footer .c-page-nav__item--heading{width:100%;padding-bottom:.5rem;font-size:1.1875rem}}@media (max-width:47.9375rem){.c-page-nav--footer .c-page-nav__link{min-height:2.875rem;padding-left:1.5625rem}}@media (min-width:48rem){.c-page-nav--footer .c-page-nav__link{padding:.1875rem 0}}@media (min-width:48rem){.c-page-nav--footer.c-page-nav--cta .c-page-nav__item:not(.c-page-nav__item--heading) .c-page-nav__link{margin-bottom:1.25rem;padding:.875rem 1.25rem;border:1px solid;font-size:.6875rem;line-height:.8125rem;font-weight:700;text-align:center}}.c-page-nav--footer a.c-page-nav__link:focus,.c-page-nav--footer a.c-page-nav__link:hover{color:#d32531}.c-page-nav--footer .c-page-nav__icon{margin-right:.75rem}.c-page-nav--footer .c-page-nav__link:hover .c-page-nav__icon{background-color:#d32531}.c-play-btn{display:block;width:2.25rem;height:2.25rem}@media (min-width:48rem){.c-play-btn{width:3.4375rem;height:3.4375rem}}.c-play-btn--medium{width:2.25rem;height:2.25rem}@media (min-width:48rem){.c-play-btn--medium{width:2.6875rem;height:2.6875rem}}.c-play-btn--small{width:1.875rem;height:1.875rem}@media (min-width:48rem){.c-play-btn--small{width:2.25rem;height:2.25rem}}.c-play-btn:not(:root){overflow:visible}.c-play-btn__icon{fill:#fff}.c-play-btn--clock{width:3.125rem;height:3.125rem}@media (min-width:48rem){.c-play-btn--clock{width:4.375rem;height:4.375rem}}.c-play-btn--big-clock{width:4.0625rem;height:4.0625rem}@media (min-width:48rem){.c-play-btn--big-clock{width:4.875rem;height:4.875rem}}.c-play-btn--clock .c-play-btn__fill{fill:rgba(0,0,0,.7)}.c-play-btn--clock .c-play-btn__border,.c-play-btn--thumb .c-play-btn__border{transform:rotate(-90deg);transform-origin:center;stroke:hsla(0,0%,100%,0);transition:stroke-dashoffset .5s cubic-bezier(.445,.05,.55,.95),stroke .5s cubic-bezier(.445,.05,.55,.95)}.c-play-btn--clock:hover .c-play-btn__border,.c-play-btn--thumb:hover .c-play-btn__border{stroke-dashoffset:0;stroke:#fff;transition:stroke-dashoffset .5s cubic-bezier(.445,.05,.55,.95),stroke .2s cubic-bezier(.445,.05,.55,.95)}.c-pmc-footer{font-family:Graphik,sans-serif;width:100%;background:#fff;padding-top:.625rem;padding-bottom:.625rem}.fonts-loading .c-pmc-footer{font-family:Graphik Bold Subset,Graphik,Tahoma,Verdana,Segoe,sans-serif;font-weight:700;font-style:normal;font-display:swap}.c-pmc-footer .c-page-nav__item,.c-pmc-footer .c-page-nav__link,.c-pmc-footer .c-page-nav__list:after{color:#000}.c-pmc-footer__wrap{margin:0 auto;padding-left:1.25rem;padding-right:1.25rem;width:100%;min-width:20rem;max-width:81.25rem;display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center}@media (max-width:47.9375rem){.c-pmc-footer__wrap{padding:.9375rem;flex-direction:column}}.c-pmc-footer__logo,.c-pmc-footer__logo a{display:-webkit-box;display:-ms-flexbox;display:flex}.c-pmc-footer__logo a svg{width:8.1875rem;height:1.5625rem}.c-pmc-footer__legal{color:#7b7b7b;font-weight:500;font-size:.6875rem;line-height:.8125rem;margin-left:1.875rem}@media (max-width:47.9375rem){.c-pmc-footer__legal{margin:.9375rem 0 0;text-align:center}}.c-pmc-footer__dropdown{margin-left:auto;margin-top:.3125rem;margin-bottom:.3125rem;position:relative;width:12.5rem;color:#000;font-size:.6875rem;text-align:left;font-weight:700}@media (max-width:47.9375rem){.c-pmc-footer__dropdown{margin-right:auto;margin-top:.9375rem;text-align:center;display:none}}.c-pmc-footer__dropdown ul{list-style:none;border:none;box-shadow:0 -.3125rem .3125rem rgba(0,0,0,.15)}.c-pmc-footer__dropdown:focus-within .c-pmc-footer__dropdown-contents,.c-pmc-footer__dropdown:hover .c-pmc-footer__dropdown-contents{visibility:visible;opacity:1;transition:opacity 225ms cubic-bezier(.4,0,.2,1)}.c-pmc-footer__dropdown:focus-within .c-pmc-footer__dropdown-trigger:after,.c-pmc-footer__dropdown:hover .c-pmc-footer__dropdown-trigger:after{transform:scaleY(-.85) translate(-50%,25%) rotate(45deg)}.c-pmc-footer__dropdown-trigger{height:1.875rem;display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;padding-left:.625rem;cursor:pointer;border:1px solid #dddee4}@media (min-width:48rem){.c-pmc-footer__dropdown-trigger:after{content:"";position:absolute;width:.75rem;height:.75rem;top:41%;right:.9375rem;transform:scaleY(.85) translate(-50%,-75%) rotate(45deg);border:.125rem solid;border-left:none;border-top:none;transition:transform 225ms cubic-bezier(.4,0,.2,1)}}.c-pmc-footer__dropdown-contents{visibility:hidden;opacity:0;position:absolute;bottom:1.875rem;width:100%;z-index:1000;background-color:#fff;max-height:9.375rem;overflow-y:scroll}.c-pmc-footer__brand{display:-webkit-box;display:-ms-flexbox;display:flex;padding-left:.625rem;color:#000;transition:background-color 225ms cubic-bezier(.4,0,.2,1),color 225ms cubic-bezier(.4,0,.2,1)}.c-pmc-footer__brand:hover{background:#d32531;color:#fff}@media (min-width:48rem){.c-pmc-footer--mobile{display:none}}.c-rating{display:-webkit-inline-box;display:-ms-inline-flexbox;display:inline-flex;align-items:center;justify-content:space-between;width:8.75rem}.c-rating.c-rating--4-stars{width:7rem}.c-rating__star{position:relative;width:.9375rem;height:.9375rem}.c-rating__star use{fill:#808baa}.c-rating__star--active use:last-child{fill:#d32531}.c-reviews{position:relative;background:#f4f4f7;border-radius:.3125rem}@media (max-width:59.9375rem){.c-reviews{width:calc(100% + 2.5rem);margin-left:-1.25rem;border-radius:0}}.c-reviews__label{position:absolute;top:0;left:1.25rem;transform:translateY(-50%);background:#fff;border:.25rem solid #d32531;padding:.625rem;font-size:1rem;line-height:1}@media (min-width:60rem){.c-reviews__label{left:2.1875rem}}.c-reviews__label-head{color:#d32531}.c-reviews__list{display:-webkit-box;display:-ms-flexbox;display:flex;justify-content:space-between;width:100%;padding:2.8125rem 1.25rem 1.875rem;overflow-x:auto;list-style:none;-webkit-overflow-scrolling:touch}@media (min-width:60rem){.c-reviews__list{padding:3.75rem 2.1875rem 2.5rem}}.c-reviews__item{width:100%}@media (max-width:59.9375rem){.c-reviews__item{min-width:14.0625rem;padding:.9375rem .9375rem .625rem;margin-right:.9375rem;background-color:#fff;border:1px solid #dddee4;border-radius:.625rem}}@media (min-width:60rem){.c-reviews__item{max-width:12.5rem}}@media (min-width:78.75rem){html:not(.has-side-skins) .c-reviews__item{max-width:14.0625rem}}.c-reviews-card{text-align:center;display:-webkit-box;display:-ms-flexbox;display:flex;height:100%}.c-reviews-card__wrap{position:relative;display:block;padding-bottom:2.5rem;color:#000;will-change:transform}.c-reviews-card__image{transition:opacity .24s cubic-bezier(.455,.03,.515,.955);margin:0 auto}.c-reviews-card__image--book{max-width:10.9375rem}.c-reviews-card__image:after{display:none}.c-reviews-card:focus .c-reviews-card__image,.c-reviews-card:hover .c-reviews-card__image{opacity:.8}.c-reviews-card__crop{box-shadow:0 .125rem .25rem 0 rgba(0,0,0,.23);border-radius:.3125rem;overflow:hidden}.c-reviews-card__rating{margin-top:.9375rem}.c-reviews-card__headline{margin-top:.3125rem;font-weight:700;font-size:1.5rem;line-height:1.6875rem}.c-reviews-card__headline .t-copy{font-family:Publico Bold Subset,Publico,Times,Times New Roman,serif}.c-reviews-card__subheadline{margin-top:.3125rem;font-size:.63438rem;letter-spacing:1.45px}.c-reviews-card__lead{margin-top:.625rem auto 0 auto;font-size:.9375rem;line-height:1.25rem;max-width:13.4375rem}.c-reviews-card__cta{position:absolute;bottom:.625rem;left:0;right:0;margin:auto;width:-webkit-fit-content;width:-moz-fit-content;width:fit-content;font-size:.63438rem;letter-spacing:1.45px;color:#d32531}.c-reviews-card__cta:after{content:"";width:100%;height:1px;background-color:#d32531;display:block;position:absolute;transition:.15s ease-in;opacity:0;transform:scaleX(0)}.c-reviews-card__cta:hover:after{opacity:1;transform:scaleX(1)}.c-section-header{position:relative;justify-content:flex-start;padding:.25rem 0;border-top:.25rem solid #d32531}.c-section-header--dark{padding-top:.75rem;background-color:#0f161e}.c-section-header--country{border-top-color:#7a592d}.c-section-header,.c-section-header__btn,.c-section-header__heading{display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;color:#000}.c-section-header--dark .c-section-header__heading{padding-left:1.25rem;color:#fff}.c-section-header__heading{font-size:1.75rem;line-height:1.1}@media (min-width:48rem){.c-section-header__heading{font-size:2.8125rem}}.c-section-header__icon{height:1em;width:1em;margin-right:.625rem;fill:#d32531}.c-section-header__cta{padding-left:.625rem;font-size:.625rem;line-height:.75rem;color:#d32531}@media (min-width:48rem){.c-section-header__cta{padding-left:1.25rem}}.c-section-header__cta:hover{color:#000}.c-section-header--dark .c-section-header__cta:hover{color:#d32531}.c-section-header__msg{display:none;margin-left:auto;font-family:Arial,Helvetica,sans-serif;font-size:.75rem;line-height:1.2;text-align:right;color:#7b7c84;opacity:0;transform:translateY(.625rem);transition:opacity .24s cubic-bezier(.455,.03,.515,.955),transform .24s cubic-bezier(.455,.03,.515,.955)}@media (min-width:48rem){.l-section.is-closing .c-section-header__msg{display:block}.l-section.is-closed .c-section-header__msg{transform:translateY(0);opacity:1}}.c-section-header__btn{margin-left:auto;padding:.4375rem .625rem;font-size:.625rem;line-height:1;letter-spacing:1px;color:#7b7c84;border:1px solid #7b7c84;border-radius:.9375rem;transition:opacity .24s cubic-bezier(.215,.61,.355,1)}.c-section-header__btn:hover{opacity:.8}.l-section.is-closed .c-section-header__btn{margin-left:1.25rem}@media (max-width:47.9375rem){.c-section-header__btn{display:none}}.c-section-header__btn-arrow{width:.4375rem;height:.25rem;margin-left:.3125rem;transform-origin:center;fill:#7b7c84;transition:transform .24s cubic-bezier(.215,.61,.355,1)}.l-section.is-closed .c-section-header__btn-arrow{transform:scale(-1)}.c-section-header__show{display:none}.c-section-header__hide,.l-section.is-closed .c-section-header__show{display:inline}.l-section.is-closed .c-section-header__hide{display:none}.c-section-header__powerby{position:absolute;right:0;width:6.25rem;letter-spacing:1px;color:#6c6c6c;font-size:.5625rem;font-family:Helvetica Neue;text-align:center;text-transform:uppercase}@media (max-width:47.9375rem){.c-section-header__powerby{width:auto}}@media (max-width:47.9375rem){.c-section-header__powerby--text{display:inline-block;vertical-align:middle;margin-right:.3125rem}}.c-section-header__powerby--logo{height:.875rem;width:6.25rem}@media (max-width:47.9375rem){.c-section-header__powerby--logo{display:inline-block;vertical-align:middle}}.c-slider{position:relative;width:100%;overflow-x:scroll;-webkit-overflow-scrolling:touch}@media (min-width:48rem){.c-slider{overflow-x:hidden}}.c-slider__nav{position:absolute;top:0;left:0;height:100%;padding:1.25rem;z-index:1000;opacity:0;transition:opacity .24s cubic-bezier(.455,.03,.515,.955)}.c-slider__nav:before{content:"";position:absolute;top:50%;transform:translateY(-50%);width:2.5rem;height:2.5rem;background-color:#fff}.c-slider__nav--right{left:auto;right:0;transform:rotate(180deg)}.c-slider__nav.is-hidden{opacity:0}@media (max-width:47.9375rem){.c-slider__nav{display:none}}.c-slider:hover .c-slider__nav{opacity:1}.c-slider__icon{position:relative;width:.875rem;height:.875rem;fill:#d32531;transform-origin:center;transform:rotate(90deg)}.c-slider__track{display:-webkit-box;display:-ms-flexbox;display:flex;transition:transform .24s cubic-bezier(.215,.61,.355,1);will-change:transform}.c-slider__item{flex-shrink:0}.c-social-bar{display:-webkit-box;display:-ms-flexbox;display:flex;list-style:none}.c-social-bar__item{flex:1 1 auto}.c-social-bar__link{background-color:#333;transition:opacity .24s cubic-bezier(.215,.61,.355,1)}.c-social-bar__link:focus,.c-social-bar__link:hover{opacity:.8}.c-social-bar__link[href*="facebook.com"]{background-color:#3e5b96}.c-social-bar__link[href*="twitter.com"]{background-color:#1dadeb}.c-social-bar__link[href*="pinterest.com"]{background-color:#ed5755}.c-social-bar__link[href*="tumblr.com"]{background-color:#284053}.c-social-bar__link[href*="reddit.com"]{background-color:#ff4500}.c-social-bar__link[href*="linkedin.com"]{background-color:#0077b5}.c-social-bar__link[data-action*=whatsapp],.c-social-bar__link[href*="whatsapp.com"]{background-color:#23c100}.c-social-bar__link--show-more{background-color:#3c8314}.c-social-bar--small .c-social-bar__item+.c-social-bar__item{margin-left:.5rem}.c-social-bar--small .c-social-bar__link{width:2.1875rem;height:1.5625rem}.c-social-bar--round .c-social-bar__item+.c-social-bar__item{margin-left:.4375rem}.c-social-bar--round .c-social-bar__link{width:2.375rem;height:2.375rem;border:1px solid #333;border-radius:99%;background-color:transparent}.c-sticky #adm-right-rail-sticky-ad,.c-sticky__item{position:-webkit-sticky;position:sticky;top:1.25rem;transition:top .24s cubic-bezier(.215,.61,.355,1);will-change:top}.is-header-sticky .c-sticky #adm-right-rail-sticky-ad,.is-header-sticky .c-sticky__item{top:4.0625rem}@supports ((position:-webkit-sticky) or (position:sticky)){@media (min-width:60rem){.c-sticky--size-screen-height{height:100vh}}}.c-sticky--size-grow{flex-grow:1}.c-subscribe{justify-content:space-between}.c-subscribe,.c-subscribe__block--get-magazine,.c-subscribe__description,.c-subscribe__form{display:-webkit-box;display:-ms-flexbox;display:flex;position:relative;z-index:1}.c-subscribe__block{position:relative;overflow:hidden;width:calc(50% - .625rem);padding:1.6875rem 1.875rem;border-radius:.3125rem;color:#fff;background-color:#0f161e;box-shadow:0 .125rem .25rem 0 rgba(0,0,0,.2)}.c-subscribe__block--get-magazine{justify-content:center;background:transparent no-repeat 50%;background-size:cover;background-color:#f0ece7;color:#000}.c-subscribe__cover{position:relative;z-index:1;flex:0 0 auto;width:11.5rem;margin-right:1.875rem}.c-subscribe__cover img{display:block}.c-subscribe__description,.c-subscribe__form{flex-flow:column nowrap;align-items:start}.c-subscribe__description{margin:0 auto;max-width:25rem;font-size:.9375rem;line-height:1.45}.c-subscribe__block--get-magazine .c-subscribe__description{width:calc(100% - 13.4375rem)}.c-subscribe__heading{font-size:1.75rem;line-height:1.25;margin-bottom:.625rem}.c-subscribe__important{flex-grow:1;font-size:1rem;line-height:1.25}.c-subscribe__content{margin-bottom:1.25rem}.c-subscribe__form{width:100%;flex-grow:1;justify-content:flex-end}.c-subscribe__input{font-family:Helvetica,Arial,sans-serif;width:100%;padding:.875rem 1.375rem;box-shadow:inset 0 1px .1875rem 0 rgba(0,0,0,.5);font-size:1rem}.c-subscribe__button{align-self:flex-start;min-width:11.9375rem;margin-top:1.875rem;padding:.625rem;font-size:.6875rem;text-align:center;color:#fff;transition:background-color .24s cubic-bezier(.215,.61,.355,1)}.c-subscribe__button--subscribe{background-color:#d32531}.c-subscribe__button--subscribe:focus,.c-subscribe__button--subscribe:hover{background-color:#a91e27}.c-subscribe__button--newsletter{background-color:#d32531}.c-subscribe__button--newsletter:focus,.c-subscribe__button--newsletter:hover{background-color:#a91e27}.c-subscribe__x{position:absolute;right:1.625rem;font-size:.6875rem;cursor:pointer;padding:0;top:.625rem;width:1.25rem;height:1.25rem}.c-subscribe__x:focus,.c-subscribe__x:hover{color:#d32531}.c-testimonial{flex-direction:column;height:100%}.c-testimonial,.c-testimonial__header{display:-webkit-box;display:-ms-flexbox;display:flex}.c-testimonial__header{align-items:center;border-bottom:1px solid #737373;padding-bottom:.5rem;position:relative}@media (min-width:48rem){.c-testimonial__header{padding-bottom:1.25rem}}.c-testimonial__header:after,.c-testimonial__header:before{content:"";position:absolute;height:.1875rem;width:.125rem;bottom:-.1875rem;background-color:#fff}.c-testimonial__header:after{right:0}.c-testimonial__avatar-wrap{flex-shrink:0;width:5rem;height:5rem;border-radius:50%;overflow:hidden}.c-testimonial__avatar{display:block}.c-testimonial__author{padding:0 0 0 .9375rem;font-size:1.25rem;letter-spacing:-.42px;line-height:1.5rem}@media (min-width:78.75rem){.c-testimonial__author{font-size:1.5625rem;letter-spacing:-.52px;line-height:1.875rem}}.c-testimonial__icon{margin-left:.3125rem;fill:#d32531}.c-testimonial__tagline{margin-top:.3125rem;font-size:.75rem;line-height:.875rem;color:#6f6f6f;font-family:Helvetica,Arial,sans-serif}.c-testimonial__detail{position:absolute;z-index:100;padding-top:.3125rem;font-size:.8125rem;opacity:0;visibility:hidden;transition:opacity .24s cubic-bezier(.455,.03,.515,.955),visibility .24s cubic-bezier(.455,.03,.515,.955)}@media (min-width:78.75rem){.c-testimonial__detail{padding-top:1.25rem}}@media (max-width:78.6875rem){.c-testimonial__detail{left:0;max-width:100%}.c-testimonial__detail .c-author{max-width:100%}}.c-testimonial__author:hover .c-testimonial__detail{opacity:1;visibility:visible}.c-testimonial__main{flex-grow:1;position:relative;padding:.9375rem 0 0;background:#fff;color:#000}@media (min-width:48rem){.c-testimonial__main{padding-top:.75rem}}.c-testimonial__title{font-size:1rem;line-height:1.1875rem;text-align:left;transition:color .24s cubic-bezier(.215,.61,.355,1)}@media (min-width:48rem){.c-testimonial__title{text-align:left;margin-bottom:.3125rem}}.c-testimonial__main:hover .c-testimonial__title{color:#d32531}.c-testimonial__body{font-size:.875rem;letter-spacing:.47px;line-height:1.3}@media (max-width:47.9375rem){.c-testimonial__body{display:none}}.c-the-list{width:100%;border:.375rem solid #d32531;padding:0 1.5625rem 0 6.875rem;position:relative;min-height:7.125rem;display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;justify-content:center;color:#000}.c-the-list__headline{font-size:.9375rem;line-height:1}.c-the-list:before{height:8.3125rem;width:4.4375rem;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='71' height='133' viewBox='0 0 71 133'%3E%3Cdefs%3E%3Cpath id='a' d='M51.012 26.007c0 13.84-11.221 25.062-25.062 25.062C12.109 51.07.888 39.847.888 26.007.888 12.167 12.108.945 25.95.945c13.84 0 25.062 11.222 25.062 25.062'/%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath fill='%23FFFFFE' d='M36.444 83.399l33.017 36.297v-35.49L57.317 70.632'/%3E%3Cpath stroke='%231A1919' stroke-width='2' d='M36.444 83.399l33.017 36.297v-35.49L57.317 70.632'/%3E%3Cpath fill='%23FFFFFE' d='M39.355 49.356L6.154 12.117V48.52l7.318 7.637'/%3E%3Cpath stroke='%231A1919' stroke-width='2' d='M39.355 49.356L6.154 12.117V48.52l7.318 7.637'/%3E%3Cpath fill='%23FFFFFE' d='M60.574 65.977c0 13.833-11.213 25.048-25.048 25.048-13.834 0-25.047-11.215-25.047-25.048 0-13.834 11.213-25.047 25.047-25.047 13.835 0 25.048 11.213 25.048 25.047'/%3E%3Cg transform='translate(9.577 39.97)'%3E%3Cmask id='b' fill='%23fff'%3E%3Cuse xlink:href='%23a'/%3E%3C/mask%3E%3Cpath fill='%23D8232A' d='M26.003.375c7.044 0 14.992 3.122 19.759 9.4-.663.135-.998.17-1.544.14-1.908-.1-3.555-.629-5.671-.629-5.07 0-8.8 2.962-8.872 7.118-.042 2.357.758 4.056 2.006 5.33.618.63 1.366 1.172 2.13 1.69.76.515 1.575 1.04 2.383 1.568 1.824 1.196 2.822 1.994 2.79 3.917-.034 2.015-1.413 3.262-3.98 3.262-3.922 0-5.727-1.785-6.551-5.674l-3.135.752c.456 2.153 1.02 5.104 1.38 7.678l.47.25c.522-.323 1.311-.47 1.755-.47.813 0 1.567.253 2.35.44.92.223 2.038.439 3.385.439 5.76 0 10.254-2.68 10.344-7.993.055-3.186-1.673-5.074-4.42-7.02l-3.008-2.133c-1.726-1.221-2.25-1.798-2.225-3.166.024-1.445 1.532-2.603 3.792-2.603 2.206 0 3.69.828 3.667 2.134-.01.541-.097 1.163-.376 2.163h3.01a53.84 53.84 0 0 1 1.286-5.94c2.972 4.246 4.754 9.386 4.754 14.96 0 4.675-.884 8.191-3.032 11.985-.983-2.166-2.912-3.163-5.483-3.35-.77-.058-1.309-.043-1.309.341 0 .244.52.42.868.841.485.595.847 1.229.847 2.357 0 1.785-1.762 3.223-5.33 3.223-7.814 0-13.903-5.927-16.393-13.699 3.274-1.11 6.332-3.712 6.332-7.74 0-4.902-4.506-6.834-10.72-6.834-2.641 0-6.447.345-9.152.88-2.01.395-4.858 1.24-6.174 3.039C5.451 7.174 14.727.375 26.003.375' mask='url(%23b)'/%3E%3Cpath fill='%23D8232A' d='M3.346 21.388c.915 0 1.896-.411 2.319-.941.09-.112.157-.208.157-.378 0-.229-.134-.378-.25-.563a.886.886 0 0 1-.127-.501c0-.486.72-1.08 1.38-1.349.585-.234 1.456-.496 2.477-.688l-2.98 17.959c-.118.72-.572 1.075-1.127 1.254-.287.095-.57.16-.909.19-.347.028-.708.03-1.221.061l-.097.705C1.246 33.482.419 30.14.419 25.937c0-2.275.277-4.467.801-6.547.084 1.237 1.123 1.998 2.126 1.998m18.399-1.223c0 3.263-3.13 5.704-6.864 5.704-.25 0-.75.02-1.034 0l1.567-9.686c.474-.044 1.254-.126 2.35-.126 2.267 0 3.98 1.582 3.98 4.108m22.224 23.822c-3.089 3.02-9.086 7.512-18.018 7.512-9.373 0-17.272-4.863-21.886-12.271a77.284 77.284 0 0 1 4.61-.132c2.192-.006 4.407.096 6.394.221l.564-2.884-1.378-.091c-2.004-.139-2.031-.506-1.85-1.635l.94-5.892h2.163c2.767 9.374 10.831 15.925 23.04 15.925 2.157 0 3.97-.265 5.421-.753' mask='url(%23b)'/%3E%3C/g%3E%3Cpath fill='%23FFFFFE' d='M52.077 44.915l-22.691-8.258L43.33 21.694 42.209 1.425l22.574 8.171-.145 2.286-12.561 33.033'/%3E%3Cpath stroke='%231A1919' stroke-width='2' d='M52.077 44.915l-22.691-8.258L43.33 21.694 42.209 1.425l22.574 8.171-.145 2.286z'/%3E%3Cpath fill='%23FFFFFE' d='M14.415 87.691l22.69 8.259-13.944 14.964 1.12 20.267-22.563-8.222.595-4.659 12.102-30.609'/%3E%3Cpath stroke='%231A1919' stroke-width='2' d='M14.415 87.691l22.69 8.259-13.944 14.964 1.12 20.267-22.563-8.222.595-4.659z'/%3E%3Cpath fill='%23FFFFFE' d='M6.154 47.521H64.9V10.028H6.154z'/%3E%3Cpath stroke='%231A1919' stroke-width='2' d='M6.154 47.521H64.9V10.028H6.154z'/%3E%3Cpath fill='%231A1919' d='M17.522 20.058h-3.018v-3.906h10.974v3.906H22.46v21.486h-4.938V20.058M29.522 16.152h4.937v10.335h1.954V16.152h4.937v25.392h-4.937V30.535h-1.954v11.009h-4.937V16.152M45.784 16.152h9.126v3.906h-4.191v6.18h3.303v3.799h-3.303v7.566h4.405v3.941h-9.34V16.152'/%3E%3Cpath fill='%23FFFFFE' d='M1.592 122.508h67.869V85.015H1.592z'/%3E%3Cpath stroke='%231A1919' stroke-width='2' d='M1.592 122.508h67.869V85.015H1.592z'/%3E%3Cpath fill='%231A1919' d='M12.269 91.138h4.935v21.38h3.979v4.013h-8.914V91.138M25.583 116.531h4.972V91.138h-4.972zM34.636 111.132v-1.917h4.795v2.273c0 1.137.249 1.527.958 1.527.675 0 .853-.463.853-1.74v-.747c0-2.166-1.03-3.018-3.02-5.47-2.166-2.697-3.445-4.439-3.445-8.132V96.5c0-3.799 1.99-5.68 5.718-5.68 3.694 0 5.471 1.846 5.471 5.326v1.846h-4.652v-1.988c0-.958-.285-1.242-.855-1.242-.567 0-.851.32-.851 1.419v.391c0 1.777.817 2.417 2.664 4.795 1.988 2.556 3.907 4.369 3.907 8.523v1.137c0 4.084-2.061 5.895-5.897 5.895-3.196 0-5.646-1.562-5.646-5.789M52.673 95.045h-3.019v-3.907h10.973v3.907H57.61v21.486h-4.937V95.045'/%3E%3C/g%3E%3C/svg%3E");left:1.25rem;top:-.9375rem}.c-the-list:after,.c-the-list:before{content:"";background-repeat:no-repeat;display:block;position:absolute}.c-the-list:after{height:2.25rem;width:2.25rem;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='37' viewBox='0 0 36 37'%3E%3Cg fill='none' fill-rule='evenodd' transform='translate(1 1.13)'%3E%3Ccircle cx='17' cy='17' r='17' fill='%23FFF' stroke='%23D32531' stroke-linecap='square' stroke-width='2'/%3E%3Cpath fill='%23D32531' d='M9.18 20.043a1.194 1.194 0 1 1 0-2.387 1.194 1.194 0 0 1 0 2.387zm0 3.995a1.194 1.194 0 1 1 0-2.387 1.194 1.194 0 0 1 0 2.387zm0-7.954a1.194 1.194 0 1 1 0-2.387 1.194 1.194 0 0 1 0 2.387zm14.952 3.884H12.936a1.195 1.195 0 0 1 0-2.39h11.196a1.196 1.196 0 0 1 0 2.39zm0 3.995H12.936a1.195 1.195 0 0 1 0-2.391h11.196a1.196 1.196 0 0 1 0 2.39zm0-7.915H12.936a1.195 1.195 0 0 1 0-2.39h11.196a1.196 1.196 0 1 1 0 2.39zM9.18 12.111a1.193 1.193 0 1 1-.002-2.386 1.193 1.193 0 0 1 .002 2.386zm14.95.003H12.937a1.195 1.195 0 1 1 0-2.391h11.196a1.196 1.196 0 0 1 0 2.39z'/%3E%3C/g%3E%3C/svg%3E");right:-1.25rem;top:0;bottom:0;margin:auto}.c-trending{counter-reset:c-trending-counter}.c-trending__heading{background-color:#d32531;border-top:.25rem solid #d32531;color:#fff;font-size:2.1875rem;padding:.625rem 0;line-height:1;letter-spacing:0}.is-sidebar-open .c-trending__heading{background-color:transparent}.c-trending__heading-icon{height:1em;width:1em;margin-right:.625rem;fill:#fff}.c-trending__list{list-style:none}.c-trending__item+.c-trending__item{border-top:1px solid #dddee4}.c-trending__link{color:currentColor;transition:color .24s cubic-bezier(.215,.61,.355,1)}.c-trending__link:focus,.c-trending__link:hover,.c-trending__link:hover .c-trending__caption{color:dimgray}.c-trending__title{display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;padding:.4375rem 0;font-size:.8125rem;line-height:.8125rem}.c-trending__number{flex-shrink:0;width:2rem;height:2rem;margin:.3125rem .9375rem;color:#d32531;font-size:1.5rem}.c-trending__number span{margin-left:1px}.c-trending__counter:before{counter-increment:c-trending-counter;content:counter(c-trending-counter)}.c-trending__caption{position:relative;left:0;padding:0 .9375rem;transition:color .24s cubic-bezier(.215,.61,.355,1)}.c-trending--hero .c-trending__title{padding:.75rem}.c-trending--hero .c-trending__list{background-color:#fff;box-shadow:0 .125rem .8125rem 0 rgba(0,0,0,.15)}.c-trending--hero .c-trending__number{border-radius:50%;border:1px solid #d32531;font-size:.89375rem;height:1.5625rem;letter-spacing:1.79px;line-height:1.125rem;width:1.5625rem;margin:.3125rem .75rem .3125rem 0}.c-trending--hero .c-trending__caption{padding:0}.c-trending--sidebar{background-color:#fff;border:.25rem solid #d32531;padding:0 1.125rem;margin-top:1rem}.is-sidebar-open .c-trending--sidebar{background-color:transparent}.c-trending--sidebar:after,.c-trending--sidebar:before{background-color:#fff;content:"";display:block;height:.25rem;left:1rem;position:relative;width:14.0625rem}.is-sidebar-open .c-trending--sidebar:after,.is-sidebar-open .c-trending--sidebar:before{background-color:#e5e5e5}.c-trending--sidebar:before{top:-.25rem}.c-trending--sidebar:after{top:.25rem}.c-trending--sidebar .c-trending__list{transform:translateY(-.75rem)}.c-trending--sidebar .c-trending__number{margin-left:0;margin-right:.5rem}.c-trending--sidebar .c-trending__number .c-trending__counter{font-family:Publico Banner;font-size:1.875rem;line-height:2.25rem}.c-trending--sidebar .c-trending__heading{background-color:#fff;border:0;color:#d32531;font-size:2.125rem;left:16px;left:1rem;line-height:2.5625rem;margin:0;padding:0;position:relative;text-align:center;top:-1.625rem;width:14.0625rem}.c-trending--sidebar .c-trending__heading-icon{fill:#d32531}.c-trending--sidebar .c-trending__image,.c-trending--sidebar .c-trending__title{position:relative;z-index:1}.c-trending--sidebar .c-trending__image:before,.c-trending--sidebar .c-trending__title:before{content:"";position:absolute;z-index:1}.c-trending--sidebar .c-trending__image{max-height:10.75rem;max-width:16.125rem;margin-bottom:.1875rem}.c-trending--sidebar .c-trending__caption{color:#000;padding:0}.c-video-gallery{width:100%;margin-top:-1.25rem}@media (min-width:60rem){.c-video-gallery{margin-top:-4.0625rem}}.c-video-gallery__slider{padding-bottom:.625rem;border-top:1px solid #282f38}.c-video-gallery__item{flex-shrink:0;width:12.5rem;padding:1.25rem .625rem}@media (min-width:48rem){.c-video-gallery__item{width:18.4375rem;padding:1.25rem}}.c-video-gallery__slider-heading{padding-top:.9375rem;font-size:1rem;color:#d32531}@media (max-width:47.9375rem){.c-video-gallery__slider-heading{display:none}}[data-st-search-form],[data-st-search-form] .search-input-with-autocomplete{height:100%}[data-st-search-form] .search-form{display:-webkit-box;display:-ms-flexbox;display:flex;align-items:center;position:relative;height:100%;color:#dddee4;border-radius:.3125rem;transition:color .24s cubic-bezier(.215,.61,.355,1)}@media (min-width:60rem){[data-st-search-form] .search-form{color:#333}}.is-search-expandable [data-st-search-form] .search-form{color:#6f6f6f}.is-search-expandable [data-st-search-form] .search-form:focus,.is-search-expandable [data-st-search-form] .search-form:hover{color:#d32531}[data-st-search-form] .search-form:after,[data-st-search-form] .search-form:before{content:"";display:block;position:absolute;z-index:1;top:50%;left:.9375rem;margin-top:-.1875rem;border:.125rem solid;cursor:pointer;pointer-events:none}@media (min-width:60rem){[data-st-search-form] .search-form:after,[data-st-search-form] .search-form:before{opacity:.6}}.is-search-expandable [data-st-search-form] .search-form:after,.is-search-expandable [data-st-search-form] .search-form:before{opacity:1}.is-search-expanded [data-st-search-form] .search-form:after,.is-search-expanded [data-st-search-form] .search-form:before{border-color:#fff}[data-st-search-form] .search-form:before{margin-top:-.5rem;width:.75rem;height:.75rem;border-radius:99%}.is-search-expandable [data-st-search-form] .search-form:before{transform:scale(1.25)}[data-st-search-form] .search-form:after{width:.5rem;border-width:.125rem 0 0;transform:translate(.5rem,.375rem) rotate(45deg)}.is-search-expandable [data-st-search-form] .search-form:after{transform:scale(1.25) translate(.5rem,.375rem) rotate(45deg)}[data-st-search-form] input{height:100%;border:none;border-radius:0;background-color:transparent}[data-st-search-form] input:focus{outline:none}[data-st-search-form] [type=text]{flex:1 0 auto;padding:.125rem .625rem 0 2.8125rem;font-size:.9375rem;color:#dddee4;background-color:#181818;box-shadow:inset 0 .1875rem .375rem 0 rgba(0,0,0,.5)}@media (min-width:60rem){[data-st-search-form] [type=text]{border-radius:.3125rem;color:#333;background-color:#fff}}[data-st-search-form] [type=text]::-webkit-input-placeholder{color:#dddee4}[data-st-search-form] [type=text]:-ms-input-placeholder,[data-st-search-form] [type=text]::-ms-input-placeholder{color:#dddee4}[data-st-search-form] [type=text]::-moz-placeholder{color:#dddee4}[data-st-search-form] [type=text]::placeholder{color:#dddee4}@media (min-width:60rem){[data-st-search-form] [type=text]::-webkit-input-placeholder{color:#6f6f6f}[data-st-search-form] [type=text]:-ms-input-placeholder,[data-st-search-form] [type=text]::-ms-input-placeholder{color:#6f6f6f}[data-st-search-form] [type=text]::-moz-placeholder{color:#6f6f6f}[data-st-search-form] [type=text]::placeholder{color:#6f6f6f}}.is-search-expandable [data-st-search-form] [type=text]::-webkit-input-placeholder{color:#6f6f6f}.is-search-expandable [data-st-search-form] [type=text]:-ms-input-placeholder,.is-search-expandable [data-st-search-form] [type=text]::-ms-input-placeholder{color:#6f6f6f}.is-search-expandable [data-st-search-form] [type=text]::-moz-placeholder{color:#6f6f6f}.is-search-expandable [data-st-search-form] [type=text]::placeholder{color:#6f6f6f}.is-search-expandable [data-st-search-form] [type=text]{position:absolute;top:1px;left:2.5rem;width:18.75rem;height:2.6875rem;padding:.125rem 3.4375rem 0 .9375rem;font-size:.875rem;opacity:0;visibility:hidden;transition:opacity .24s cubic-bezier(.215,.61,.355,1),visibility .24s cubic-bezier(.215,.61,.355,1);color:#000;background-color:#fff;border:1px solid #dddee4;border-radius:.375rem;box-shadow:inset 0 .125rem .25rem 0 rgba(0,0,0,.3)}.is-header-sticky .is-search-expandable [data-st-search-form] [type=text]{border-radius:0;background-color:#f4f4f7;left:-16rem}.is-search-expanded [data-st-search-form] [type=text]{opacity:1;visibility:visible}[data-st-search-form] [type=submit]{position:absolute;top:calc(50% - 1.375rem);left:0;width:2.8125rem;height:2.75rem;padding:0;overflow:hidden;font-size:0;background-color:transparent;cursor:pointer}.is-search-expandable [data-st-search-form] [type=submit]{left:auto;right:0;border:1px solid #dddee4;border-radius:.375rem;transition:background-color .24s cubic-bezier(.215,.61,.355,1)}.is-header-sticky .is-search-expandable [data-st-search-form] [type=submit]{border-radius:0;border-top:none;border-bottom:none}.is-search-expanded [data-st-search-form] [type=submit]{border-radius:.375rem 0 0 .375rem;background-color:#d32531}.l-header__wrap [data-st-search-form] .swiftype-widget{position:absolute;z-index:-1;top:100%;left:0;right:0;width:21.25rem}@media (min-width:60rem){.is-header-sticky .l-header__wrap [data-st-search-form] .swiftype-widget{left:-16rem}}[data-st-search-form] .autocomplete{margin-top:-.3125rem;padding-top:.3125rem;background-color:#fff;border:1px solid #dddee4;border-top-color:transparent;font-size:.875rem;line-height:1.5;box-shadow:0 .125rem .25rem rgba(0,0,0,.2)}@media (min-width:60rem){[data-st-search-form] .autocomplete{background-color:#000;border-color:#303030}.is-search-expandable [data-st-search-form] .autocomplete{background-color:#fff;border-color:#dddee4}}[data-st-search-form] .autocomplete.inactive{display:none}.is-header-sticky [data-st-search-form] .autocomplete{margin-top:0;padding-top:0}[data-st-search-form] .ac-result,[data-st-search-form] .ac-section-title{padding:.625rem}[data-st-search-form] .ac-section-title{font-size:.75rem;text-transform:uppercase;color:#d32531}[data-st-search-form] .ac-result{border-top:1px solid #dddee4;cursor:pointer;transition:background-color .24s cubic-bezier(.215,.61,.355,1)}@media (min-width:60rem){[data-st-search-form] .ac-result{border-top-color:#303030}.is-search-expandable [data-st-search-form] .ac-result{border-top-color:#dddee4}}[data-st-search-form] .ac-result:focus,[data-st-search-form] .ac-result:hover{background-color:#f4f4f7}@media (min-width:60rem){[data-st-search-form] .ac-result:focus,[data-st-search-form] .ac-result:hover{background-color:#181818}.is-search-expandable [data-st-search-form] .ac-result:focus,.is-search-expandable [data-st-search-form] .ac-result:hover{background-color:#f4f4f7}}[data-st-search-form] .ac_title{display:inline;padding-right:.5em;color:#333}@media (min-width:60rem){[data-st-search-form] .ac_title{color:#f4f4f7}.is-search-expandable [data-st-search-form] .ac_title{color:#333}}[data-st-search-form] .ac_title em{font-style:normal;font-weight:700;color:#000}@media (min-width:60rem){[data-st-search-form] .ac_title em{color:#fff}.is-search-expandable [data-st-search-form] .ac_title em{color:#000}}[data-st-search-form] .ac_sub{font-family:Georgia,Times,Times New Roman,serif;display:inline-block;font-weight:400;font-style:italic;font-size:.75rem;color:#6f6f6f}.l-3-pack--reversed{display:-ms-grid;display:grid;-ms-grid-columns:1fr 1.25rem 1fr;grid-template-columns:1fr 1.25rem 1fr;-ms-grid-rows:1fr 1.25rem auto;grid-template-rows:1fr 1.25rem auto}.l-3-pack--reversed .l-3-pack__item{padding-top:0}.l-3-pack--reversed .l-3-pack__item--primary{-ms-grid-column:1;-ms-grid-column-span:3;grid-column:1/4;-ms-grid-row:1;-ms-grid-row-span:1;grid-row:1/2}.l-3-pack--reversed .l-3-pack__item--secondary{-ms-grid-column:1;-ms-grid-column-span:1;grid-column:1/2;-ms-grid-row:3;-ms-grid-row-span:1;grid-row:3/4}.l-3-pack--reversed .l-3-pack__item--tertiary{-ms-grid-column:3;-ms-grid-column-span:1;grid-column:3/4;-ms-grid-row:3;-ms-grid-row-span:1;grid-row:3/4}@media (min-width:48rem) and (max-width:59.9375rem),(min-width:68.75rem){.l-3-pack--reversed{-ms-grid-columns:2fr 1.25rem 26%;grid-template-columns:2fr 1.25rem 26%;-ms-grid-rows:1fr 1.25rem 1fr;grid-template-rows:1fr 1.25rem 1fr}.l-3-pack--reversed .l-3-pack__item--primary{-ms-grid-column:1;-ms-grid-column-span:1;grid-column:1/2;-ms-grid-row:1;-ms-grid-row-span:3;grid-row:1/4}.l-3-pack--reversed .l-3-pack__item--secondary{-ms-grid-column:3;-ms-grid-column-span:1;grid-column:3/4;-ms-grid-row:1;-ms-grid-row-span:1;grid-row:1/2}.l-3-pack--reversed .l-3-pack__item--tertiary{-ms-grid-column:3;-ms-grid-column-span:1;grid-column:3/4;-ms-grid-row:3;-ms-grid-row-span:1;grid-row:3/4}}.has-side-skins .l-3-pack--reversed{display:-ms-grid;display:grid;-ms-grid-columns:1fr 1.25rem 1fr;grid-template-columns:1fr 1.25rem 1fr;-ms-grid-rows:1fr 1.25rem auto;grid-template-rows:1fr 1.25rem auto}.has-side-skins .l-3-pack--reversed .l-3-pack__item--primary{-ms-grid-column:1;-ms-grid-column-span:3;grid-column:1/4;-ms-grid-row:1;-ms-grid-row-span:1;grid-row:1/2}.has-side-skins .l-3-pack--reversed .l-3-pack__item--secondary{-ms-grid-column:1;-ms-grid-column-span:1;grid-column:1/2;-ms-grid-row:3;-ms-grid-row-span:1;grid-row:3/4}has-side-skins.l-3-pack--reversed .l-3-pack__item--tertiary{-ms-grid-column:3;-ms-grid-column-span:1;grid-column:3/4;-ms-grid-row:3;-ms-grid-row-span:1;grid-row:3/4}.l-footer{margin-top:1.5625rem;color:#fff;background-color:#000}.l-footer__wrap{margin:0 auto;padding:1.5625rem 1.25rem;width:100%;min-width:20rem;max-width:81.25rem;position:relative}@media (min-width:48rem){.l-footer__wrap{padding-bottom:.9375rem}}@media (min-width:78.75rem){html:not(.has-side-skins) .l-footer__wrap{padding-left:20.3125rem}}@media (min-width:48rem){.l-footer__nav{display:-webkit-box;display:-ms-flexbox;display:flex;margin:0 -1.25rem}}@media (min-width:48rem){.l-footer__menu{flex:1 1 auto;width:25%;padding:.3125rem 1.5625rem}.l-footer__menu--wide{width:33.33333%}}.l-footer__menu+.l-footer__menu{padding-top:1.25rem}@media (min-width:48rem){.l-footer__menu+.l-footer__menu{padding-top:0;border-left:1px solid #303030}}.l-footer__newsletter{display:none}@media (min-width:48rem){.l-footer__newsletter{display:-webkit-box;display:-ms-flexbox;display:flex;justify-content:space-between;align-items:center;padding:.75rem 0;margin:.625rem 0;border-top:1px solid #303030;border-bottom:1px solid #303030}}.l-footer__newsletter-heading{padding-right:3.125rem;font-size:1.8125rem}.l-footer__newsletter-form{flex:1 1 auto}.l-footer__cover{display:none}@media (min-width:78.75rem){html:not(.has-side-skins) .l-footer__cover{display:block;position:absolute;bottom:0;left:.625rem;width:18.75rem;height:calc(100% - 1.25rem)}}.l-footer__cover-image{display:block;position:absolute;left:50%;transform:translateX(-50%) scale(.9);width:auto;max-height:100%}@media (min-width:48rem){.l-footer__legal{display:-webkit-box;display:-ms-flexbox;display:flex;justify-content:space-between;align-items:center}}.l-footer__copyright{padding-top:1.25rem;font-size:.875rem;line-height:1.2;text-align:center}@media (min-width:48rem){.l-footer__copyright{order:-1;flex:1 1 auto;padding-top:0;font-size:.75rem;text-align:left;color:#a7a6a6}}.l-footer__branding{display:block;width:100%;padding-top:1.5625rem;text-align:center}@media (min-width:48rem){.l-footer__branding{width:auto;padding-top:.625rem}}.l-footer__logo{position:relative;top:.1875rem;width:12.6875rem;height:2.3125rem;fill:#d32531}.l-footer__tip{display:none}@media (min-width:48rem){.l-footer__tip{display:-webkit-box;display:-ms-flexbox;display:flex;justify-content:space-between;align-items:center;padding:.75rem 0;margin:.625rem 0}}.l-footer__tip-heading{font-size:1.8125rem;flex:none;line-height:2.1875rem;padding-right:1.5625rem}.l-footer__tip-body{flex:1 1 auto;font-size:.875rem;font-style:italic;height:2.125rem;line-height:1.0625rem}.l-footer__tip-link{align-items:center;border:1px solid currentColor;color:#fff;display:-webkit-box;display:-ms-flexbox;display:flex;height:2.625rem;justify-content:center;font-size:.6875rem;letter-spacing:1px;line-height:.8125rem;text-transform:uppercase;width:11.875rem}.l-footer__tip-link:focus,.l-footer__tip-link:hover{color:#d32531}.l-footer__tip .l-footer__logo{margin-left:2.5rem}.l-header{position:relative}.l-header,.l-header__wrap{width:100%;max-width:100%;height:3.1875rem}@media (min-width:60rem){.l-header,.l-header__content,.l-header__wrap{height:8.875rem}}.l-header__wrap{position:absolute;z-index:20001;overflow:hidden;left:50%;transform:translateX(-50%);background-color:#fff;box-shadow:0 .25rem .25rem rgba(0,0,0,.2)}.l-header__wrap--layer{margin:0 auto;padding-left:1.25rem;padding-right:1.25rem;width:100%;min-width:20rem;max-width:81.25rem;height:1px;overflow:visible;background-color:transparent;box-shadow:none}.l-header__wrap--subscribe{top:6.5625rem;opacity:0;visibility:hidden;transition:opacity .24s cubic-bezier(.455,.03,.515,.955),visibility .24s cubic-bezier(.455,.03,.515,.955)}.is-header-subscribe-open .l-header__wrap--subscribe{opacity:1;visibility:visible}.l-header__block,.l-header__content--sticky,.l-header__link,.l-header__menu,.l-header__nav{flex-flow:row wrap}.l-header__content{margin:0 auto;padding-left:1.25rem;padding-right:1.25rem;width:100%;min-width:20rem;max-width:81.25rem;position:relative;height:100%}.l-header__content--sticky{overflow-y:hidden;flex-wrap:nowrap;justify-content:flex-start;height:2.8125rem;padding-right:4.0625rem}.l-header__search{position:absolute;z-index:1;top:2.1875rem;width:2.8125rem;height:2.8125rem;background-color:#fff}@media (max-width:59.9375rem){.l-header__search{display:none}}.l-header__branding{display:block;width:100%;padding:.5rem;text-align:center}@media (min-width:60rem){.l-header__branding{width:auto;margin:0 auto;padding:.8125rem}}.l-header__branding--sticky{flex:0 0 auto;width:9.6875rem;padding:.5625rem .9375rem .3125rem 0;margin:0;text-align:left;transform:none;border-right:1px solid #dddee4}@media (max-width:59.9375rem){.l-header__branding--sticky{display:none}}.l-header__logo{position:relative;top:.1875rem;width:11.125rem;height:2rem;fill:#d32531}@media (min-width:60rem){.l-header__logo{width:29.5625rem;height:5.3125rem}}.l-header__logo--sticky{width:8.5625rem;height:1.5625rem}@media (max-width:59.9375rem){.l-header__logo--sticky{display:none}}.l-header__nav{position:relative;font-size:.875rem}@media (max-width:59.9375rem){.l-header__nav{position:absolute;top:0;bottom:0;left:0}}@media (min-width:60rem){.l-header__nav{flex:0 0 auto;order:10;width:100%;height:1.875rem}}.l-header__menu{list-style:none}@media (max-width:59.9375rem){.l-header__menu{display:none}}.l-header__menu-link,.l-header__toggle{color:#000}@media (min-width:60rem){.l-header__menu-link,.l-header__toggle{padding:.3125rem 1.5625rem}}.l-header__menu-link.is-active,.l-header__menu-link:focus,.l-header__menu-link:hover,.l-header__toggle.is-active,.l-header__toggle:focus,.l-header__toggle:hover{color:#d32531}.l-header__toggle{max-height:1.875rem;padding:0}.l-header__toggle--sticky{height:100%;max-height:none;padding:0;border-right:1px solid #dddee4}@media (max-width:59.9375rem){.is-mega-open .l-header__toggle--hamburger,.l-header__toggle--sticky{display:none}}.l-header__toggle--close{display:none}@media (max-width:59.9375rem){.is-mega-open .l-header__toggle--close{position:relative;display:block;margin-left:.625rem;min-height:2.25rem}}.l-header__menu--list{display:-webkit-box;display:-ms-flexbox;display:flex;width:auto;overflow:auto;flex-wrap:nowrap;justify-content:flex-start;font-size:.8125rem;-webkit-overflow-scrolling:touch}@media (min-width:60rem){.l-header__menu--list{flex:1 1 auto;width:100%;justify-content:space-between}}.l-header__menu--list .l-header__menu-item{flex:1 1 auto}@media (max-width:59.9375rem){.l-header__menu--list .l-header__menu-item:first-child{padding-left:.3125rem}.l-header__menu--list .l-header__menu-item:last-child{padding-right:.9375rem}}.l-header__menu--list .l-header__menu-link{padding:.125rem .75rem;white-space:nowrap}@media (min-width:60rem){.l-header__menu--list .l-header__menu-link{padding:.125rem .3125rem}}.l-header__block{position:absolute;top:0;left:1.25rem;height:7rem;font-size:.9375rem;transition:opacity .24s cubic-bezier(.215,.61,.355,1),visibility .24s cubic-bezier(.215,.61,.355,1)}@media (max-width:59.9375rem){.l-header__block{display:none}}.l-header__link{display:block;color:#d32531;padding:0 1.25rem;font-size:1rem}.l-header__link:focus,.l-header__link:hover{color:#000}.l-header__tooltip-container{position:relative}.l-header__tooltip{z-index:1;top:100%;transform:translateX(-50%);padding:.5rem;margin:.3125rem;border-radius:.1875rem;box-shadow:0 .1875rem .4375rem rgba(0,0,0,.4)}.l-header__tooltip,.l-header__tooltip:before{position:absolute;left:50%;border:1px solid #dddee4;background-color:#fff}.l-header__tooltip:before{content:"";top:-.125rem;width:.625rem;height:.625rem;transform:rotate(45deg) translateX(-50%);border-right:none;border-bottom:none}.l-header__block--left{left:4.8125rem}@media (min-width:60rem){.is-search-expanded .l-header__block--left{opacity:0;visibility:hidden}}.l-header__block--right{left:auto;right:1.875rem}@media (max-width:59.9375rem){.l-header__block--right{display:block;top:calc(50% - .9375rem);right:1.125rem;height:auto;font-size:.625rem;line-height:1rem}}.l-header__subscribe{position:absolute;left:0;width:100%;margin:0 auto;padding:1.75rem 4.375rem}.l-header__subscribe:before{content:"";position:absolute;z-index:-1;width:calc(100% - .625rem);height:100%;top:0;left:50%;transform:translateX(-50%);background-color:#fff;border-top:1px solid #dddee4;border-bottom:1px solid #dddee4;box-shadow:0 .125rem .25rem rgba(0,0,0,.2)}.l-header__block--read-next{position:static;flex:1 1 auto;flex-wrap:nowrap;justify-content:flex-start;height:100%;padding:.75rem 1.5625rem .625rem;color:#000}.l-header__block--read-next:focus,.l-header__block--read-next:hover{color:#d32531}.is-search-expanded .l-header__block--read-next{padding-right:16.875rem}.l-header__read-next-label{font-size:.75rem;font-style:italic;color:#6f6f6f}.l-header__read-next-title{display:inline-block;padding-left:.625rem;font-size:.9375rem}.l-header__block--read-next,.l-header__read-next-title{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.l-header__block--sticky-link{border-left:1px solid #dddee4;color:#d32531;flex-wrap:nowrap;font-size:.9375rem;height:100%;line-height:1.125rem;padding:0 1.25rem;position:static}.l-header__block--sticky-link:focus,.l-header__block--sticky-link:hover{color:#000}.l-header__block--sticky-link:last-child{border-right:1px solid #dddee4}.l-header__block--list-nav{position:relative;top:0;left:0;display:-webkit-box;display:-ms-flexbox;display:flex;width:100%;height:100%;padding:0}@media (max-width:59.9375rem){.l-header__block--list-nav{height:1.875rem;border-top:1px solid #dddee4}.l-header__block--list-nav:after,.l-header__block--list-nav:before{content:"";position:absolute;width:1.5625rem;height:100%;top:1px}.l-header__block--list-nav:before{left:0;background-image:-webkit-gradient(linear,left top,right top,from(#fff),to(hsla(0,0%,100%,0)));background-image:linear-gradient(90deg,#fff,hsla(0,0%,100%,0))}.l-header__block--list-nav:after{width:2.1875rem;right:0;background-image:-webkit-gradient(linear,right top,left top,from(#fff),to(hsla(0,0%,100%,0)));background-image:linear-gradient(270deg,#fff,hsla(0,0%,100%,0))}}@media (min-width:60rem){.l-header__block--list-nav{justify-content:flex-start;padding:0 .9375rem}.is-search-expanded .l-header__block--list-nav{padding-right:16.875rem}}.l-header__progress-bar{display:block;position:absolute;top:0;left:0;width:100%;height:.1875rem;transform:scaleX(0);transform-origin:left center;background-color:#d32531;transition:transform .24s cubic-bezier(.215,.61,.355,1);will-change:transform}@media (min-width:60rem){.l-header__progress-bar{top:.3125rem}}@media (min-width:60rem){.l-header__nav:after,.l-header__nav:before{content:"";position:absolute;left:50%;transform:translateX(-50%);width:100vw;height:1px;background-color:#dddee4}.has-side-skins .l-header__nav:after,.has-side-skins .l-header__nav:before{max-width:100%}.l-header__nav:before{top:-1px}.l-header__nav:after{bottom:0}}@media (max-width:59.9375rem){.l-header--list,.l-header--list .l-header__wrap:not(.l-header__wrap--search){height:5rem}.l-header--list .l-header__content{height:3.1875rem}.l-header--list .l-header__content--sticky{height:1.875rem;padding:0}}.l-header--list .l-header__toggle--sticky{order:-1;margin-left:-.625rem;border-right:none}.l-header--list .l-header__logo--sticky{width:7.5rem;height:1.375rem}.is-header-ready .l-header__content{transition:transform .24s cubic-bezier(.215,.61,.355,1)}@media (max-width:59.9375rem){.l-header__wrap{position:fixed}}.admin-bar .l-header__wrap:not(.l-header__wrap--subscribe){top:0}@media (min-width:37.5rem) and (max-width:48.875rem){.admin-bar .l-header__wrap:not(.l-header__wrap--subscribe){top:2.875rem}}@media (min-width:48.9375rem) and (max-width:59.9375rem){.admin-bar .l-header__wrap:not(.l-header__wrap--subscribe){top:2rem}}.is-header-sticky .l-header__wrap{position:fixed;top:0}@media (min-width:60rem){.is-header-sticky .l-header__wrap{top:-6.375rem}}@media (min-width:48.9375rem) and (max-width:59.9375rem){.is-header-sticky .admin-bar .l-header__wrap{top:2rem}}@media (min-width:60rem){.is-header-sticky .admin-bar .l-header__wrap{top:-4.1875rem}}@media (min-width:60rem){.is-header-sticky .l-header__content{transform:translateY(-2.8125rem)}}.is-header-sticky .l-header__search{top:6.0625rem;width:2.8125rem;height:2.75rem;right:1.25rem}.l-home-top{margin:0 auto;padding-left:1.25rem;padding-right:1.25rem;width:100%;min-width:20rem;max-width:81.25rem;position:relative;margin-bottom:2.8125rem}@media (min-width:48rem){.l-home-top{padding-top:2rem}}@media (min-width:60rem){.l-home-top{display:-ms-grid;display:grid;-ms-grid-columns:15% 1.25rem 3fr 1.25rem 18.75rem;grid-template-columns:15% 1.25rem 3fr 1.25rem 18.75rem;-ms-grid-rows:1fr;grid-template-rows:1fr;margin-bottom:2.5rem}}.l-home-top>*{position:relative}.l-home-top:before{content:"";position:absolute;width:100vw;height:7.1875rem;top:0;left:50%;transform:translateX(-50%);background-color:#d32531}.has-side-skins .l-home-top:before{max-width:100%}.l-home-top__list{-ms-grid-column:1;-ms-grid-column-span:1;grid-column:1/2;-ms-grid-row:1;grid-row:1}.l-home-top__3-pack{-ms-grid-column:3;-ms-grid-column-span:1;grid-column:3/4;-ms-grid-row:1;grid-row:1}.l-home-top__sidebar{-ms-grid-column:5;-ms-grid-column-span:1;grid-column:5/6;-ms-grid-row:1;grid-row:1}.l-home-top__sidebar-item{margin-top:2.25rem}@media (min-width:60rem){.l-home-top__sidebar-item:first-child{margin-top:0}}.l-home-top .c-ad--boxed{border-bottom:none}.l-mega{position:absolute;width:100%;height:100%;overflow:auto;-webkit-overflow-scrolling:touch}@media (min-width:60rem){.l-mega{background-color:rgba(0,0,0,.9)}}.l-mega__wrap{display:-webkit-box;display:-ms-flexbox;display:flex;flex-flow:column nowrap;position:absolute;top:3.1875rem;right:0;left:0;min-height:100vh;overflow:hidden;color:#fff;background-color:#000}@media (min-width:60rem){.l-mega__wrap{top:0;width:100%;max-width:62.5rem;margin:0 auto;padding:0 1.25rem;background-color:transparent}}.l-mega__branding{display:none}@media (min-width:60rem){.l-mega__branding{display:block;padding:.875rem 1.875rem .25rem 0}}.l-mega__logo{width:18.75rem;height:3.4375rem;fill:#d32531}.l-mega__nav{position:relative;flex:1 0 auto;padding-bottom:2.5rem}@media (min-width:60rem){.l-mega__nav{flex:0 0 auto;margin:0 -.9375rem;padding-bottom:1.875rem;overflow:hidden}}.l-mega__cover{display:none}@media (min-width:60rem){.l-mega__cover{display:block;position:absolute;right:0;bottom:-2.5rem}}.l-mega__block,.l-mega__search{font-family:Helvetica,Arial,sans-serif}.l-mega__search{position:relative;z-index:100;width:100%;height:3.1875rem}@media (min-width:60rem){.l-mega__search{height:2.5625rem;margin-right:5rem}}.l-mega__block{flex-flow:column nowrap;padding:.9375rem}@media (min-width:60rem){.l-mega__block{flex-flow:row nowrap;padding:.9375rem 0}}.l-mega__block--footer{padding-top:.3125rem;padding-bottom:.625rem}.l-mega__block--legal{flex-flow:row nowrap;justify-content:space-between;border-top:1px solid #303030}@media (min-width:60rem){.l-mega__block--legal{border-top:none}}@media (min-width:60rem){.l-mega__row{display:-webkit-box;display:-ms-flexbox;display:flex;flex-flow:row nowrap;justify-content:space-between;align-items:center;border-bottom:1px solid #303030}.l-mega__row:last-child{border-bottom:none}}@media (min-width:60rem){.l-mega__nav+.l-mega__row{border-top:1px solid #303030}}.l-mega__heading{padding:.3125rem 0;font-size:1.25rem;text-align:center}@media (min-width:60rem){.l-mega__heading{padding-right:1.25rem}}.l-mega__copyright,.l-mega__menu{font-size:.625rem;text-transform:uppercase;white-space:nowrap}.l-mega__menu{list-style:none;justify-content:space-between;margin:0 auto}@media (min-width:60rem){.l-mega__menu{font-size:.75rem}}.l-mega__menu-item{padding:0 .3125rem}.l-mega__menu-link{color:#fff}.l-mega__menu-link:focus,.l-mega__menu-link:hover{color:#d32531}.l-mega__pmc-logo{width:6.625rem;height:1rem}.l-mega__copyright{padding-left:.9375rem}.l-mega__close{display:none}@media (min-width:60rem){.l-mega__close{display:block;position:absolute;z-index:1000;top:.9375rem;left:calc(50% + 26.875rem);opacity:0;visibility:hidden;transition:opacity .16s cubic-bezier(.4,0,.2,1),visibility .16s cubic-bezier(.4,0,.2,1)}.is-mega-open .l-mega__close{opacity:1;visibility:visible;transition-delay:.25s,.25s}}.l-page{position:relative;margin-left:auto;margin-right:auto;background-color:#fff}.l-page__content{position:relative;transition:transform .5s cubic-bezier(.86,0,.07,1)}@media (min-width:85rem){.is-sidebar-open .l-page__content{transform:translateX(-2.5rem)}}@media (min-width:105rem){.is-sidebar-open .l-page__content{transform:translateX(-12.5rem)}}@media (min-width:111.25rem){.is-sidebar-open .l-page__content{transform:translateX(-15.625rem)}}.l-page__content:after{content:"";position:absolute;top:0;left:50%;width:100vw;height:100%;background:#000;opacity:0;pointer-events:none;transform:translateX(-50%);transition:opacity .5s cubic-bezier(.86,0,.07,1)}.is-sidebar-open .l-page__content:after{opacity:.1}.is-mega-open .l-page__content:after{opacity:1}.l-page__sidebar{position:fixed;top:0;right:0;z-index:1000;height:100vh;width:31.25rem;max-width:100vw;transform:translateX(100%);background-color:#fff;overflow-y:scroll;transition:transform .5s cubic-bezier(.86,0,.07,1);opacity:0;-webkit-overflow-scrolling:touch}@media (min-width:85rem){.l-page__sidebar{width:25rem}}@media (min-width:111.25rem){.l-page__sidebar{width:31.25rem}}.is-sidebar-open .l-page__sidebar{opacity:1;box-shadow:0 1.25rem 1.5rem 0 rgba(0,0,0,.1);transform:translateX(0)}.is-header-sticky .l-page__sidebar{position:fixed;top:2.6875rem;height:calc(100vh - 2.6875rem);z-index:1}.l-page__secondary{transition:opacity .5s cubic-bezier(.86,0,.07,1)}@media (min-width:85rem){.is-sidebar-open .l-page__secondary{opacity:0}}@media (min-width:105rem){.is-sidebar-open .l-page__secondary{opacity:1}}.l-page__mega{position:fixed;z-index:20000;top:0;left:0;right:0;bottom:0;overflow:hidden;opacity:0;visibility:hidden;transform:translateY(-20%);transition:transform .25s cubic-bezier(0,0,.2,1) .25s,opacity .16s cubic-bezier(0,0,.2,1),visibility .16s cubic-bezier(0,0,.2,1);-webkit-overflow-scrolling:touch}.admin-bar .l-page__mega{top:2.875rem}@media (min-width:48.9375rem){.admin-bar .l-page__mega{top:1.9375rem}}@media (min-width:60rem){.l-page__mega{z-index:40000;transition:transform .35s cubic-bezier(0,0,.2,1) .35s,opacity .35s cubic-bezier(0,0,.2,1),visibility .35s cubic-bezier(0,0,.2,1)}}.is-mega-open .l-page__mega{transform:none;opacity:1;visibility:visible;transition-delay:0ms,0ms,0ms}.has-side-skins .l-page{margin:0 auto;max-width:62.5rem}.has-branding:not(.single-pmc_top_video) .l-page{background:#f4f3f1}.l-section{margin:0 auto;padding-left:1.25rem;padding-right:1.25rem;width:100%;min-width:20rem;max-width:81.25rem;position:relative;display:-webkit-box;display:-ms-flexbox;display:flex;flex-wrap:wrap;justify-content:space-between}.l-section:hover{z-index:100}.l-section:after{content:"";display:block;width:100%;height:0;margin-top:1.875rem}@media (min-width:48rem){.l-section:after{margin-top:1.875rem;padding-bottom:1.875rem}}.l-section--no-separator:after{display:none}.l-section--with-bottom-margin{margin-bottom:2.5rem}.l-section--pagination{margin-bottom:1.5625rem}@media (min-width:48rem){.l-section--pagination{margin-top:3.75rem;margin-bottom:3.75rem}}@media (max-width:47.9375rem){.l-section--dark{padding-left:0;padding-right:0}}@media (min-width:48rem){.l-section.is-closed{height:5.625rem;margin-bottom:.625rem;overflow:hidden}}.l-section__header{position:relative;width:100%}.l-section__header--spaced{margin-bottom:1.25rem}@media (min-width:48rem){.l-section.is-closed .l-section__header:after{content:"";display:block;width:100%;height:0;border-top:1px solid #dddee4}}.l-section__content{display:-webkit-box;display:-ms-flexbox;display:flex;flex-wrap:wrap;justify-content:space-between;width:100%;padding-top:.625rem;transition:transform .5s cubic-bezier(.86,0,.07,1),opacity .5s cubic-bezier(.86,0,.07,1)}.l-section--dark .l-section__content{background:#0f161e;color:#fff}@media (min-width:48rem){.l-section.is-closing .l-section__content{transform:scale(.99);opacity:0}}.l-section__grid{width:100%}@media (min-width:48rem){.l-section__grid{width:calc(100% - 20rem);margin-bottom:1.875rem}}.l-section__sidebar{width:100%;margin:1.25rem 0 3.4375rem}@media (min-width:48rem){.l-section__sidebar{display:-webkit-box;display:-ms-flexbox;display:flex;flex-direction:column;width:18.75rem;margin:0 0 4.375rem}}@media (max-width:47.9375rem){.l-section__sticky{display:none}}@media (min-width:48rem){.l-section__sidebar-footer:not(:first-child){padding-top:3.75rem}}.l-section__block{width:100%}.l-section--newswire{position:relative;padding-bottom:1.5625rem;margin-bottom:-1.5625rem}.l-section--newswire:before{content:"";position:absolute;top:0;left:50%;height:100%;width:100vw;transform:translateX(-50%);background-color:#fff}.l-section--standard-template{margin-top:3.75rem;margin-bottom:3.75rem}@media (min-width:48rem){.l-section--standard-template{margin-bottom:6.25rem}}.u-spacer--v-small{padding-top:.9375rem;padding-bottom:.9375rem}.u-color--black{color:#000!important}       </style>
+        <script type="text/javascript">
+/* <![CDATA[ */
+var pmc_site_config = {"rot13_hostname":"jjj.ebyyvatfgbar.pbz","hostname":"www.rollingstone.com","is_proxied":null};
+
+/* ]]> */
+</script>
+        <script type='text/javascript'>
+            var pmc_tracking_url = "https://s3.amazonaws.com/heartbeat.pmc.com/track?host=www.rollingstone.com&path=%2F&query=redirurl%253D%252Fpolitics%252Fnews%252Fgreed-and-debt-the-true-story-of-mitt-romney-and-bain-capital-20120829&ct=home&lob=rollingstone&loc=us&env=desktop";
+            var pmc_tracking_image = new Image();
+            if ( 'undefined' !== typeof pmc_meta && 'string' === typeof pmc_meta.omni_visit_id ) {
+                pmc_tracking_url = pmc_tracking_url + '&omni_visit_id=' + pmc_meta.omni_visit_id;
+            }
+            if ( 'string' === typeof window.location.hash && window.location.hash.length ) {
+                pmc_tracking_url = pmc_tracking_url + "&h=" + encodeURIComponent( window.location.hash );
+            }
+            pmc_tracking_image.src = pmc_tracking_url + "&ts=" + Date.now();
+        </script>
+        <script async src="//js-sec.indexww.com/ht/p/182698-239012565232640.js"></script>
+<!-- Jetpack Open Graph Tags -->
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Rolling Stone" />
+<meta property="og:description" content="Music, Film, TV and Political News Coverage" />
+<meta property="og:url" content="https://www.rollingstone.com/" />
+<meta property="og:site_name" content="Rolling Stone" />
+<meta property="og:image" content="https://www.rollingstone.com/wp-content/uploads/2018/07/cropped-rs-favicon.png" />
+<meta property="og:image:width" content="512" />
+<meta property="og:image:height" content="512" />
+<meta property="og:locale" content="en_US" />
+<meta name="twitter:site" content="@RollingStone" />
+<meta name="twitter:card" content="summary" />
+
+<!-- End Jetpack Open Graph Tags -->
+            <link rel="preload" href="https://www.rollingstone.com/wp-content/themes/vip/pmc-rollingstone-2018/assets/build/fonts/Graphik/Graphik-Semibold.woff2" as="font" type="font/woff2">
+        <script type="text/javascript">
+/* <![CDATA[ */
+var pmc_krux = {"lob":"rollingstone","page-type":"home","env":"desktop","primary-category":"","primary-vertical":"","vertical":"","category":"","tag":"","author":"","logged-in":"","subscriber-type":""};
+
+/* ]]> */
+</script>
+<link rel="icon" href="https://www.rollingstone.com/wp-content/uploads/2018/07/cropped-rs-favicon.png?w=32" sizes="32x32" />
+<link rel="icon" href="https://www.rollingstone.com/wp-content/uploads/2018/07/cropped-rs-favicon.png?w=192" sizes="192x192" />
+<link rel="apple-touch-icon-precomposed" href="https://www.rollingstone.com/wp-content/uploads/2018/07/cropped-rs-favicon.png?w=180" />
+<meta name="msapplication-TileImage" content="https://www.rollingstone.com/wp-content/uploads/2018/07/cropped-rs-favicon.png?w=270" />
+            <link rel="stylesheet" type="text/css" id="wp-custom-css" href="https://www.rollingstone.com/?custom-css=171b554379" />
+
+                <script>
+            function PMC_RS_isSectionOpen ( name ) {
+                var storage = localStorage.getItem( 'PMC_RS_homeState' );
+                var hasState = storage && 'undefined' !== typeof JSON.parse( storage )[ name ];
+                return hasState ? JSON.parse( storage )[ name ] : true;
+            }
+
+            function PMC_RS_setHomeAppearance ( name ) {
+                var isSectionOpen = PMC_RS_isSectionOpen( name );
+                var section = document.querySelector( '[data-section="' + name +  '"]' );
+
+                if ( null !== section ) {
+                    if ( isSectionOpen ) {
+                        section.classList.remove( 'is-closing' );
+                        section.classList.remove( 'is-closed' );
+                    } else {
+                        section.classList.add( 'is-closing' );
+                        section.classList.add( 'is-closed' );
+                    }
+                }
+            }
+
+            function PMC_RS_toggleHomeAd ( name ) {
+                var isSectionOpen = PMC_RS_isSectionOpen( name );
+                var ad = document.querySelector( '[data-section-ad="' + name +  '"]' );
+
+                if ( ! isSectionOpen && null !== ad ) {
+                    ad.parentNode.removeChild( ad );
+                }
+            }
+        </script>
+            </head>
+
+
+        <body class="home blog pmc-desktop pmc-no-tablet pmc-no-mobile geo-us">
+
+
+        <!-- Google Tag Manager -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MH9FBDT"
+                      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MH9FBDT');</script>
+    <!-- End Google Tag Manager -->
+
+    <!-- pmc-tags-top Comscore -->  <noscript>
+        <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035310&c3=&c4=&c5=&c6=&c15=&cv=2.0&cj=1" />
+    </noscript>
+
+<!-- end pmc-tags-top Comscore --><!-- pmc-tags-top CrazyEgg --><!-- CrazyEgg Start -->
+<script type="text/javascript">
+    setTimeout(function(){var a=document.createElement("script");
+        var b=document.getElementsByTagName("script")[0];
+        a.src=document.location.protocol+"//script.crazyegg.com/pages/scripts/0011/4414.js?"+Math.floor(new Date().getTime()/3600000);
+        a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
+</script>
+<!-- CrazyEgg End -->
+<!-- end pmc-tags-top CrazyEgg --><!-- pmc-tags-top Quantcast -->   <script type="text/javascript"> var _qevents = _qevents || []; (function() { var elem = document.createElement('script'); elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js"; elem.async = true; elem.type = "text/javascript"; var scpt = document.getElementsByTagName('script')[0]; scpt.parentNode.insertBefore(elem, scpt); })(); </script>
+
+<!-- end pmc-tags-top Quantcast --><!-- pmc-tags-top Prefetch --><meta http-equiv="x-dns-prefetch-control" content="on"><link rel="dns-prefetch" href="//aax.amazon-adsystem.com"/><link rel="dns-prefetch" href="//ajax.googleapis.com"/><link rel="dns-prefetch" href="//apiservices.krxd.net"/><link rel="dns-prefetch" href="//beacon.krxd.net"/><link rel="dns-prefetch" href="//boygeniusreport.files.wordpress.com"/><link rel="dns-prefetch" href="//cdn.krxd.net"/><link rel="dns-prefetch" href="//cdn.syndication.twimg.com"/><link rel="dns-prefetch" href="//disqus.com"/><link rel="dns-prefetch" href="//edge.quantserve.com"/><link rel="dns-prefetch" href="//googleads.g.doubleclick.net"/><link rel="dns-prefetch" href="//i0.wp.com"/><link rel="dns-prefetch" href="//i1.wp.com"/><link rel="dns-prefetch" href="//i2.wp.com"/><link rel="dns-prefetch" href="//load.instinctiveads.com"/><link rel="dns-prefetch" href="//load.s3.amazonaws.com"/><link rel="dns-prefetch" href="//o.twimg.com"/><link rel="dns-prefetch" href="//p.skimresources.com"/><link rel="dns-prefetch" href="//pagead2.googlesyndication.com"/><link rel="dns-prefetch" href="//pbs.twimg.com"/><link rel="dns-prefetch" href="//pixel.quantserve.com"/><link rel="dns-prefetch" href="//pmcdeadline2.files.wordpress.com"/><link rel="dns-prefetch" href="//pmcfootwearnews.files.wordpress.com"/><link rel="dns-prefetch" href="//pmchollywoodlife.files.wordpress.com"/><link rel="dns-prefetch" href="//pmcvariety.files.wordpress.com"/><link rel="dns-prefetch" href="//r.skimresources.com"/><link rel="dns-prefetch" href="//s.gravatar.com"/><link rel="dns-prefetch" href="//s.skimresources.com"/><link rel="dns-prefetch" href="//s0.wp.com"/><link rel="dns-prefetch" href="//securepubads.g.doubleclick.net"/><link rel="dns-prefetch" href="//stats.wordpress.com"/><link rel="dns-prefetch" href="//summits.wwd.com"/><link rel="dns-prefetch" href="//ton.twimg.com"/><link rel="dns-prefetch" href="//tpc.googlesyndication.com"/><link rel="dns-prefetch" href="//www.google-analytics.com"/><link rel="dns-prefetch" href="//www.googletagmanager.com"/><link rel="dns-prefetch" href="//www.googletagservices.com"/><link rel="dns-prefetch" href="//www.youtube.com"/><link rel="dns-prefetch" href="//x.skimresources.com"/><!-- end pmc-tags-top Prefetch --><script async="1">
+    (function() {
+        __mtm = [ "5afb75072acf633f5a4b748c", "cdn01.mzbcdn.net/mngr" ];
+        var s = document.createElement('script');
+        s.async = 1;
+        s.src = '//' + __mtm[1] + '/mtm.js';
+        var e = document.getElementsByTagName('script')[0];
+        (e.parentNode || document.body).insertBefore(s, e);
+    })();
+</script><!-- Placeholder for Responsive Skin Ad -->
+<div id="skin-ad-section">
+
+    <div id="skin-ad-left-rail-container"></div>
+
+    <div id="skin-ad-right-rail-container"></div>
+    <div id="skin-ad-inject-container">
+            <div class="admz" id="adm-responsive-skin-ad">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="1">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-hp-skin-oop-uid0" class="ad-rotatable adw-1 adh-1"></div>
+    </div>
+            </div>
+                </div>
+    </div>
+</div>
+
+<!-- End Placeholder for Responsive Skin Ad -->
+            <div class="l-page" id="site_wrap">
+
+<div class="l-page__header">
+
+
+<div class="c-ad c-ad--desktop-header c-ad--728x90">
+        <div class="admz" id="adm-leaderboard">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="728">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-hp-leaderboard-uid1" class=" adw-728 adh-90"></div>
+    </div>
+            </div>
+                </div>
+</div><!-- .c-ad -->
+
+<div class="rs-leaderboard-ad"></div> <!-- marker for pmc-sticky-ad -->
+
+    <header class="l-header"
+            data-header
+            data-header-sticky-class="is-header-sticky"
+            data-header-ready-class="is-header-ready"
+            data-header-search-class="is-search-expanded">
+        <div class="l-header__wrap">
+            <div class="l-header__content">
+
+                                    <h1 class="l-header__branding">
+                        <a href="https://www.rollingstone.com/">
+                            <svg class="l-header__logo"><use xlink:href="#svg-rs-logo"></use></svg>
+                            <span class="screen-reader-text">Rolling Stone</span>
+                        </a>
+                    </h1>
+                <!-- .l-header__branding -->
+
+                <div class="l-header__block l-header__block--left t-bold">
+                    <a href="https://www.rollingstone.com/tips" class="l-header__link">Send Us a Tip</a>
+                </div><!-- .l-header__block--left -->
+
+                <div class="l-header__block l-header__block--right">
+                    <div class="c-cover t-bold ">
+
+
+        <a href="https://www.rollingstone.com/subscribe-more/" class="c-cover__cta c-cover__cta--desktop" data-flyout="is-header-subscribe-open">
+            Subscribe       </a>
+
+        <a href="https://www.rollingstone.com/subscribe-more/" class="c-cover__cta c-cover__cta--mobile">
+            Subscribe       </a>
+
+
+    <a href="https://www.rollingstone.com/subscribe-more/">
+        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=80" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=80 1x, https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=160 2x" alt="Issue 1323: Travis Scott" class="c-cover__image" /> </a>
+
+</div><!-- .c-cover -->
+                </div><!-- .l-header__block--right -->
+
+
+<nav class="l-header__nav">
+    <div class="l-header__toggle l-header__toggle--hamburger">
+
+<button class="c-hamburger" data-flyout="is-mega-open" data-flyout-scroll-freeze>
+    <svg class="c-hamburger__icon"><use xlink:href="#svg-icon-hamburger"></use></svg>
+    <span class="c-hamburger__label t-semibold">Menu</span>
+</button><!-- .c-hamburger -->
+    </div><!-- .l-header__toggle--hamburger -->
+
+    <div class="l-header__toggle l-header__toggle--close">
+
+<button class="c-close-button" data-flyout="is-mega-open" data-flyout-trigger="close">
+    <span class="screen-reader-text">Close the menu</span>
+</button><!-- .c-close-button -->
+    </div><!-- .l-header__toggle--close -->
+
+    <ul class="l-header__menu t-semibold">
+<li class="l-header__menu-item"><a href='https://www.rollingstone.com/music/' class="l-header__menu-link">Music</a></li>
+
+<li class="l-header__menu-item"><a href='https://www.rollingstone.com/tv/' class="l-header__menu-link">TV</a></li>
+
+<li class="l-header__menu-item"><a href='https://www.rollingstone.com/movies/' class="l-header__menu-link">Movies</a></li>
+
+<li class="l-header__menu-item"><a href='https://www.rollingstone.com/politics/' class="l-header__menu-link">Politics</a></li>
+
+<li class="l-header__menu-item"><a href='https://www.rollingstone.com/culture/' class="l-header__menu-link">Culture</a></li>
+
+<li class="l-header__menu-item"><a href='https://www.rollingstone.com/rs-pro/' class="l-header__menu-link"><span class="c-icon c-icon--rs-pro"><svg><use xlink:href="#svg-rs-badge"></use></svg></span>Pro</a></li>
+</ul></nav><!-- .l-header__nav -->
+
+            </div><!-- .l-header__content -->
+
+            <div class="l-header__content l-header__content--sticky">
+
+                <a href="https://www.rollingstone.com/" class="l-header__branding l-header__branding--sticky">
+                    <svg class="l-header__logo l-header__logo--sticky"><use xlink:href="#svg-rs-logo"></use></svg>
+                </a><!-- .l-header__branding--sticky -->
+
+                <div class="l-header__toggle l-header__toggle--sticky l-header__toggle--hamburger">
+
+<button class="c-hamburger" data-flyout="is-mega-open" data-flyout-scroll-freeze>
+    <svg class="c-hamburger__icon"><use xlink:href="#svg-icon-hamburger"></use></svg>
+    <span class="c-hamburger__label t-semibold">Menu</span>
+</button><!-- .c-hamburger -->
+                </div><!-- .l-header__toggle--sticky--hamburger -->
+
+                <div class="l-header__toggle l-header__toggle--sticky l-header__toggle--close">
+
+<button class="c-close-button" data-flyout="is-mega-open" data-flyout-trigger="close">
+    <span class="screen-reader-text">Close the menu</span>
+</button><!-- .c-close-button -->
+                </div><!-- .l-header__toggle--sticky--close -->
+
+
+<a href="https://www.rollingstone.com/music/music-country/randy-rogers-band-new-album-hellbent-782096/" class="l-header__block l-header__block--read-next">
+    <span class="l-header__read-next-label">Read Next</span>
+    <span class="l-header__read-next-title t-semibold">
+        Randy Rogers Band Announces New &#039;Hellbent&#039; Album With Dave Cobb   </span>
+</a><!-- .l-header__block--read-next -->
+
+                <a href="https://www.rollingstone.com/tips/" class="l-header__block l-header__block--sticky-link t-bold">
+                    Send Us a Tip               </a>
+
+                <a href="https://www.rollingstone.com/subscribe-more/" class="l-header__block l-header__block--sticky-link  t-bold">
+                    Subscribe               </a>
+
+            </div><!-- .l-header__content--sticky -->
+        </div><!--. l-header__wrap -->
+
+        <div class="l-header__wrap l-header__wrap--layer l-header__wrap--search">
+
+            <div class="l-header__search t-semibold is-search-expandable" data-header-search-trigger>
+                <div data-st-search-form="small_search_form"></div>
+            </div><!-- .l-header__search -->
+
+        </div><!-- .l-header__wrap--layer--search -->
+
+        <div class="l-header__wrap l-header__wrap--layer l-header__wrap--subscribe">
+
+            <div class="l-header__subscribe">
+
+<div class="c-subscribe">
+    <div class="c-subscribe__block c-subscribe__block--get-magazine" >
+        <div class="c-subscribe__cover">
+            <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=184" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=184 1x, https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=368 2x" alt="Issue 1323: Travis Scott" class="" />     </div>
+        <div class="c-subscribe__description">
+            <p class="c-subscribe__heading t-bold">Get The Magazine</p>
+            <p class="c-subscribe__content">Subscribe to the all-new Rolling Stone! Everything you need to know from the authority on music, entertainment, politics and pop culture.</p>
+            <p class="c-subscribe__important t-semibold">Order today and save over 66%!</p>
+            <a href="https://www.rollingstone.com/subscribe-more/" class="c-subscribe__button c-subscribe__button--subscribe t-bold t-bold--upper">
+                Subscribe Now           </a>
+        </div>
+    </div>
+    <div class="c-subscribe__block">
+        <div class="c-subscribe__description">
+            <p class="c-subscribe__heading t-bold">Newsletter Signup</p>
+            <p class="c-subscribe__content">Sign up for our newsletter and go inside the world of music, culture and entertainment.</p>
+            <form class="c-subscribe__form" action="https://pages.email.rollingstone.com/signup-api/" method="POST">
+                <input type="hidden" name="Editorial_RollingStone_Opted_In" value="Yes">
+<input type="hidden" name="Editorial_RollingStone_Source" value="rs site">
+<input name="__contextName" value="FormPost" type="hidden">
+<input name="__executionContext" value="POST" type="hidden">
+<input name="__successPage" class="js-newsletter-successpage" data-base-url="/signup?signup=success" value="/signup?signup=success" type="hidden">
+<input type="email" name="EmailAddress" class="js-newsletter-email c-subscribe__input" placeholder="Your email" required>
+
+<script>
+jQuery( document ).ready(function($) {
+
+    // Validate email will return true if valid and false if invalid.
+    function validate_email( email ) {
+        const expr = /^([\w.+-]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
+        return expr.test( email );
+    }
+
+    $email_field = jQuery('.js-newsletter-email')
+    $success_page_field = jQuery('.js-newsletter-successpage');
+
+    if ( 0 === $email_field.length || 0 === $success_page_field.length ) {
+        return;
+    }
+
+    success_page_base_url = $success_page_field.data( 'base-url' );
+
+    $email_field.on( 'keyup blur', ( e ) => {
+
+        // validate email and check for empty value.
+        if ( '' === $( e.target ).val() || validate_email( $( e.target ).val() ) ) {
+            $( e.target ).removeClass( 'invalid' );
+        }
+
+        var email_address = encodeURIComponent( $( e.target ).val() );
+        $success_page_field.val( success_page_base_url + '&email=' + email_address );
+
+    } );
+
+});
+</script>
+                <button type="submit" class="c-subscribe__button c-subscribe__button--newsletter t-bold t-bold--upper">
+                    Sign Up             </button>
+            </form>
+        </div>
+    </div>
+</div>
+<svg class="c-subscribe__x" data-flyout="is-header-subscribe-open" viewPort="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg"><line x1="1" y1="20" x2="20" y2="1" stroke="red" stroke-width="2"/><line x1="1" y1="1" x2="20" y2="20" stroke="red" stroke-width="2"/></svg>
+            </div><!-- .l-header__subscribe -->
+
+        </div><!-- .l-header__wrap--layer--subscribe -->
+    </header><!-- .l-header -->
+
+
+</div>
+        <div class="l-page__content">
+        <div class="l-home-top">
+            <div class="l-home-top__3-pack">
+    <section class="l-3-pack l-3-pack--reversed">
+                        <div class="l-3-pack__item l-3-pack__item--primary">
+
+    <article class="c-card c-card--overlay c-card--overlay--home">
+        <a href="https://www.rollingstone.com/politics/politics-features/alexandria-ocasio-cortez-media-781571/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--ratio-5x6">
+                    <img width="584" height="742" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/aoc-caro.jpg?crop=725:870&width=440" class="c-crop__img wp-post-image" alt="Alexandria Ocasio-Cortez, Ilhan Omar, Dina Titus. Rep. Alexandria Ocasio-Cortez, left, and D-N.Y., Rep. Ilhan Omar, D-Minn., center, walk down the House steps to take a group photograph of the House Democratic women members of the 116th Congress on the East Front Capitol Plaza on Capitol Hill in Washington, as the 116th Congress begins. Also pictured is Rep. Dina Titus, D-Nev., rightNew Congress, Washington, USA - 04 Jan 2019" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/aoc-caro.jpg?crop=725:870&width=440 440w, https://www.rollingstone.com/wp-content/uploads/2018/12/aoc-caro.jpg?crop=725:870&width=560 560w, https://www.rollingstone.com/wp-content/uploads/2018/12/aoc-caro.jpg?crop=725:870&width=660 660w, https://www.rollingstone.com/wp-content/uploads/2018/12/aoc-caro.jpg?crop=725:870&width=725 725w" sizes="(max-width: 480px) 440px, (max-width: 767px) 725px, (max-width: 959px) 660px, 560px" />             </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Alexandria Ocasio-Cortez, Crusher of Sacred Cows</h3><!-- .c-card__heading -->
+
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics Features</span>
+    </div><!-- c-card__tag -->
+
+
+<p class="c-card__lead">
+    With its silly swipes at AOC, the American political establishment is once again revealing its blindness to its own unpopularity</p><!-- c-card__lead -->
+
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--overlay -->
+
+                </div><!-- .l-3-pack__item--primary -->
+                            <div class="l-3-pack__item l-3-pack__item--secondary">
+
+    <article class="c-card c-card--featured-home">
+        <a href="https://www.rollingstone.com/music/music-features/future-the-wizrd-profile-779220/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--size-featured-home">
+                    <img width="1240" height="1240" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/future-11-x-14.jpg?crop=1240:1240&width=190" class="c-crop__img wp-post-image" alt="281367-01-006 001" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/future-11-x-14.jpg?crop=1240:1240&width=190 190w, https://www.rollingstone.com/wp-content/uploads/2019/01/future-11-x-14.jpg?crop=1240:1240&width=210 210w, https://www.rollingstone.com/wp-content/uploads/2019/01/future-11-x-14.jpg?crop=1240:1240&width=240 240w, https://www.rollingstone.com/wp-content/uploads/2019/01/future-11-x-14.jpg?crop=1240:1240&width=270 270w, https://www.rollingstone.com/wp-content/uploads/2019/01/future-11-x-14.jpg?crop=1240:1240&width=350 350w" sizes="(max-width: 480px) 210px, (max-width: 767px) 350px, (max-width: 959px) 240px, (max-width: 1100px) 270px, 190px" />              </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Future Changed Rap for a Generation. He Doesn’t Know How to Feel About It</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Music Features</span>
+    </div><!-- c-card__tag -->
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--featured -->
+
+            </div><!-- .l-3-pack__item--[secondary|tertiary] -->
+                    <div class="l-3-pack__item l-3-pack__item--tertiary">
+
+    <article class="c-card c-card--featured-home">
+        <a href="https://www.rollingstone.com/politics/politics-news/kamala-harris-2020-781990/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--size-featured-home">
+                    <img width="574" height="632" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-8.23.47-AM.png?crop=1240:1240&width=190" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-8.23.47-AM.png?crop=1240:1240&width=190 190w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-8.23.47-AM.png?crop=1240:1240&width=210 210w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-8.23.47-AM.png?crop=1240:1240&width=240 240w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-8.23.47-AM.png?crop=1240:1240&width=270 270w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-8.23.47-AM.png?crop=1240:1240&width=350 350w" sizes="(max-width: 480px) 210px, (max-width: 767px) 350px, (max-width: 959px) 240px, (max-width: 1100px) 270px, 190px" />             </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Kamala Harris Officially Enters 2020 Race for President</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics News</span>
+    </div><!-- c-card__tag -->
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--featured -->
+
+            </div><!-- .l-3-pack__item--[secondary|tertiary] -->
+            </section><!-- .l-3-pack -->
+</div><!-- /.l-home-top__3-pack -->
+
+            <div class="l-home-top__list">
+
+<div class="c-latest-list">
+
+    <div class="c-latest-list__header">
+        <h4 class="c-latest-list__heading">
+            <span class="t-bold">The Latest</span>
+        </h4>
+    </div><!-- .c-latest-list__header -->
+
+            <div class="c-latest-list__item">
+
+<article class="c-card c-card--excerpt">
+    <a href="https://www.rollingstone.com/politics/politics-features/mlk-amazon-fbi-781327/" class="c-card__wrap">
+        <header class="c-card__header">
+
+<h3 class="c-card__heading t-copy">
+
+    Op-Ed: MLK Offers a Lesson on Why We Should Be Worried About Amazon and the FBI</h3><!-- .c-card__heading -->
+
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics Features</span>
+    </div><!-- c-card__tag -->
+
+
+<div class="c-card__timestamp t-semibold">
+    <span class="screen-reader-text">Posted</span>
+    1 day ago</div><!-- c-card__timestamp -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+        </div><!-- /.c-latest-list__item -->
+                    <hr class="c-latest-list__line">
+                    <div class="c-latest-list__item">
+
+<article class="c-card c-card--excerpt">
+    <a href="https://www.rollingstone.com/tv/tv-features/conan-obrien-late-night-simpsons-catholicism-780706/" class="c-card__wrap">
+        <header class="c-card__header">
+
+<h3 class="c-card__heading t-copy">
+
+    The Last Word: Conan O&#8217;Brien</h3><!-- .c-card__heading -->
+
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> TV Features</span>
+    </div><!-- c-card__tag -->
+
+
+<div class="c-card__timestamp t-semibold">
+    <span class="screen-reader-text">Posted</span>
+    1 day ago</div><!-- c-card__timestamp -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+        </div><!-- /.c-latest-list__item -->
+                    <hr class="c-latest-list__line">
+                    <div class="c-latest-list__item">
+
+<article class="c-card c-card--excerpt">
+    <a href="https://www.rollingstone.com/music/music-news/martin-luther-king-stevie-wonder-happy-birthday-781384/" class="c-card__wrap">
+        <header class="c-card__header">
+
+<h3 class="c-card__heading t-copy">
+
+    Stevie Wonder&#8217;s Mission to Honor Martin Luther King Jr.</h3><!-- .c-card__heading -->
+
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Music News</span>
+    </div><!-- c-card__tag -->
+
+
+<div class="c-card__timestamp t-semibold">
+    <span class="screen-reader-text">Posted</span>
+    1 day ago</div><!-- c-card__timestamp -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+        </div><!-- /.c-latest-list__item -->
+                    <hr class="c-latest-list__line">
+                    <div class="c-latest-list__item">
+
+<article class="c-card c-card--excerpt">
+    <a href="https://www.rollingstone.com/politics/politics-features/roe-v-wade-2019-781520/" class="c-card__wrap">
+        <header class="c-card__header">
+
+<h3 class="c-card__heading t-copy">
+
+    Op-Ed: On the Anniversary of Roe v. Wade, We’re Still Fighting for Access to Safe, Legal Abortion</h3><!-- .c-card__heading -->
+
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics Features</span>
+    </div><!-- c-card__tag -->
+
+
+<div class="c-card__timestamp t-semibold">
+    <span class="screen-reader-text">Posted</span>
+    16 hours ago</div><!-- c-card__timestamp -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+        </div><!-- /.c-latest-list__item -->
+            <a href="https://www.rollingstone.com/2019/01/" class="c-latest-list__cta">
+        <span class="t-semibold">More News</span>
+    </a>
+</div><!-- .clatest-list -->
+            </div><!-- /.l-home-top__list -->
+            <aside class="l-home-top__sidebar">
+
+<div class="l-home-top__sidebar-item">
+    <div class="c-trending c-trending--hero">
+
+            <h4 class="c-trending__heading t-bold t-bold--loose">
+                Trending            </h4><!-- .c-trending__heading -->
+
+
+        <ol class="c-trending__list">
+                            <li class="c-trending__item">
+                    <a href="https://www.rollingstone.com/politics/politics-features/roe-v-wade-2019-781520/" class="c-trending__link">
+                        <h5 class="c-trending__title">
+                            <div class="c-trending__number"><span class="c-trending__counter t-bold"></span></div>
+                            <span class="c-trending__caption t-semibold">Op-Ed: On the Anniversary of Roe v. Wade, We’re Still Fighting for Access to Safe, Legal Abortion</span>
+                        </h5><!-- .c-trending__title -->
+                    </a><!-- .c-trending__link -->
+                </li><!-- .c-trending__item -->
+                            <li class="c-trending__item">
+                    <a href="https://www.rollingstone.com/politics/politics-features/alexandria-ocasio-cortez-media-781571/" class="c-trending__link">
+                        <h5 class="c-trending__title">
+                            <div class="c-trending__number"><span class="c-trending__counter t-bold"></span></div>
+                            <span class="c-trending__caption t-semibold">Alexandria Ocasio-Cortez, Crusher of Sacred Cows</span>
+                        </h5><!-- .c-trending__title -->
+                    </a><!-- .c-trending__link -->
+                </li><!-- .c-trending__item -->
+                            <li class="c-trending__item">
+                    <a href="https://www.rollingstone.com/music/music-features/pearl-jam-chris-cornell-death-album-update-778635/" class="c-trending__link">
+                        <h5 class="c-trending__title">
+                            <div class="c-trending__number"><span class="c-trending__counter t-bold"></span></div>
+                            <span class="c-trending__caption t-semibold">Pearl Jam: &#8216;Chris Cornell&#8217;s Death Has Been a Tough One to Wrap Our Heads Around&#8217;</span>
+                        </h5><!-- .c-trending__title -->
+                    </a><!-- .c-trending__link -->
+                </li><!-- .c-trending__item -->
+                            <li class="c-trending__item">
+                    <a href="https://www.rollingstone.com/music/music-news/lady-gaga-mike-pence-worst-representation-christian-782040/" class="c-trending__link">
+                        <h5 class="c-trending__title">
+                            <div class="c-trending__number"><span class="c-trending__counter t-bold"></span></div>
+                            <span class="c-trending__caption t-semibold">Lady Gaga to Mike Pence: &#8216;You Are the Worst Representation of What It Means to Be a Christian&#8217;</span>
+                        </h5><!-- .c-trending__title -->
+                    </a><!-- .c-trending__link -->
+                </li><!-- .c-trending__item -->
+                            <li class="c-trending__item">
+                    <a href="https://www.rollingstone.com/movies/movie-news/fyre-fest-documentary-cook-fundraising-goal-782116/" class="c-trending__link">
+                        <h5 class="c-trending__title">
+                            <div class="c-trending__number"><span class="c-trending__counter t-bold"></span></div>
+                            <span class="c-trending__caption t-semibold">&#8216;Fyre&#8217; Fest Documentary: Bahamian Cook Surpasses $123,000 Fundraising Goal</span>
+                        </h5><!-- .c-trending__title -->
+                    </a><!-- .c-trending__link -->
+                </li><!-- .c-trending__item -->
+                    </ol><!-- .c-trending__list -->
+    </div><!-- .c-trending -->
+</div>
+    <div class="admz" id="adm-right-rail-1">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="300">
+
+<div class="pmc-adm-goog-pub-div c-ad c-ad--300x250 c-ad--boxed">
+    <div id="gpt-dsk-tab-hp-rail-top-uid2" class="ad-rotatable adw-300 adh-250"></div>
+    </div>
+            </div>
+                </div>
+    <div class="admz" id="adm-widget-dsk-tab-hp-1x1">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="1">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-logo1x1-uid3" class="ad-rotatable adw-1 adh-1"></div>
+    </div>
+            </div>
+                </div>
+                            </aside><!-- /.l-home-top__sidebar -->
+        </div><!-- .l-home-top -->
+
+                        <div class="l-section l-section--no-separator l-section--with-bottom-margin">
+
+        <div class="c-features">
+
+                            <article class="c-features__main">
+                    <a href="https://www.rollingstone.com/movies/movie-lists/25-movies-we-cant-wait-to-see-at-sundance-2019-779642/" class="c-features__main-wrap">
+
+                        <figure class="c-features__main-image">
+
+                            <div class="c-crop c-crop--size-features-main">
+                                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/sundance-films-2.jpg?crop=900:600&width=510" class="c-crop__img wp-post-image" alt="Emma Thompson in Late Night, Noah Jupe in Honeyboy and Miles Davis." data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/sundance-films-2.jpg?crop=900:600&width=510 510w, https://www.rollingstone.com/wp-content/uploads/2019/01/sundance-films-2.jpg?crop=900:600&width=780 780w, https://www.rollingstone.com/wp-content/uploads/2019/01/sundance-films-2.jpg?crop=900:600&width=480 480w" sizes="(max-width: 480px) 480px, (max-width: 820px) 780px, 510px" />                           </div><!-- .c-crop -->
+
+                        </figure><!-- .c-features__main-image -->
+
+                        <span class="c-features__tag t-bold">Features</span>
+
+                        <header class="c-features__main-header">
+                            <h3 class="c-features__main-headline t-bold">
+                                Sundance 2019                           </h3><!-- /.c-features__main-headline -->
+                            <p class="c-features__main-lead t-copy">
+                                25 Movies We Can&#8217;t Wait to See                            </p><!-- /.c-features__main-lead -->
+                        </header><!-- /.c-features__main-header -->
+
+                    </a><!-- /.c-features__main-wrap -->
+                </article><!-- /.c-features__main -->
+                        <div class="c-features__slider c-slider" data-slider>
+
+                <a href="" class="c-slider__nav c-slider__nav--left" data-slider-nav="prev">
+                    <svg class="c-slider__icon">
+                        <use xlink:href="#svg-icon-chevron"></use>
+                    </svg>
+                </a>
+                <a href="" class="c-slider__nav c-slider__nav--right" data-slider-nav="next">
+                    <svg class="c-slider__icon">
+                        <use xlink:href="#svg-icon-chevron"></use>
+                    </svg>
+                </a>
+
+                <div class="c-slider__track" data-slider-track>
+                                            <article class="c-features__item c-slider__item" data-slider-item>
+                            <a href="https://www.rollingstone.com/tv/tv-news/mahershala-ali-reflects-on-moonlight-oscar-win-and-the-first-albums-he-ever-bought-778855/" class="c-features__item-wrap">
+
+                                <figure class="c-features__item-image">
+
+                                    <div class="c-crop c-crop--ratio-11x14">
+                                        <img width="220" height="280" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/R1322_FEA_M_Ali.jpg?crop=220:280&width=220" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/R1322_FEA_M_Ali.jpg?crop=220:280&width=220 220w, https://www.rollingstone.com/wp-content/uploads/2018/12/R1322_FEA_M_Ali.jpg?crop=220:280&width=440 440w" sizes="220px" />                                   </div><!-- .c-crop -->
+
+                                </figure><!-- .c-features__item-image -->
+
+                                <header class="c-features__item-header">
+                                    <h3 class="c-features__item-headline t-semibold">
+                                        &#8216;First Time&#8217; With Mahershala Ali                                    </h3><!-- /.c-features__item-headline -->
+                                </header><!-- /.c-features__item-header -->
+
+                            </a><!-- /.c-features__item-wrap -->
+                        </article><!-- /.c-features__item c-slider__item -->
+                                            <article class="c-features__item c-slider__item" data-slider-item>
+                            <a href="https://www.rollingstone.com/music/music-news/greta-van-fleet-on-the-grammys-why-its-time-to-stop-the-zeppelin-comparisons-779296/" class="c-features__item-wrap">
+
+                                <figure class="c-features__item-image">
+
+                                    <div class="c-crop c-crop--ratio-11x14">
+                                        <img width="220" height="280" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/GVF_RS_Gafkjen_057.jpg?crop=220:280&width=220" class="c-crop__img wp-post-image" alt="GRETA VAN FLEET" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/GVF_RS_Gafkjen_057.jpg?crop=220:280&width=220 220w, https://www.rollingstone.com/wp-content/uploads/2019/01/GVF_RS_Gafkjen_057.jpg?crop=220:280&width=440 440w" sizes="220px" />                                   </div><!-- .c-crop -->
+
+                                </figure><!-- .c-features__item-image -->
+
+                                <header class="c-features__item-header">
+                                    <h3 class="c-features__item-headline t-semibold">
+                                        Greta Van Fleet on Why It&#8217;s Time to Stop the Zeppelin Comparisons                                 </h3><!-- /.c-features__item-headline -->
+                                </header><!-- /.c-features__item-header -->
+
+                            </a><!-- /.c-features__item-wrap -->
+                        </article><!-- /.c-features__item c-slider__item -->
+                                            <article class="c-features__item c-slider__item" data-slider-item>
+                            <a href="https://www.rollingstone.com/music/music-features/travis-scott-rap-superstar-cover-story-767906/" class="c-features__item-wrap">
+
+                                <figure class="c-features__item-image">
+
+                                    <div class="c-crop c-crop--ratio-11x14">
+                                        <img width="220" height="280" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/travis-extra-1.jpg?crop=220:280&width=220" class="c-crop__img wp-post-image" alt="travis scott" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/travis-extra-1.jpg?crop=220:280&width=220 220w, https://www.rollingstone.com/wp-content/uploads/2018/12/travis-extra-1.jpg?crop=220:280&width=440 440w" sizes="220px" />                                  </div><!-- .c-crop -->
+
+                                </figure><!-- .c-features__item-image -->
+
+                                <header class="c-features__item-header">
+                                    <h3 class="c-features__item-headline t-semibold">
+                                        On the Cover: Travis Scott                                  </h3><!-- /.c-features__item-headline -->
+                                </header><!-- /.c-features__item-header -->
+
+                            </a><!-- /.c-features__item-wrap -->
+                        </article><!-- /.c-features__item c-slider__item -->
+                                    </div><!-- /.c-slider__track -->
+            </div><!-- /.c-features__slider -->
+        </div><!-- /.c-features -->
+
+
+    </div><!-- /.l-section -->
+<div class="l-section" data-section="Music">
+
+    <script>
+        PMC_RS_setHomeAppearance( "Music" );
+    </script>
+
+    <div class="l-section__header">
+        <div class="c-section-header">
+            <h3 class="c-section-header__heading t-bold t-bold--condensed">
+                Music           </h3>
+                            <a href="/music/" class="c-section-header__cta t-semibold t-semibold--upper t-semibold--loose">
+                    View All                </a>
+                        <p class="c-section-header__msg">
+                You have set the display of this section to be hidden.<br>
+                Click the button to the right to show it again.         </p><!-- /.c-section-header__msg -->
+            <a href="#" class="c-section-header__btn" data-section-toggle>
+                <span class="c-section-header__hide t-semibold t-semibold--upper">Hide</span>
+                <span class="c-section-header__show t-semibold t-semibold--upper">Show</span>
+                <svg class="c-section-header__btn-arrow">
+                    <use xlink:href="#svg-icon-arrow-down"></use>
+                </svg>
+            </a>
+        </div><!-- .c-section-header -->
+    </div><!-- /.l-section__header -->
+
+    <div class="l-section__content">
+        <div class="l-section__grid">
+            <div class="c-cards-grid">
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--primary ">
+    <a href="https://www.rollingstone.com/music/music-news/drax-project-hailee-steinfeld-woke-up-late-782125/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/DRAX-Jory-Lee-Cordy-8121re300.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/DRAX-Jory-Lee-Cordy-8121re300.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/DRAX-Jory-Lee-Cordy-8121re300.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/DRAX-Jory-Lee-Cordy-8121re300.jpg?crop=900:600&width=335 335w, https://www.rollingstone.com/wp-content/uploads/2019/01/DRAX-Jory-Lee-Cordy-8121re300.jpg?crop=900:600&width=730 730w" sizes="(max-width: 767px) 730px, (max-width: 380px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Hear Drax Project, Hailee Steinfeld Team for New Song &#8216;Woke Up Late&#8217;</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Music News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Daniel Kreps</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    New Zealand band collaborates with singer for single about &quot;wrapping your head around the adventure of the night before and ultimately deciding that you&#039;re cool with it&quot;</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/music/music-country/randy-rogers-band-new-album-hellbent-782096/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/RRB-Press-Shot-2019.jpeg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Randy Rogers Band" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/RRB-Press-Shot-2019.jpeg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/RRB-Press-Shot-2019.jpeg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/RRB-Press-Shot-2019.jpeg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Randy Rogers Band Announces New &#8216;Hellbent&#8217; Album With Dave Cobb</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Music Country</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Jeff Gage</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Due in April, LP is the Texas group&#039;s first release since 2016&#039;s &#039;Nothing Shines Like Neon&#039;</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+
+<div class="c-cards-grid__item">
+    <article class="c-card c-card--grid c-card--grid--secondary c-card--grid-sponsored">
+            <div class="admz" id="adm-sponsored-homepage-sections">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="3">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-native-uid4" class="ad-rotatable adw-3 adh-3"></div>
+    </div>
+            </div>
+                </div>
+    </article><!-- .c-card--grid -->
+</div><!-- /.c-cards-grid__item -->
+                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/music/music-news/ozzy-osbourne-bat-plush-toy-782066/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9131895a.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Ozzy OsbourneOzzy Osbourne in Concert - 31 Dec 1981" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9131895a.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9131895a.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9131895a.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Ozzy Osbourne Commemorates Bat-Biting Anniversary With Plush Toy</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Music News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Daniel Kreps</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Singer releases bat doll with detachable head to celebrate incident from January 20th, 1982 concert</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/music/music-country/best-country-songs-this-week-maren-morris-yola-782016/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/maren-yola-split.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Maren Morris, Yola" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/maren-yola-split.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/maren-yola-split.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/maren-yola-split.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    10 Best Country and Americana Songs to Hear Now: Maren Morris, Yola</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Music Country</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Robert Crawford</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Maren Morris&#039;s &quot;Girl,&quot; Yola&#039;s &quot;Faraway Look&quot; and other tracks to hear this week</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/music/music-country/pickathon-2019-lineup-tyler-childers-782049/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9782561ek.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Tyler Childers" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9782561ek.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9782561ek.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9782561ek.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Tyler Childers, Mike and the Moonpies Set for Pickathon 2019 Lineup</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Music Country</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Jeff Gage</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Nathaniel Rateliff and the Night Sweats, Mandolin Orange and others set for Oregon&#039;s fest in the woods</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                            </div><!-- .c-cards-grid -->
+        </div><!-- /.l-section__grid -->
+
+        <div class="l-section__sidebar">
+            <div class="l-section__sticky c-sticky c-sticky--size-grow" data-section-ad="Music">
+                <script>
+                    PMC_RS_toggleHomeAd( "Music" );
+                </script>
+                <div class="c-sticky__item">
+                    <div class="c-ad c-ad--300x250">
+        <div class="admz" id="adm-front-section-sticky-ad">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="300">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-railX-uid5" class="ad-rotatable adw-300 adh-250"></div>
+    </div>
+            </div>
+                </div>
+</div>
+                </div><!-- /.c-sticky__item -->
+            </div><!-- /.l-section__sticky c-sticky c-sticky--size-grow -->
+
+            <div class="l-section__sidebar-footer">
+                            </div><!-- /.l-section__sidebar-footer -->
+        </div><!-- /.l-section__sidebar -->
+
+                    <div class="l-section__block">
+
+<div class="c-reviews">
+    <h3 class="c-reviews__label">
+        <span class="c-reviews__label-head t-bold">Album</span>
+        <span class="c-reviews__label-tail t-bold">Reviews</span>
+    </h3><!-- /.c-reviews__label -->
+
+    <ul class="c-reviews__list">
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/music/music-album-reviews/review-international-artist-is-a-boogie-wit-da-hoodies-bid-for-crossover-success-666893/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-1x1">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/06/34348544_480721632385821_6519541204621721600_n.jpg?crop=1:1,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/06/34348544_480721632385821_6519541204621721600_n.jpg?crop=1:1,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/06/34348544_480721632385821_6519541204621721600_n.jpg?crop=1:1,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="200" />          </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            A Boogie Wit Da Hoodie                                  </span>
+            </h4>
+
+                        <h5 class="c-reviews-card__subheadline">
+                <span class="t-semibold t-semibold--upper">
+                    International Artist                </span>
+            </h5>
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">The Bronx rapper&#039;s latest is a shameless if charming bid for crossover success.</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/music/music-album-reviews/randy-houser-magnolia-review-748614/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-1x1">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/11/RH-Magnolia-3000x3000-1280x1280.jpg?crop=1:1,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/11/RH-Magnolia-3000x3000-1280x1280.jpg?crop=1:1,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/11/RH-Magnolia-3000x3000-1280x1280.jpg?crop=1:1,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="200" />           </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                    <use xlink:href="#svg-icon-star--half"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            Randy Houser                                    </span>
+            </h4>
+
+                        <h5 class="c-reviews-card__subheadline">
+                <span class="t-semibold t-semibold--upper">
+                    Magnolia                </span>
+            </h5>
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">Country singer sounds grand on his fifth album</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/music/music-album-reviews/bad-bunny-x100pre-album-review-772379/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-1x1">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/bad-bunny.jpg?crop=1:1,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/bad-bunny.jpg?crop=1:1,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/12/bad-bunny.jpg?crop=1:1,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="200" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            Bad Bunny                                   </span>
+            </h4>
+
+                        <h5 class="c-reviews-card__subheadline">
+                <span class="t-semibold t-semibold--upper">
+                    X100PRE             </span>
+            </h5>
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">24-year-old Puerto Rican star&#039;s debut full-length is assured, varied and full of potential hits</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/music/music-album-reviews/review-alessia-cara-never-runs-out-of-eloquent-coming-of-age-complaints-on-the-pains-of-growing-760978/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-1x1">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/11/Alessia-Cara-pains-of-growing.jpg?crop=1:1,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/11/Alessia-Cara-pains-of-growing.jpg?crop=1:1,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/11/Alessia-Cara-pains-of-growing.jpg?crop=1:1,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="200" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            Alessia Cara                                    </span>
+            </h4>
+
+                        <h5 class="c-reviews-card__subheadline">
+                <span class="t-semibold t-semibold--upper">
+                    The Pains of Growing                </span>
+            </h5>
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">On her second LP, the 22-year-old singer emerges as a bold new voice in young-adult angst.</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+            </ul><!-- /.c-reviews__list -->
+</div><!-- .c-reviews -->
+            </div><!-- /.l-section__block -->
+
+            </div><!-- /.l-section__content -->
+</div><!-- /.l-section -->
+<div class="l-section" data-section="Politics">
+
+    <script>
+        PMC_RS_setHomeAppearance( "Politics" );
+    </script>
+
+    <div class="l-section__header">
+        <div class="c-section-header">
+            <h3 class="c-section-header__heading t-bold t-bold--condensed">
+                Politics            </h3>
+                            <a href="/politics/" class="c-section-header__cta t-semibold t-semibold--upper t-semibold--loose">
+                    View All                </a>
+                        <p class="c-section-header__msg">
+                You have set the display of this section to be hidden.<br>
+                Click the button to the right to show it again.         </p><!-- /.c-section-header__msg -->
+            <a href="#" class="c-section-header__btn" data-section-toggle>
+                <span class="c-section-header__hide t-semibold t-semibold--upper">Hide</span>
+                <span class="c-section-header__show t-semibold t-semibold--upper">Show</span>
+                <svg class="c-section-header__btn-arrow">
+                    <use xlink:href="#svg-icon-arrow-down"></use>
+                </svg>
+            </a>
+        </div><!-- .c-section-header -->
+    </div><!-- /.l-section__header -->
+
+    <div class="l-section__content">
+        <div class="l-section__grid">
+            <div class="c-cards-grid">
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--primary ">
+    <a href="https://www.rollingstone.com/politics/politics-features/roe-v-wade-2019-781520/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/roe-v-wade-anniversary.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="People gather for a rally in support of women&#039;s reproductive rights that was called in response to announcement of Judge Brett Kavanaugh as President Donald Trump&#039;s nominee for the U.S. Supreme Court in New York, New York, USA, 10 July 2018. Democrats and groups actively supporting women&#039;s reproductive rights are attacking Kavanaugh as being too conservative.Rally to Protect Women&#039;s Reproductive Rights in New York, USA - 10 Jul 2018" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/roe-v-wade-anniversary.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/roe-v-wade-anniversary.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/roe-v-wade-anniversary.jpg?crop=900:600&width=335 335w, https://www.rollingstone.com/wp-content/uploads/2019/01/roe-v-wade-anniversary.jpg?crop=900:600&width=730 730w" sizes="(max-width: 767px) 730px, (max-width: 380px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Op-Ed: On the Anniversary of Roe v. Wade, We’re Still Fighting for Access to Safe, Legal Abortion</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics Features</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Leana S. Wen, M.D. M.Sc.</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    The new president of Planned Parenthood, Dr. Leana S. Wen, on the state of reproductive freedom in 2019</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/politics/politics-features/alexandria-ocasio-cortez-media-781571/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/10047908nW.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Alexandria Ocasio-Cortez, Ilhan Omar, Dina Titus. Rep. Alexandria Ocasio-Cortez, left, and D-N.Y., Rep. Ilhan Omar, D-Minn., center, walk down the House steps to take a group photograph of the House Democratic women members of the 116th Congress on the East Front Capitol Plaza on Capitol Hill in Washington, as the 116th Congress begins. Also pictured is Rep. Dina Titus, D-Nev., rightNew Congress, Washington, USA - 04 Jan 2019" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/10047908nW.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/10047908nW.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/10047908nW.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Alexandria Ocasio-Cortez, Crusher of Sacred Cows</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics Features</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Matt Taibbi</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    With its silly swipes at AOC, the American political establishment is once again revealing its blindness to its own unpopularity</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+
+<div class="c-cards-grid__item">
+    <article class="c-card c-card--grid c-card--grid--secondary c-card--grid-sponsored">
+            <div class="admz" id="adm-sponsored-homepage-sections">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="3">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-native-uid6" class="ad-rotatable adw-3 adh-3"></div>
+    </div>
+            </div>
+                </div>
+    </article><!-- .c-card--grid -->
+</div><!-- /.c-cards-grid__item -->
+                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/politics/politics-features/mlk-amazon-fbi-781327/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/MLK_JEH.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/MLK_JEH.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/MLK_JEH.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/MLK_JEH.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Op-Ed: MLK Offers a Lesson on Why We Should Be Worried About Amazon and the FBI</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics Features</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Kade Crockford</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Imagine if the FBI&#039;s surveillance of the civil rights leader had used today&#039;s technology</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/politics/politics-news/kamala-harris-2020-781990/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/Kamala-Harris-Is-Not-Running-Yet-senate-win-2016.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Sen. Kamala Harris greets supporters at an election night victory rally in Los Angeles, Nov. 9, 2016." data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/Kamala-Harris-Is-Not-Running-Yet-senate-win-2016.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2018/12/Kamala-Harris-Is-Not-Running-Yet-senate-win-2016.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2018/12/Kamala-Harris-Is-Not-Running-Yet-senate-win-2016.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Kamala Harris Officially Enters the 2020 Race on MLK Day</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Jamil Smith</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    The California senator formally announced her plans to run for president during an appearance on &quot;Good Morning America&quot;</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/politics/politics-news/aaron-sorkin-bad-advice-democrats-781950/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10031536a.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Aaron Sorkin" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10031536a.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10031536a.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10031536a.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Aaron Sorkin&#8217;s Advice to Democrats: &#8216;Stop Acting Like Young People&#8217;</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Politics News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Peter Wade</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Twitter couldn&#039;t help but dunk on him</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                            </div><!-- .c-cards-grid -->
+        </div><!-- /.l-section__grid -->
+
+        <div class="l-section__sidebar">
+            <div class="l-section__sticky c-sticky c-sticky--size-grow" data-section-ad="Politics">
+                <script>
+                    PMC_RS_toggleHomeAd( "Politics" );
+                </script>
+                <div class="c-sticky__item">
+                    <div class="c-ad c-ad--300x250">
+        <div class="admz" id="adm-front-section-sticky-ad">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="300">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-railX-uid7" class="ad-rotatable adw-300 adh-250"></div>
+    </div>
+            </div>
+                </div>
+</div>
+                </div><!-- /.c-sticky__item -->
+            </div><!-- /.l-section__sticky c-sticky c-sticky--size-grow -->
+
+            <div class="l-section__sidebar-footer">
+                            </div><!-- /.l-section__sidebar-footer -->
+        </div><!-- /.l-section__sidebar -->
+
+
+                    <div class="l-section__block">
+
+<div class="c-columnists">
+    <h3 class="c-columnists__label">
+        <span class="c-columnists__badge">
+                <svg class="c-columnists__icon"><use xlink:href="#svg-rs-badge"></use></svg>
+        </span>
+        <span class="t-bold">
+            Columnists      </span>
+    </h3>
+    <ul class="c-columnists__list">
+                    <li class="c-columnists__item">
+                <article class="c-testimonial">
+                    <header class="c-testimonial__header">
+                        <div class="c-testimonial__avatar-wrap">
+                            <img width="160" height="160" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/06/Taibbi.jpg?w=160" class="avatar avatar-160 photo wp-post-image" alt="" />
+                        </div><!-- /.c-testimonial__avatar-wrap -->
+
+                        <div class="c-testimonial__author">
+                            <p class="t-copy t-bold">
+                                Matt Taibbi                         </p>
+
+                            <p class="c-testimonial__tagline">
+                                <span>
+                                                                    </span>
+                            </p>
+
+                        </div><!-- /.c-testimonial__author -->
+                    </header><!-- /.c-testimonial__header -->
+
+                    <a href="https://www.rollingstone.com/politics/politics-features/alexandria-ocasio-cortez-media-781571/" class="c-testimonial__main">
+                        <h4 class="c-testimonial__title">
+                            <span class="t-semibold">
+                                Alexandria Ocasio-Cortez, Crusher of Sacred Cows                            </span>
+                        </h4>
+
+                        <p class="c-testimonial__body">
+                            <span class="t-copy">
+                                With its silly swipes at AOC, the American political establishment is once again revealing its blindness to its own unpopularity                            </span>
+                        </p><!-- /.c-testimonial__body -->
+                    </a><!-- /.c-testimonial__main -->
+                </article><!-- /.c-testimonial__item -->
+            </li><!-- /.c-columnists__item -->
+
+                    <li class="c-columnists__item">
+                <article class="c-testimonial">
+                    <header class="c-testimonial__header">
+                        <div class="c-testimonial__avatar-wrap">
+                            <img width="160" height="160" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/06/tessa-author-photo.jpg?w=160" class="avatar avatar-160 photo wp-post-image" alt="" />
+                        </div><!-- /.c-testimonial__avatar-wrap -->
+
+                        <div class="c-testimonial__author">
+                            <p class="t-copy t-bold">
+                                Tessa Stuart                            </p>
+
+                            <p class="c-testimonial__tagline">
+                                <span>
+                                                                    </span>
+                            </p>
+
+                        </div><!-- /.c-testimonial__author -->
+                    </header><!-- /.c-testimonial__header -->
+
+                    <a href="https://www.rollingstone.com/politics/politics-news/family-separation-thousands-779254/" class="c-testimonial__main">
+                        <h4 class="c-testimonial__title">
+                            <span class="t-semibold">
+                                Trump’s Family Separation Policy Was Exponentially Worse Than Previously Known                          </span>
+                        </h4>
+
+                        <p class="c-testimonial__body">
+                            <span class="t-copy">
+                                A new Inspector General report states that &quot;thousands&quot; more children were taken from their parents at the border                          </span>
+                        </p><!-- /.c-testimonial__body -->
+                    </a><!-- /.c-testimonial__main -->
+                </article><!-- /.c-testimonial__item -->
+            </li><!-- /.c-columnists__item -->
+
+                    <li class="c-columnists__item">
+                <article class="c-testimonial">
+                    <header class="c-testimonial__header">
+                        <div class="c-testimonial__avatar-wrap">
+                            <img width="128" height="160" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/06/Jamil_Smith.jpg?w=128" class="avatar avatar-160 photo wp-post-image" alt="" />
+                        </div><!-- /.c-testimonial__avatar-wrap -->
+
+                        <div class="c-testimonial__author">
+                            <p class="t-copy t-bold">
+                                Jamil Smith                         </p>
+
+                            <p class="c-testimonial__tagline">
+                                <span>
+                                                                    </span>
+                            </p>
+
+                        </div><!-- /.c-testimonial__author -->
+                    </header><!-- /.c-testimonial__header -->
+
+                    <a href="https://www.rollingstone.com/politics/politics-news/kamala-harris-2020-781990/" class="c-testimonial__main">
+                        <h4 class="c-testimonial__title">
+                            <span class="t-semibold">
+                                Kamala Harris Officially Enters the 2020 Race on MLK Day                            </span>
+                        </h4>
+
+                        <p class="c-testimonial__body">
+                            <span class="t-copy">
+                                The California senator formally announced her plans to run for president during an appearance on &quot;Good Morning America&quot;                           </span>
+                        </p><!-- /.c-testimonial__body -->
+                    </a><!-- /.c-testimonial__main -->
+                </article><!-- /.c-testimonial__item -->
+            </li><!-- /.c-columnists__item -->
+
+            </ul><!-- /.c-columnists__list -->
+</div><!-- .c-columnists -->
+            </div><!-- /.l-section__block -->
+            </div><!-- /.l-section__content -->
+</div><!-- /.l-section -->
+
+<div class="l-section l-section--dark">
+
+    <div class="l-section__header">
+        <div class="c-section-header c-section-header--dark">
+            <h3 class="c-section-header__heading t-bold t-bold--upper t-bold--condensed">
+                Video           </h3>
+
+            <a href="https://www.rollingstone.com/video/" class="c-section-header__cta t-semibold t-semibold--upper t-semibold--loose">
+                View All            </a>
+        </div><!-- .c-section-header -->
+    </div><!-- /.l-section__header -->
+
+    <div class="l-section__content">
+        <div class="c-video-gallery" data-video-gallery>
+
+
+    <div class="c-video-gallery__main">
+
+<article class="c-card c-card--video ">
+    <div class="c-card__wrap">
+        <figure class="c-card__image">
+
+            <div class="c-crop c-crop--video c-crop--ratio-video">
+                <div data-video-crop>
+                    <div hidden>
+                        <script type="text/javascript" src="https://content.jwplatform.com/libraries/zFOPDjEV.js"></script><div id='jwplayer_KGFFymUY_div' data-videoid='KGFFymUY' data-jsonfeed='https://content.jwplatform.com/feeds/KGFFymUY.json'></div>                    </div>
+
+
+<div class="c-card__badge c-card__badge--play">
+    <div class="c-badge c-badge--play">
+        <svg class="c-play-btn c-play-btn--clock" viewBox="0 0 88 88">
+            <g transform="translate(-.082 -.082)" fill="none" fill-rule="evenodd">
+                <circle class="c-play-btn__fill" fill="#D32531" stroke="#D32531" stroke-width="4" cx="44" cy="44" r="44" />
+                <circle class="c-play-btn__border" fill="none" stroke="none" stroke-width=4 cx="44" cy="44" r="44" stroke-dasharray="276" stroke-dashoffset="276" />
+                <path class="c-play-btn__icon" d="M38.242 28.835c-.634-.467-2.323-.467-2.46 1.298v19.743a.99.99 0 0 0 1.577.796 3.88 3.88 0 0 0 1.577-3.123V33.105l16.008 10.969-18.458 12.61c-.44.3-.703.798-.703 1.331a1.564 1.564 0 0 0 2.46 1.298l20.383-13.941c.528-.317 1.252-1.615 0-2.596l-20.384-13.94z" fill="#FFF"/>
+            </g>
+        </svg>
+    </div><!-- .c-badge -->
+</div><!-- .c-card__badge -->
+
+                    <img width="815" height="458" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=815:458&width=350" class="c-crop__img wp-post-image" alt="ethan hawke rs interview" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=815:458&width=350 350w, https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=815:458&width=600 600w, https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=815:458&width=800 800w" sizes="(max-width: 959px) 92%, (max-width: 1300px) 55%, 775px" />             </div>
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+            <h3 class="c-card__heading t-bold">
+
+                <a href="https://www.rollingstone.com/movies/movie-videos/ethan-hawke-the-rolling-stone-interview-776498/" data-video-gallery-card-heading>
+                    Ethan Hawke: The Rolling Stone Interview                </a>
+            </h3><!-- .c-card__heading -->
+
+
+                <span class="c-card__tag t-semibold t-semibold--upper t-semibold--loose" data-video-gallery-card-tag>
+
+                    Movies
+                </span>
+
+
+            <p class="c-card__lead t-copy" data-video-gallery-card-lead>
+                Ethan Hawke Talks New Movie ‘Blaze,’ Positives of Fame          </p><!-- /.c-card__lead t-copy -->
+
+
+        </header><!-- .c-card__header -->
+    </div><!-- .c-card__wrap -->
+</article><!-- .c-card -->
+    </div><!-- /.c-video-gallery__main -->
+
+
+<div class="c-video-gallery__slider c-slider " data-slider data-slider--centered>
+
+
+    <a href="" class="c-slider__nav c-slider__nav--left" data-slider-nav="prev">
+        <svg class="c-slider__icon"><use xlink:href="#svg-icon-chevron"></use></svg>
+    </a>
+    <a href="" class="c-slider__nav c-slider__nav--right" data-slider-nav="next">
+        <svg class="c-slider__icon"><use xlink:href="#svg-icon-chevron"></use></svg>
+    </a>
+
+    <div class="c-slider__track" data-slider-track>
+
+        <div class="c-video-gallery__item c-slider__item" data-slider-item>
+
+<article class="c-card c-card--video-thumb  t-semibold">
+    <a href="https://www.rollingstone.com/music/music-videos/elvis-costello-the-rolling-stone-interview-755470/" class="c-card__wrap" data-video-gallery-thumb
+        data-tag="Music"
+        data-heading="Elvis Costello: The Rolling Stone Interview"
+        data-lead="Elvis Costello on His New Album, Mortality and His Musical Evolution"
+        data-permalink="https://www.rollingstone.com/music/music-videos/elvis-costello-the-rolling-stone-interview-755470/"
+        data-tag-permalink="/music/">
+
+        <figure class="c-card__image" data-active-text="Now Playing">
+            <div hidden>
+                <div id='jwplayer_FFQp3SbT_div' data-videoid='FFQp3SbT' data-jsonfeed='https://content.jwplatform.com/feeds/FFQp3SbT.json'></div>           </div>
+
+
+<div class="c-card__badge c-card__badge--play">
+    <div class="c-badge c-badge--play">
+        <svg class="c-play-btn c-play-btn--medium c-play-btn--thumb" viewBox="0 0 88 88">
+            <g transform="translate(-.082 -.082)" fill="none" fill-rule="evenodd">
+                <circle class="c-play-btn__fill" fill="#D32531" stroke="#D32531" stroke-width="4" cx="44" cy="44" r="44"/>
+                <circle class="c-play-btn__border" fill="none" stroke="none" stroke-width=4 cx="44" cy="44" r="44" stroke-dasharray="276" stroke-dashoffset="276"/>
+                <path class="c-play-btn__icon" d="M38.242 28.835c-.634-.467-2.323-.467-2.46 1.298v19.743a.99.99 0 0 0 1.577.796 3.88 3.88 0 0 0 1.577-3.123V33.105l16.008 10.969-18.458 12.61c-.44.3-.703.798-.703 1.331a1.564 1.564 0 0 0 2.46 1.298l20.383-13.941c.528-.317 1.252-1.615 0-2.596l-20.384-13.94z" fill="#FFF"/>
+            </g>
+        </svg>
+    </div><!-- .c-badge--play -->
+</div><!-- /.c-card__badge -->
+
+
+            <div class="c-crop c-crop--ratio-7x4">
+                <img width="1260" height="720" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/11/Elvis-Costello-video-post.jpg?crop=1260:720&width=300" class="c-crop__img wp-post-image" alt="Elvis Costello video post" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/11/Elvis-Costello-video-post.jpg?crop=1260:720&width=300 300w, https://www.rollingstone.com/wp-content/uploads/2018/11/Elvis-Costello-video-post.jpg?crop=1260:720&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2018/11/Elvis-Costello-video-post.jpg?crop=1260:720&width=350 350w, https://www.rollingstone.com/wp-content/uploads/2018/11/Elvis-Costello-video-post.jpg?crop=1260:720&width=210 210w" sizes="(max-width: 480px) 210px, (max-width: 767px) 350px,(max-width: 959px) 450px, 300px" />           </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+            <h3 class="c-card__heading ">
+                Elvis Costello: The Rolling Stone Interview         </h3><!-- .c-card__heading -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card -->
+        </div><!-- /.c-video-gallery__item c-slider__item -->
+
+
+        <div class="c-video-gallery__item c-slider__item" data-slider-item>
+
+<article class="c-card c-card--video-thumb  t-semibold">
+    <a href="https://www.rollingstone.com/music/music-videos/the-first-time-with-travis-scott-773830/" class="c-card__wrap" data-video-gallery-thumb
+        data-tag="Music"
+        data-heading="The First Time with Travis Scott"
+        data-lead="Hip-hop superstar talks weed, Jamba Juice, the origin of his rap name and the first CD [&hellip;]"
+        data-permalink="https://www.rollingstone.com/music/music-videos/the-first-time-with-travis-scott-773830/"
+        data-tag-permalink="/music/">
+
+        <figure class="c-card__image" data-active-text="Now Playing">
+            <div hidden>
+                <div id='jwplayer_wVbwnAuc_div' data-videoid='wVbwnAuc' data-jsonfeed='https://content.jwplatform.com/feeds/wVbwnAuc.json'></div>           </div>
+
+
+<div class="c-card__badge c-card__badge--play">
+    <div class="c-badge c-badge--play">
+        <svg class="c-play-btn c-play-btn--medium c-play-btn--thumb" viewBox="0 0 88 88">
+            <g transform="translate(-.082 -.082)" fill="none" fill-rule="evenodd">
+                <circle class="c-play-btn__fill" fill="#D32531" stroke="#D32531" stroke-width="4" cx="44" cy="44" r="44"/>
+                <circle class="c-play-btn__border" fill="none" stroke="none" stroke-width=4 cx="44" cy="44" r="44" stroke-dasharray="276" stroke-dashoffset="276"/>
+                <path class="c-play-btn__icon" d="M38.242 28.835c-.634-.467-2.323-.467-2.46 1.298v19.743a.99.99 0 0 0 1.577.796 3.88 3.88 0 0 0 1.577-3.123V33.105l16.008 10.969-18.458 12.61c-.44.3-.703.798-.703 1.331a1.564 1.564 0 0 0 2.46 1.298l20.383-13.941c.528-.317 1.252-1.615 0-2.596l-20.384-13.94z" fill="#FFF"/>
+            </g>
+        </svg>
+    </div><!-- .c-badge--play -->
+</div><!-- /.c-card__badge -->
+
+
+            <div class="c-crop c-crop--ratio-7x4">
+                <img width="1260" height="720" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/travis-scott-first-time.jpg?crop=1260:720&width=300" class="c-crop__img wp-post-image" alt="travis scott first time" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/travis-scott-first-time.jpg?crop=1260:720&width=300 300w, https://www.rollingstone.com/wp-content/uploads/2018/12/travis-scott-first-time.jpg?crop=1260:720&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2018/12/travis-scott-first-time.jpg?crop=1260:720&width=350 350w, https://www.rollingstone.com/wp-content/uploads/2018/12/travis-scott-first-time.jpg?crop=1260:720&width=210 210w" sizes="(max-width: 480px) 210px, (max-width: 767px) 350px,(max-width: 959px) 450px, 300px" />           </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+            <h3 class="c-card__heading ">
+                The First Time with Travis Scott            </h3><!-- .c-card__heading -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card -->
+        </div><!-- /.c-video-gallery__item c-slider__item -->
+
+
+        <div class="c-video-gallery__item c-slider__item" data-slider-item>
+
+<article class="c-card c-card--video-thumb  t-semibold">
+    <a href="https://www.rollingstone.com/movies/movie-videos/ethan-hawke-the-rolling-stone-interview-776498/" class="c-card__wrap is-active" data-video-gallery-thumb
+        data-tag="Movies"
+        data-heading="Ethan Hawke: The Rolling Stone Interview"
+        data-lead="Ethan Hawke Talks New Movie ‘Blaze,’ Positives of Fame"
+        data-permalink="https://www.rollingstone.com/movies/movie-videos/ethan-hawke-the-rolling-stone-interview-776498/"
+        data-tag-permalink="/movies/">
+
+        <figure class="c-card__image" data-active-text="Now Playing">
+            <div hidden>
+                <div id='jwplayer_KGFFymUY_div' data-videoid='KGFFymUY' data-jsonfeed='https://content.jwplatform.com/feeds/KGFFymUY.json'></div>           </div>
+
+
+<div class="c-card__badge c-card__badge--play">
+    <div class="c-badge c-badge--play">
+        <svg class="c-play-btn c-play-btn--medium c-play-btn--thumb" viewBox="0 0 88 88">
+            <g transform="translate(-.082 -.082)" fill="none" fill-rule="evenodd">
+                <circle class="c-play-btn__fill" fill="#D32531" stroke="#D32531" stroke-width="4" cx="44" cy="44" r="44"/>
+                <circle class="c-play-btn__border" fill="none" stroke="none" stroke-width=4 cx="44" cy="44" r="44" stroke-dasharray="276" stroke-dashoffset="276"/>
+                <path class="c-play-btn__icon" d="M38.242 28.835c-.634-.467-2.323-.467-2.46 1.298v19.743a.99.99 0 0 0 1.577.796 3.88 3.88 0 0 0 1.577-3.123V33.105l16.008 10.969-18.458 12.61c-.44.3-.703.798-.703 1.331a1.564 1.564 0 0 0 2.46 1.298l20.383-13.941c.528-.317 1.252-1.615 0-2.596l-20.384-13.94z" fill="#FFF"/>
+            </g>
+        </svg>
+    </div><!-- .c-badge--play -->
+</div><!-- /.c-card__badge -->
+
+
+            <div class="c-crop c-crop--ratio-7x4">
+                <img width="1078" height="720" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=1260:720&width=300" class="c-crop__img wp-post-image" alt="ethan hawke rs interview" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=1260:720&width=300 300w, https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=1260:720&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=1260:720&width=350 350w, https://www.rollingstone.com/wp-content/uploads/2019/01/ethan-hawke-rs-interview.jpg?crop=1260:720&width=210 210w" sizes="(max-width: 480px) 210px, (max-width: 767px) 350px,(max-width: 959px) 450px, 300px" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+            <h3 class="c-card__heading ">
+                Ethan Hawke: The Rolling Stone Interview            </h3><!-- .c-card__heading -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card -->
+        </div><!-- /.c-video-gallery__item c-slider__item -->
+
+
+        <div class="c-video-gallery__item c-slider__item" data-slider-item>
+
+<article class="c-card c-card--video-thumb  t-semibold">
+    <a href="https://www.rollingstone.com/tv/tv-features/surviving-r-kelly-lifetime-docuseries-review-774317/" class="c-card__wrap" data-video-gallery-thumb
+        data-tag="TV"
+        data-heading="&#8216;Surviving R. Kelly&#8217;: Powerful Docuseries Is a Reckoning for the Singer — And Us"
+        data-lead="Lifetime&#039;s harrowing six-part docuseries paints a textbook picture of an abuser and gives a voice to survivors who&#039;ve long been silenced"
+        data-permalink="https://www.rollingstone.com/tv/tv-features/surviving-r-kelly-lifetime-docuseries-review-774317/"
+        data-tag-permalink="/tv/">
+
+        <figure class="c-card__image" data-active-text="Now Playing">
+            <div hidden>
+                <div id='jwplayer_tsR0QwvF_div' data-videoid='tsR0QwvF' data-jsonfeed='https://content.jwplatform.com/feeds/tsR0QwvF.json'></div>           </div>
+
+
+            <div class="c-crop c-crop--ratio-7x4">
+                <img width="1260" height="720" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/surviving-r-kelly-lifetime-.jpg?crop=1260:720&width=300" class="c-crop__img wp-post-image" alt="Kitti Jones, Lizzette Martinez and Andrea Kelly in the documentary series, &quot;Surviving R. Kelly&quot;" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/surviving-r-kelly-lifetime-.jpg?crop=1260:720&width=300 300w, https://www.rollingstone.com/wp-content/uploads/2019/01/surviving-r-kelly-lifetime-.jpg?crop=1260:720&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2019/01/surviving-r-kelly-lifetime-.jpg?crop=1260:720&width=350 350w, https://www.rollingstone.com/wp-content/uploads/2019/01/surviving-r-kelly-lifetime-.jpg?crop=1260:720&width=210 210w" sizes="(max-width: 480px) 210px, (max-width: 767px) 350px,(max-width: 959px) 450px, 300px" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+            <h3 class="c-card__heading ">
+                &#8216;Surviving R. Kelly&#8217;: Powerful Docuseries Is a Reckoning for the Singer — And Us            </h3><!-- .c-card__heading -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card -->
+        </div><!-- /.c-video-gallery__item c-slider__item -->
+
+
+        <div class="c-video-gallery__item c-slider__item" data-slider-item>
+
+<article class="c-card c-card--video-thumb  t-semibold">
+    <a href="https://www.rollingstone.com/music/music-videos/the-first-time-with-charli-xcx-766410/" class="c-card__wrap" data-video-gallery-thumb
+        data-tag="Music"
+        data-heading="The First Time with Charli XCX"
+        data-lead="The British pop star talks her first celebrity crushes, her first time getting drunk and more"
+        data-permalink="https://www.rollingstone.com/music/music-videos/the-first-time-with-charli-xcx-766410/"
+        data-tag-permalink="/music/">
+
+        <figure class="c-card__image" data-active-text="Now Playing">
+            <div hidden>
+                <div id='jwplayer_p9XJ7JJe_div' data-videoid='p9XJ7JJe' data-jsonfeed='https://content.jwplatform.com/feeds/p9XJ7JJe.json'></div>           </div>
+
+
+<div class="c-card__badge c-card__badge--play">
+    <div class="c-badge c-badge--play">
+        <svg class="c-play-btn c-play-btn--medium c-play-btn--thumb" viewBox="0 0 88 88">
+            <g transform="translate(-.082 -.082)" fill="none" fill-rule="evenodd">
+                <circle class="c-play-btn__fill" fill="#D32531" stroke="#D32531" stroke-width="4" cx="44" cy="44" r="44"/>
+                <circle class="c-play-btn__border" fill="none" stroke="none" stroke-width=4 cx="44" cy="44" r="44" stroke-dasharray="276" stroke-dashoffset="276"/>
+                <path class="c-play-btn__icon" d="M38.242 28.835c-.634-.467-2.323-.467-2.46 1.298v19.743a.99.99 0 0 0 1.577.796 3.88 3.88 0 0 0 1.577-3.123V33.105l16.008 10.969-18.458 12.61c-.44.3-.703.798-.703 1.331a1.564 1.564 0 0 0 2.46 1.298l20.383-13.941c.528-.317 1.252-1.615 0-2.596l-20.384-13.94z" fill="#FFF"/>
+            </g>
+        </svg>
+    </div><!-- .c-badge--play -->
+</div><!-- /.c-card__badge -->
+
+
+            <div class="c-crop c-crop--ratio-7x4">
+                <img width="1260" height="720" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/charlithumb.jpg?crop=1260:720&width=300" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/charlithumb.jpg?crop=1260:720&width=300 300w, https://www.rollingstone.com/wp-content/uploads/2018/12/charlithumb.jpg?crop=1260:720&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2018/12/charlithumb.jpg?crop=1260:720&width=350 350w, https://www.rollingstone.com/wp-content/uploads/2018/12/charlithumb.jpg?crop=1260:720&width=210 210w" sizes="(max-width: 480px) 210px, (max-width: 767px) 350px,(max-width: 959px) 450px, 300px" />          </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+            <h3 class="c-card__heading ">
+                The First Time with Charli XCX          </h3><!-- .c-card__heading -->
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card -->
+        </div><!-- /.c-video-gallery__item c-slider__item -->
+
+            </div><!-- /.c-slider__track -->
+</div><!-- /.c-video-gallery__slider c-slider -->
+
+
+        </div><!-- /.c-video-gallery -->
+    </div><!-- /.l-section__content -->
+
+</div><!-- .c-coverage -->
+<div class="l-section" data-section="TV">
+
+    <script>
+        PMC_RS_setHomeAppearance( "TV" );
+    </script>
+
+    <div class="l-section__header">
+        <div class="c-section-header">
+            <h3 class="c-section-header__heading t-bold t-bold--condensed">
+                TV          </h3>
+                            <a href="/tv/" class="c-section-header__cta t-semibold t-semibold--upper t-semibold--loose">
+                    View All                </a>
+                        <p class="c-section-header__msg">
+                You have set the display of this section to be hidden.<br>
+                Click the button to the right to show it again.         </p><!-- /.c-section-header__msg -->
+            <a href="#" class="c-section-header__btn" data-section-toggle>
+                <span class="c-section-header__hide t-semibold t-semibold--upper">Hide</span>
+                <span class="c-section-header__show t-semibold t-semibold--upper">Show</span>
+                <svg class="c-section-header__btn-arrow">
+                    <use xlink:href="#svg-icon-arrow-down"></use>
+                </svg>
+            </a>
+        </div><!-- .c-section-header -->
+    </div><!-- /.l-section__header -->
+
+    <div class="l-section__content">
+        <div class="l-section__grid">
+            <div class="c-cards-grid">
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--primary ">
+    <a href="https://www.rollingstone.com/tv/tv-features/conan-obrien-late-night-simpsons-catholicism-780706/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/Conan-OBrien-last-word.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="conan obrien last word" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/Conan-OBrien-last-word.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/Conan-OBrien-last-word.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/Conan-OBrien-last-word.jpg?crop=900:600&width=335 335w, https://www.rollingstone.com/wp-content/uploads/2019/01/Conan-OBrien-last-word.jpg?crop=900:600&width=730 730w" sizes="(max-width: 767px) 730px, (max-width: 380px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    The Last Word: Conan O&#8217;Brien on Catholicism, &#8216;The Simpsons&#8217; and Life As Late Night&#8217;s Elder Statesman</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> TV Features</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Patrick Doyle</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    The TV host shares the lessons he learned from losing the &#039;Tonight Show&#039; — and why he&#039;s trying to shut off his inner voice of disapproval</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/tv/tv-recaps/true-detective-recap-season-3-episode-3-the-big-never-779557/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/TD_HBO.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Stephen Dorff, Mahershala Ali, Michael Broderick, in episode 3, Season 3 of HBO&#039;s True Detective" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/TD_HBO.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/TD_HBO.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/TD_HBO.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    &#8216;True Detective&#8217; Recap: Just the Facts, Ma&#8217;am</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> TV Recaps</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Sean T. Collins</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Never mind the Yellow King; this new season is settling into a straight-ahead, remarkably TV crime procedural groove</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+
+<div class="c-cards-grid__item">
+    <article class="c-card c-card--grid c-card--grid--secondary c-card--grid-sponsored">
+            <div class="admz" id="adm-sponsored-homepage-sections">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="3">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-native-uid8" class="ad-rotatable adw-3 adh-3"></div>
+    </div>
+            </div>
+                </div>
+    </article><!-- .c-card--grid -->
+</div><!-- /.c-cards-grid__item -->
+                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/tv/tv-news/american-gods-season-2-trailer-781868/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-9.30.22-AM.png?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-9.30.22-AM.png?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-9.30.22-AM.png?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-9.30.22-AM.png?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    &#8216;American Gods&#8217;: Watch First Trailer for Long-Delayed Season 2</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> TV News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Ilana Kaplan</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Despite showrunner drama, the Starz series based on Neil Gaiman&#039;s novel returns in March</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/tv/tv-news/snl-mrs-maisel-raunchiest-miss-rita-781823/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="676" height="382" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-7.44.00-AM.png?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-7.44.00-AM.png?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-7.44.00-AM.png?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-20-at-7.44.00-AM.png?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    &#8216;SNL&#8217;: Leslie Jones Parodies &#8216;Marvelous Mrs. Maisel&#8217; With &#8216;Raunchiest Miss Rita&#8217;</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> TV News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Ilana Kaplan</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Aidy Bryant took on Alex Borstein&#039;s role, while Kyle Mooney appeared as &quot;an even more exasperated Tony Shalhoub&quot;</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/tv/tv-features/broad-city-final-season-ilana-glazer-abbi-jacobson-interview-779316/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/broad-city-final-season.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="&#039;Broad City&#039; co-creators and stars Abbi Jacobson (left) and Ilana Glazer." data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/broad-city-final-season.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/broad-city-final-season.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/broad-city-final-season.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    The &#8216;Broad City&#8217; Gals Say Goodbye</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> TV Features</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Rob Sheffield</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    As the series enters its fifth and final season, Abbi Jacobson and Ilana Glazer look back on their favorite episodes</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                            </div><!-- .c-cards-grid -->
+        </div><!-- /.l-section__grid -->
+
+        <div class="l-section__sidebar">
+            <div class="l-section__sticky c-sticky c-sticky--size-grow" data-section-ad="TV">
+                <script>
+                    PMC_RS_toggleHomeAd( "TV" );
+                </script>
+                <div class="c-sticky__item">
+                    <div class="c-ad c-ad--300x250">
+        <div class="admz" id="adm-front-section-sticky-ad">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="300">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-railX-uid9" class="ad-rotatable adw-300 adh-250"></div>
+    </div>
+            </div>
+                </div>
+</div>
+                </div><!-- /.c-sticky__item -->
+            </div><!-- /.l-section__sticky c-sticky c-sticky--size-grow -->
+
+            <div class="l-section__sidebar-footer">
+
+<a href="https://www.rollingstone.com/tv/tv-news/10-best-movies-and-tv-to-stream-in-july-castle-rock-seinfeld-sci-fi-666867/" class="c-the-list">
+    <h4 class="c-the-list__headline">
+        <span class="t-bold">
+            10 Best Movies and TV to Stream in July: &#8216;Castle Rock,&#8217; Seinfeld, Sci-Fi        </span>
+    </h4><!-- /.c-the-list__headline -->
+</a><!-- .c-the-list -->
+
+            </div><!-- /.l-section__sidebar-footer -->
+        </div><!-- /.l-section__sidebar -->
+
+                    <div class="l-section__block">
+
+<div class="c-reviews">
+    <h3 class="c-reviews__label">
+        <span class="c-reviews__label-head t-bold">TV</span>
+        <span class="c-reviews__label-tail t-bold">Reviews</span>
+    </h3><!-- /.c-reviews__label -->
+
+    <ul class="c-reviews__list">
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/tv/tv-reviews/brooklyn-nine-nine-season-6-review-776381/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/brooklyn-nine-nine-poster.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/brooklyn-nine-nine-poster.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2019/01/brooklyn-nine-nine-poster.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                                                                </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">It&#039;s got a new network, but &#039;Nine-Nine&#039; is as giddy, goofy and stupid-grin-inducing as ever</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/tv/tv-reviews/true-detective-season-3-review-774278/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/true-detective-poster.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/true-detective-poster.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2019/01/true-detective-poster.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                                                                </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">It&#039;s déjà vu all over again as series creator Nic Pizzolatto revisits the successful formula of Season One, this time with mixed results</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/tv/tv-reviews/marvelous-mrs-maisel-season-2-review-761751/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/11/marvelous-mrs-maisel-season-2-poster.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/11/marvelous-mrs-maisel-season-2-poster.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/11/marvelous-mrs-maisel-season-2-poster.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />            </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                    <use xlink:href="#svg-icon-star--half"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                                                                </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">The sophomore season of Amazon&#039;s Emmy-winning juggernaut is still sharply written and beautifully shot, but it needs to put its heroine back at center stage</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/tv/tv-reviews/black-mirror-bandersnatch-tv-review-772876/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/BM_Bandersnatch_Vertical-Main_PRE_RGB.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/BM_Bandersnatch_Vertical-Main_PRE_RGB.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/12/BM_Bandersnatch_Vertical-Main_PRE_RGB.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                                                                </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">The sci-fi anthology show and Netflix deliver an interactive choose-your-own-adventure experience — the question is, why?</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+            </ul><!-- /.c-reviews__list -->
+</div><!-- .c-reviews -->
+            </div><!-- /.l-section__block -->
+
+            </div><!-- /.l-section__content -->
+</div><!-- /.l-section -->
+<div class="l-section" data-section="Movies">
+
+    <script>
+        PMC_RS_setHomeAppearance( "Movies" );
+    </script>
+
+    <div class="l-section__header">
+        <div class="c-section-header">
+            <h3 class="c-section-header__heading t-bold t-bold--condensed">
+                Movies          </h3>
+                            <a href="/movies/" class="c-section-header__cta t-semibold t-semibold--upper t-semibold--loose">
+                    View All                </a>
+                        <p class="c-section-header__msg">
+                You have set the display of this section to be hidden.<br>
+                Click the button to the right to show it again.         </p><!-- /.c-section-header__msg -->
+            <a href="#" class="c-section-header__btn" data-section-toggle>
+                <span class="c-section-header__hide t-semibold t-semibold--upper">Hide</span>
+                <span class="c-section-header__show t-semibold t-semibold--upper">Show</span>
+                <svg class="c-section-header__btn-arrow">
+                    <use xlink:href="#svg-icon-arrow-down"></use>
+                </svg>
+            </a>
+        </div><!-- .c-section-header -->
+    </div><!-- /.l-section__header -->
+
+    <div class="l-section__content">
+        <div class="l-section__grid">
+            <div class="c-cards-grid">
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--primary ">
+    <a href="https://www.rollingstone.com/movies/movie-news/fyre-fest-documentary-cook-fundraising-goal-782116/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-1.14.32-PM.png?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-1.14.32-PM.png?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-1.14.32-PM.png?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-1.14.32-PM.png?crop=900:600&width=335 335w, https://www.rollingstone.com/wp-content/uploads/2019/01/Screen-Shot-2019-01-21-at-1.14.32-PM.png?crop=900:600&width=730 730w" sizes="(max-width: 767px) 730px, (max-width: 380px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    &#8216;Fyre&#8217; Fest Documentary: Bahamian Cook Surpasses $123,000 Fundraising Goal</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Movie News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Daniel Kreps</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    &quot;My life was changed forever, and my credit was ruined by Fyre Fest,&quot; Maryann Rolle wrote on GoFundMe page</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/movies/movie-news/trump-happytime-murders-gotti-2019-razzie-nominations-782008/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10068802d.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="United States President Donald J. Trump makes remarks on the humanitarian crisis on the southern border of the US and on the partial shutdown of the federal government in the Diplomatic Reception Room of the White House in Washington, DC.Donald Trump partial government shutdown speech, Washington DC, USA - 19 Jan 2019" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10068802d.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10068802d.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10068802d.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Trump, &#8216;Happytime Murders,&#8217; &#8216;Gotti&#8217; Lead 2019 Razzie Nominations</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Movie News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Daniel Kreps</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Gotti, The Happytime Murders, Holmes &amp; Watson and President Donald Trump each earned multiple nominations at [&hellip;]</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+
+<div class="c-cards-grid__item">
+    <article class="c-card c-card--grid c-card--grid--secondary c-card--grid-sponsored">
+            <div class="admz" id="adm-sponsored-homepage-sections">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="3">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-native-uid10" class="ad-rotatable adw-3 adh-3"></div>
+    </div>
+            </div>
+                </div>
+    </article><!-- .c-card--grid -->
+</div><!-- /.c-cards-grid__item -->
+                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/movies/movie-news/leslie-jones-slams-insulting-new-ghostbusters-movie-781951/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9213932a.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Leslie Jones arrives at the Los Angeles premiere of &quot;Ghostbusters.&quot; Undeterred by the hacking of her personal website, Leslie Jones returned to Twitter to pledge that she will &quot;always get back up.&quot; On, she told concerned fans &quot;I&#039;m sooooo OK, really.&quot; She added that she &quot;will always be funnyPeople-Leslie Jones, Los Angeles, USA - 4 Sep 2016" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9213932a.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9213932a.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_9213932a.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Leslie Jones Slams &#8216;Insulting&#8217; New &#8216;Ghostbusters&#8217; Movie: &#8216;Such a Dick Move&#8217;</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Movie News</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Daniel Kreps</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    &quot;It’s like something trump would do. (Trump voice) &#039;Gonna redo ghostbusteeeeers, better with men, will be huge&#039;,&quot; SNL actress tweets of franchise&#039;s 2020 installment</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/movies/movie-features/trailers-of-the-week-spider-man-ghostbusters-john-wick-3-779188/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/spider-man-far-from-home-trailer-otw.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Tom Holland is  Peter Parker,  in Columbia Pictures&#039; SPIDER-MAN:™ FAR FROM HOME." data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/spider-man-far-from-home-trailer-otw.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/spider-man-far-from-home-trailer-otw.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/spider-man-far-from-home-trailer-otw.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Trailers of the Week: &#8216;Spider-Man: Far From Home,&#8217; &#8216;Ghostbusters,&#8217; &#8216;John Wick 3&#8217;</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Movie Features</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    David Fear</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    From the latest live-action Webslinger adventure to Keanu Reeves&#039; hired killer vs. all of New York City — your must-see trailer round-up</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                                    <div class="c-cards-grid__item">
+
+<article class="c-card c-card--grid c-card--grid--secondary ">
+    <a href="https://www.rollingstone.com/movies/movie-features/revisiting-hours-to-die-for-stream-this-movie-779943/" class="c-card__wrap">
+        <figure class="c-card__image">
+
+
+            <div class="c-crop c-crop--ratio-3x2">
+
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/to-die-for-revisiting-hours.jpg?crop=900:600&width=160" class="c-crop__img wp-post-image" alt="Editorial use onlyMandatory Credit: Photo by ITV/REX/Shutterstock (788096gs)&#039;To Die For&#039; - Nicole Kidman, Casey Affleck, Joaquin Phoenix, Alison Folland.ITV ARCHIVESuzanne (Nicole Kidman) is a weathergirl on a local TV station who longs to be a high flying star on Network television.She marries local boy Tony Maretto (Matt Dillon) whose family are highly suspicious of her true intentions.Her ambition leads her to the local high school where she meets a group of young drop outs.When her husband becomes a hindrance,she seduces one of the group,Jimmy (Joaquin Phoenix) and persuades them all to murder Tony.But will her in law&#039;s Italian background turn out to be more influential than she thought?" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/to-die-for-revisiting-hours.jpg?crop=900:600&width=160 160w, https://www.rollingstone.com/wp-content/uploads/2019/01/to-die-for-revisiting-hours.jpg?crop=900:600&width=285 285w, https://www.rollingstone.com/wp-content/uploads/2019/01/to-die-for-revisiting-hours.jpg?crop=900:600&width=335 335w" sizes="(max-width: 480px) 210px, (max-width: 767px) 345px, 285px" />
+            </div><!-- .c-crop -->
+
+        </figure><!-- .c-card__image -->
+
+        <header class="c-card__header">
+
+
+<h3 class="c-card__heading t-bold">
+
+    Revisiting Hours: Murder, Sexism and the Nightly News — &#8216;To Die For&#8217;</h3><!-- .c-card__heading -->
+
+<div class="c-card__tag t-bold t-bold--upper">
+    <span class="screen-reader-text">Posted in:</span>
+        <span class="c-card__featured-tag"> Movie Features</span>
+    </div><!-- c-card__tag -->
+
+<div class="c-card__byline t-copy">
+    By
+    Amy Nicholson</div><!-- c-card__byline -->
+
+<p class="c-card__lead">
+    Amy Nicholson on watching Gus Van Sant&#039;s tabloid-crime satire in the post-Roger Ailes era — and rooting for the murderer</p><!-- c-card__lead -->
+
+
+        </header><!-- .c-card__header -->
+    </a><!-- .c-card__wrap -->
+</article><!-- .c-card--grid -->
+
+                    </div><!-- /.c-cards-grid__item -->
+                            </div><!-- .c-cards-grid -->
+        </div><!-- /.l-section__grid -->
+
+        <div class="l-section__sidebar">
+            <div class="l-section__sticky c-sticky c-sticky--size-grow" data-section-ad="Movies">
+                <script>
+                    PMC_RS_toggleHomeAd( "Movies" );
+                </script>
+                <div class="c-sticky__item">
+                    <div class="c-ad c-ad--300x250">
+        <div class="admz" id="adm-front-section-sticky-ad">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="300">
+
+<div class="pmc-adm-goog-pub-div ">
+    <div id="gpt-dsk-tab-hp-railX-uid11" class="ad-rotatable adw-300 adh-250"></div>
+    </div>
+            </div>
+                </div>
+</div>
+                </div><!-- /.c-sticky__item -->
+            </div><!-- /.l-section__sticky c-sticky c-sticky--size-grow -->
+
+            <div class="l-section__sidebar-footer">
+
+<a href="https://www.rollingstone.com/movies/movie-lists/10-best-movies-of-2018-so-far-628487/" class="c-the-list">
+    <h4 class="c-the-list__headline">
+        <span class="t-bold">
+            10 Best Movies of 2018 So Far       </span>
+    </h4><!-- /.c-the-list__headline -->
+</a><!-- .c-the-list -->
+
+            </div><!-- /.l-section__sidebar-footer -->
+        </div><!-- /.l-section__sidebar -->
+
+                    <div class="l-section__block">
+
+<div class="c-reviews">
+    <h3 class="c-reviews__label">
+        <span class="c-reviews__label-head t-bold">Movie</span>
+        <span class="c-reviews__label-tail t-bold">Reviews</span>
+    </h3><!-- /.c-reviews__label -->
+
+    <ul class="c-reviews__list">
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/movies/movie-reviews/the-upside-review-kevin-hart-776720/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/the-upside-TheUpside_1Sht_rgb.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/the-upside-TheUpside_1Sht_rgb.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2019/01/the-upside-TheUpside_1Sht_rgb.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />         </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            The Upside                                  </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">Kevin Hart and Bryan Cranston star in aggressively mediocre redo of a hit about an ex-con taking care of a quadriplegic billionaire</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/movies/movie-reviews/destroyer-movie-review-770201/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/destroyer-Destroyer-Poster_rgb.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/destroyer-Destroyer-Poster_rgb.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/12/destroyer-Destroyer-Poster_rgb.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />          </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                    <use xlink:href="#svg-icon-star--half"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            Destroyer                                   </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">The actor turns this twisty, slightly confused piece of pulp fiction into a hell of a showcase</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/movies/movie-reviews/aquaman-movie-review-jason-momoa-760942/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/11/aquaman-poster.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/11/aquaman-poster.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/11/aquaman-poster.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />          </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                    <use xlink:href="#svg-icon-star--half"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            Aquaman                                 </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">Not even Jason Momoa and a cast of overqualified supporting actors can save the character from being the joke of the DCEU</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+                    <li class="c-reviews__item">
+
+<article class="c-reviews-card">
+    <a href="https://www.rollingstone.com/movies/movie-reviews/on-the-basis-of-sex-movie-review-772434/" class="c-reviews-card__wrap">
+        <figure class="c-reviews-card__image">
+
+            <div class="c-reviews-card__crop c-crop c-crop--ratio-2x3">
+                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/on-the-basis-of-sex-rbg-poster.jpg?crop=2:3,smart&#038;width=225" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/on-the-basis-of-sex-rbg-poster.jpg?crop=2:3,smart&#038;width=225 225w, https://www.rollingstone.com/wp-content/uploads/2018/12/on-the-basis-of-sex-rbg-poster.jpg?crop=2:3,smart&#038;width=400 400w"sizes="(max-width: 1259px) 200px, 225px"class="c-crop__img" alt width="200" height="300" />          </div><!-- .c-crop -->
+
+        </figure><!-- .c-reviews-card__image -->
+
+        <header class="c-reviews-card__header">
+
+            <div class="c-reviews-card__rating">
+
+<div class="l-article-header__row">
+    <div class="c-rating c-rating--5-stars">
+
+                                    <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+                                                <svg class="c-rating__star c-rating__star--active">
+                    <use xlink:href="#svg-icon-star"></use>
+                    <use xlink:href="#svg-icon-star--half"></use>
+                </svg>
+                                                <svg class="c-rating__star">
+                    <use xlink:href="#svg-icon-star"></use>
+                </svg>
+
+    </div><!-- /.c-star-rating -->
+</div>
+
+            </div>
+
+            <h4 class="c-reviews-card__headline">
+                <span class="t-copy">
+                                            On the Basis of Sex                                 </span>
+            </h4>
+
+
+            <p class="c-reviews-card__lead">
+                <span class="t-copy">Felicity Jones plays the young-and-restless Ruth Bader Ginsburg in this superhero-origin-story biopic</span>
+            </p>
+
+            <div class="c-reviews-card__cta">
+                <span class="t-semibold t-semibold--upper">Read More</span>
+            </div>
+
+        </header><!-- .c-reviews-card__header -->
+    </a><!-- .c-reviews-card__wrap -->
+</article><!-- .c-reviews-card -->
+
+            </li><!-- /.c-reviews__item -->
+            </ul><!-- /.c-reviews__list -->
+</div><!-- .c-reviews -->
+            </div><!-- /.l-section__block -->
+
+            </div><!-- /.l-section__content -->
+</div><!-- /.l-section -->
+
+<div class="l-section" data-section="Photo Galleries">
+
+    <script>
+        PMC_RS_setHomeAppearance( "Photo Galleries" );
+    </script>
+
+    <div class="l-section__header">
+
+<div class="c-section-header">
+    <h3 class="c-section-header__heading t-bold t-bold--condensed">
+        Photo Galleries </h3>
+
+    <a href="https://www.rollingstone.com/pictures/" class="c-section-header__cta t-semibold t-semibold--upper t-semibold--loose">
+        View All    </a>
+
+    <p class="c-section-header__msg">
+        You have set the display of this section to be hidden.<br>
+        Click the button to the right to show it again. </p><!-- /.c-section-header__msg -->
+
+    <a href="#" class="c-section-header__btn" data-section-toggle>
+        <span class="c-section-header__hide t-semibold t-semibold--upper">Hide</span>
+        <span class="c-section-header__show t-semibold t-semibold--upper">Show</span>
+        <svg class="c-section-header__btn-arrow"><use xlink:href="#svg-icon-arrow-down"></use></svg>
+    </a>
+</div><!-- .c-section-header -->
+    </div><!-- /.l-section__header -->
+
+    <div class="l-section__content">
+        <div class="c-galleries">
+            <div class="c-galleries__slider c-slider" data-slider>
+                <a href="" class="c-slider__nav c-slider__nav--left" data-slider-nav="prev">
+                    <svg class="c-slider__icon"><use xlink:href="#svg-icon-chevron"></use></svg>
+                </a>
+                <a href="" class="c-slider__nav c-slider__nav--right" data-slider-nav="next">
+                    <svg class="c-slider__icon"><use xlink:href="#svg-icon-chevron"></use></svg>
+                </a>
+
+                <div class="c-slider__track" data-slider-track>
+
+
+                        <div class="c-galleries__item c-slider__item" data-slider-item>
+
+<article class="c-gallery-card">
+    <a href="https://www.rollingstone.com/music/music-pictures/chris-cornell-tribute-concert-gallery-780519/" class="c-gallery-card__wrap">
+        <figure class="c-gallery-card__image">
+
+            <div class="c-crop c-crop--ratio-3x2">
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/Cornell-Tribute-concert-gallery-lead.jpg?crop=900:600&width=450" class="c-crop__img wp-post-image" alt="Audioslave performs during the &quot;I am the Highway: A Tribute to Chris Cornell&quot; tribute concert at the Forum in Los Angeles on January 16th, 2019.  Photograph by Andy Keilen for Rolling Stone." data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/Cornell-Tribute-concert-gallery-lead.jpg?crop=900:600&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2019/01/Cornell-Tribute-concert-gallery-lead.jpg?crop=900:600&width=760 760w, https://www.rollingstone.com/wp-content/uploads/2019/01/Cornell-Tribute-concert-gallery-lead.jpg?crop=900:600&width=920 920w, https://www.rollingstone.com/wp-content/uploads/2019/01/Cornell-Tribute-concert-gallery-lead.jpg?crop=900:600&width=1440 1440w" sizes="(max-width: 1259px) 60%, 760px" />         </div><!-- .c-crop -->
+
+
+<div class="c-gallery-card__badge">
+
+
+<div class="c-badge c-badge--gallery c-badge--mobile-full">
+    <svg class="c-badge__icon"><use xlink:href="#svg-icon-camera"></use></svg>
+    <div class="c-badge__label t-semibold t-semibold--upper">
+        18 Photos   </div><!-- .c-badge__label -->
+</div><!-- .c-badge--gallery -->
+
+</div><!-- /.c-gallery-card__badge -->
+
+
+        </figure><!-- .c-gallery-card__image -->
+        <header class="c-gallery-card__header">
+
+            <h4 class="c-gallery-card__headline t-bold">Chris Cornell Tribute Concert: Photos From All-Star Lineup</h4>
+            <p class="c-gallery-card__lead t-copy">
+                            </p>
+
+            <div class="c-gallery-card__thumbs">
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_002.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_002.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_002.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;A star-studded musical lineup that included&nbsp;Soundgarden, Audioslave, Metallica, Dave Grohl, Josh Homme, Miley Cyrus, Fiona Apple and The Melvins (pictured) performed at Wednesday night&#8217;s tribute to deceased singer Chris Cornell at Los Angeles&#8217; Forum.&nbsp;Cornell&rsquo;s vocal acrobatics and unique magic may have been absent at the five-hour event, officially dubbed I Am the Highway: A Tribute to Chris Cornell, but there were plenty of singers who came close, and many of his former bandmates and friends summoned his quintessence as they pulled from all corners of his songbook. Check out photos of the historic event.&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_020.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_020.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_020.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;Rita Wilson performs during the &#8220;I am the Highway: A Tribute to Chris Cornell&#8221; tribute concert at the Forum in Los Angeles on January 16th, 2019.&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_025.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_025.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2019/01/AK_CornellTribute_011619_025.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;Nikka Costa &amp; Alain Johannes perform during the &#8220;I am the Highway: A Tribute to Chris Cornell&#8221; tribute concert at the Forum in Los Angeles on January 16th, 2019.&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+                                    </div><!-- .c-gallery-card__thumbs -->
+
+        </header><!-- .c-gallery-card__header -->
+    </a><!-- .c-gallery-card__wrap -->
+</article><!-- .c-gallery-card -->
+
+                        </div><!-- /.c-galleries__item c-slider__item -->
+
+
+                        <div class="c-galleries__item c-slider__item" data-slider-item>
+
+<article class="c-gallery-card">
+    <a href="https://www.rollingstone.com/movies/movie-pictures/golden-globes-red-carpet-2019-775507/" class="c-gallery-card__wrap">
+        <figure class="c-gallery-card__image">
+
+            <div class="c-crop c-crop--ratio-3x2">
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-troye-sivan.jpg?crop=900:600&width=450" class="c-crop__img wp-post-image" alt="BEVERLY HILLS, CA - JANUARY 06:  76th ANNUAL GOLDEN GLOBE AWARDS -- Pictured: (l-r) Troye Sivan arrive to the 76th Annual Golden Globe Awards held at the Beverly Hilton Hotel on January 6, 2019. --  (Photo by Christopher Polk/NBC/NBCU Photo Bank)" data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-troye-sivan.jpg?crop=900:600&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-troye-sivan.jpg?crop=900:600&width=760 760w, https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-troye-sivan.jpg?crop=900:600&width=920 920w, https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-troye-sivan.jpg?crop=900:600&width=1440 1440w" sizes="(max-width: 1259px) 60%, 760px" />           </div><!-- .c-crop -->
+
+
+<div class="c-gallery-card__badge">
+
+
+<div class="c-badge c-badge--gallery c-badge--mobile-full">
+    <svg class="c-badge__icon"><use xlink:href="#svg-icon-camera"></use></svg>
+    <div class="c-badge__label t-semibold t-semibold--upper">
+        15 Photos   </div><!-- .c-badge__label -->
+</div><!-- .c-badge--gallery -->
+
+</div><!-- /.c-gallery-card__badge -->
+
+
+        </figure><!-- .c-gallery-card__image -->
+        <header class="c-gallery-card__header">
+
+            <h4 class="c-gallery-card__headline t-bold">Golden Globes 2019: Red Carpet</h4>
+            <p class="c-gallery-card__lead t-copy">
+                            </p>
+
+            <div class="c-gallery-card__thumbs">
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-lady-gaga.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-lady-gaga.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-lady-gaga.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;Lady Gaga&nbsp;attends the 76th Annual Golden Globe Awards at The Beverly Hilton Hotel on January 6, 2019 in Beverly Hills, California.&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-janelle-monae.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-janelle-monae.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-janelle-monae.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;Janelle Monae arrives at the 76th annual Golden Globe Awards at the Beverly Hilton Hotel.&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-jim-carrey.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-jim-carrey.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2019/01/golden-globes-red-carpet-jim-carrey.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;Jim Carrey and Ginger Gonzaga arrive to the 76th Annual Golden Globe Awards held at the Beverly Hilton Hotel on January 6, 2019.&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+                                    </div><!-- .c-gallery-card__thumbs -->
+
+        </header><!-- .c-gallery-card__header -->
+    </a><!-- .c-gallery-card__wrap -->
+</article><!-- .c-gallery-card -->
+
+                        </div><!-- /.c-galleries__item c-slider__item -->
+
+
+                        <div class="c-galleries__item c-slider__item" data-slider-item>
+
+<article class="c-gallery-card">
+    <a href="https://www.rollingstone.com/music/music-pictures/low-cut-connie-tour-photos-773544/" class="c-gallery-card__wrap">
+        <figure class="c-gallery-card__image">
+
+            <div class="c-crop c-crop--ratio-3x2">
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=900:600&width=450" class="c-crop__img wp-post-image" alt="low cut connie" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=900:600&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=900:600&width=760 760w, https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=900:600&width=920 920w, https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=900:600&width=1440 1440w" sizes="(max-width: 1259px) 60%, 760px" />           </div><!-- .c-crop -->
+
+
+<div class="c-gallery-card__badge">
+
+
+<div class="c-badge c-badge--gallery c-badge--mobile-full">
+    <svg class="c-badge__icon"><use xlink:href="#svg-icon-camera"></use></svg>
+    <div class="c-badge__label t-semibold t-semibold--upper">
+        12 Photos   </div><!-- .c-badge__label -->
+</div><!-- .c-badge--gallery -->
+
+</div><!-- /.c-gallery-card__badge -->
+
+
+        </figure><!-- .c-gallery-card__image -->
+        <header class="c-gallery-card__header">
+
+            <h4 class="c-gallery-card__headline t-bold">Low Cut Connie Tour Gallery</h4>
+            <p class="c-gallery-card__lead t-copy">
+                When Low Cut Connie frontman Adam Weiner was invited to meet his hero Bruce Springsteen backstage [&hellip;]            </p>
+
+            <div class="c-gallery-card__thumbs">
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie649.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;&nbsp;&#8220;It just shows how some nights we really go eyeball to eyeball with our fans. I love these kinds of shows because the connection is so profound between us and the fans,&#8221; says Weiner. &#8220;When you can rock a show like this, when you can blow up a room with no frills, no lights, no great sound, no production value- if you can do that and&nbsp;then you get on a huge stage with all kinds of technological assistance and a huge crowd, it&#8217;s easy. These gritty little club shows, that&#8217;s like punching the heavy bag if you know what I mean.&#8221;&nbsp;&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.03_LowCutConnie127-1.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.03_LowCutConnie127-1.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.03_LowCutConnie127-1.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;&#8220;If you look at the photo of me at First Avenue facing the camera from the drums, you&#8217;d see it&#8217;s like 1500 screaming people,&#8221; says Weiner.&#8221;And here I am just a couple nights later, in a really packed, sweaty, little bar and it&#8217;s like the same intensity of the show. People are just going crazy and we&#8217;re just having such an amazing time.&#8221;&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie622.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie622.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2018/12/18.11.06_LowCutConnie622.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;&nbsp;&#8220;That was the night of the election. I was just following the election and the news and feeling very stressed, as were many people in the crowd because in the bar behind them, the TVs were on,&#8221; says Weiner. &#8220;Then it was time to do the show and time to just release all your feelings, release stress, release any uptight feeling and just totally connect and feel present, in the moment.&#8221;&nbsp;&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+                                    </div><!-- .c-gallery-card__thumbs -->
+
+        </header><!-- .c-gallery-card__header -->
+    </a><!-- .c-gallery-card__wrap -->
+</article><!-- .c-gallery-card -->
+
+                        </div><!-- /.c-galleries__item c-slider__item -->
+
+
+                        <div class="c-galleries__item c-slider__item" data-slider-item>
+
+<article class="c-gallery-card">
+    <a href="https://www.rollingstone.com/culture/culture-pictures/2018-people-died-obituary-photos-773061/" class="c-gallery-card__wrap">
+        <figure class="c-gallery-card__image">
+
+            <div class="c-crop c-crop--ratio-3x2">
+                <img width="900" height="600" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/obit_trip.jpg?crop=900:600&width=450" class="c-crop__img wp-post-image" alt="" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/obit_trip.jpg?crop=900:600&width=450 450w, https://www.rollingstone.com/wp-content/uploads/2018/12/obit_trip.jpg?crop=900:600&width=760 760w, https://www.rollingstone.com/wp-content/uploads/2018/12/obit_trip.jpg?crop=900:600&width=920 920w, https://www.rollingstone.com/wp-content/uploads/2018/12/obit_trip.jpg?crop=900:600&width=1440 1440w" sizes="(max-width: 1259px) 60%, 760px" />            </div><!-- .c-crop -->
+
+
+<div class="c-gallery-card__badge">
+
+
+<div class="c-badge c-badge--gallery c-badge--mobile-full">
+    <svg class="c-badge__icon"><use xlink:href="#svg-icon-camera"></use></svg>
+    <div class="c-badge__label t-semibold t-semibold--upper">
+        46 Photos   </div><!-- .c-badge__label -->
+</div><!-- .c-badge--gallery -->
+
+</div><!-- /.c-gallery-card__badge -->
+
+
+        </figure><!-- .c-gallery-card__image -->
+        <header class="c-gallery-card__header">
+
+            <h4 class="c-gallery-card__headline t-bold">In Memoriam 2018: People We Lost This Year</h4>
+            <p class="c-gallery-card__lead t-copy">
+                            </p>
+
+            <div class="c-gallery-card__thumbs">
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/GettyImages-74272037.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/GettyImages-74272037.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2018/12/GettyImages-74272037.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;For more than five decades, Aretha Franklin was a singular presence in pop music, a symbol of strength, women&rsquo;s liberation and the civil rights movement. Franklin, one of the&nbsp;greatest singers of all time, died in August.&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;../music/music-news/aretha-franklin-queen-of-soul-dead-at-76-119453/&quot;&gt;Read more here.&lt;/a&gt;&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/GettyImages-85005700.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/GettyImages-85005700.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2018/12/GettyImages-85005700.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;Lead singer of Nineties hits &ldquo;Linger,&rdquo; &ldquo;Dreams&rdquo; and &ldquo;Zombie&rdquo; &lt;a href=&quot;../music/music-news/dolores-oriordan-the-cranberries-singer-dead-at-46-253547/&quot;&gt;died in January.&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;../music/music-news/dolores-oriordan-inside-cranberries-singers-final-days-125322/&quot;&gt;Read: Inside the singer&#8217;s final days.&lt;/a&gt;&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+
+                        <figure class="c-gallery-card__thumb">
+                            <div class="c-crop c-crop--ratio-3x2">
+                                <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                                    data-src="https://www.rollingstone.com/wp-content/uploads/2018/11/mac-miller-left-behind.jpg?crop=3:2,smart&#038;width=90"
+                                    data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/11/mac-miller-left-behind.jpg?crop=3:2,smart&#038;width=90 90w, https://www.rollingstone.com/wp-content/uploads/2018/11/mac-miller-left-behind.jpg?crop=3:2,smart&#038;width=180 180w"
+                                    sizes="90px"
+                                    alt="&lt;p&gt;The 26-year-old rapper known for his canny wordplay and artistic reinvention &lt;a href=&quot;../music/music-news/mac-miller-dead-at-26-720756/&quot;&gt;died in September&lt;/a&gt; at his Los Angeles home.&nbsp;&lt;/p&gt;
+"
+                                    class="c-crop__img" width="90" height="60" />
+                            </div><!-- .c-crop -->
+                        </figure><!-- .c-gallery-card__thumb -->
+
+                                    </div><!-- .c-gallery-card__thumbs -->
+
+        </header><!-- .c-gallery-card__header -->
+    </a><!-- .c-gallery-card__wrap -->
+</article><!-- .c-gallery-card -->
+
+                        </div><!-- /.c-galleries__item c-slider__item -->
+
+
+                </div><!-- /.c-slider__track -->
+            </div><!-- /.c-slider -->
+        </div><!-- /.c-galleries -->
+    </div><!-- /.l-section__content -->
+</div><!-- /.l-section -->
+
+
+
+        <div class="c-ad c-ad--admz">
+        <div class="admz" id="adm-below-article">
+                    <div class="adma google-publisher" data-device="Desktop" data-width="728">
+
+<div class="pmc-adm-goog-pub-div ad-text">
+    <div id="gpt-dsk-tab-hp-footer-uid12" class="ad-rotatable adw-728 adh-90"></div>
+    </div>
+            </div>
+                </div>
+</div>
+
+<div class="l-section l-section--no-separator">
+
+    <div class="l-section__header">
+        <div class="c-section-header">
+            <h3 class="c-section-header__heading t-bold t-bold--condensed">
+                Newswire            </h3>
+            <div class="c-section-header__powerby">
+                <div class="c-section-header__powerby--text">
+                Powered by              </div>
+                <svg class="c-section-header__powerby--logo"><use xlink:href="#svg-pmc-logo-black"></use></svg>
+            </div>
+        </div><!-- .c-section-header -->
+    </div><!-- /.l-section__header -->
+
+    <ul class="c-newswire">
+
+<li class="c-newswire__item">
+
+    <article class="c-card c-card--brand">
+        <a href="https://hollywoodlife.com/2019/01/22/chris-brown-rape-paris-arrest/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--ratio-7x4">
+
+                                        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                        data-src="//pmchollywoodlife.files.wordpress.com/2019/01/chris-brown-loving-cardi-b-and-nicki-drama-ftr.jpg?resize=230%2C135&#038;w=300"
+                        data-srcset="//pmchollywoodlife.files.wordpress.com/2019/01/chris-brown-loving-cardi-b-and-nicki-drama-ftr.jpg?resize=230%2C135&#038;w=300 300w, //pmchollywoodlife.files.wordpress.com/2019/01/chris-brown-loving-cardi-b-and-nicki-drama-ftr.jpg?resize=230%2C135&#038;w=600 600w"
+                        alt="Chris Brown Detained In Paris Over Rape Accusations: Police Confirm Singer Is Being Investigated"
+                        sizes="(max-width: 959px) 46%, (max-width: 1259px) 22%, 300px"
+                        class="c-crop__img" width="300" height="171"
+                    >
+
+                </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+                <h3 class="c-card__heading t-bold">
+                    Chris Brown Detained In Paris Over Rape Accusations: Police Confirm Singer Is Being Investigated                </h3><!-- .c-card__heading -->
+
+                <div class="c-card__brand t-bold">
+                    <span class="screen-reader-text">Posted on:</span> HollywoodLife                </div><!-- c-card__tag -->
+
+                <div class="c-card__timestamp t-copy">
+                    <span class="screen-reader-text">Posted</span>
+                    5 hours ago             </div><!-- c-card__timestamp -->
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--brand -->
+
+</li><!-- /.c-newswire__item -->
+
+
+<li class="c-newswire__item">
+
+    <article class="c-card c-card--brand">
+        <a href="https://wwd.com/fashion-news/fashion-scoops/karl-lagerfeld-absent-chanel-couture-show-1202981313/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--ratio-7x4">
+
+                                        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                        data-src="//pmcwwd.files.wordpress.com/2019/01/chanel-couture-ss19.jpg?resize=230%2C135&#038;w=300"
+                        data-srcset="//pmcwwd.files.wordpress.com/2019/01/chanel-couture-ss19.jpg?resize=230%2C135&#038;w=300 300w, //pmcwwd.files.wordpress.com/2019/01/chanel-couture-ss19.jpg?resize=230%2C135&#038;w=600 600w"
+                        alt="Karl Lagerfeld Absent from Chanel Couture Shows"
+                        sizes="(max-width: 959px) 46%, (max-width: 1259px) 22%, 300px"
+                        class="c-crop__img" width="300" height="171"
+                    >
+
+                </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+                <h3 class="c-card__heading t-bold">
+                    Karl Lagerfeld Absent from Chanel Couture Shows             </h3><!-- .c-card__heading -->
+
+                <div class="c-card__brand t-bold">
+                    <span class="screen-reader-text">Posted on:</span> WWD              </div><!-- c-card__tag -->
+
+                <div class="c-card__timestamp t-copy">
+                    <span class="screen-reader-text">Posted</span>
+                    3 hours ago             </div><!-- c-card__timestamp -->
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--brand -->
+
+</li><!-- /.c-newswire__item -->
+
+
+<li class="c-newswire__item">
+
+    <article class="c-card c-card--brand">
+        <a href="https://deadline.com/2019/01/ovation-journy-chasing-the-sun-1202539051/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--ratio-7x4">
+
+                                        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                        data-src="//pmcdeadline2.files.wordpress.com/2019/01/chasing.jpg?resize=230%2C135&#038;w=300"
+                        data-srcset="//pmcdeadline2.files.wordpress.com/2019/01/chasing.jpg?resize=230%2C135&#038;w=300 300w, //pmcdeadline2.files.wordpress.com/2019/01/chasing.jpg?resize=230%2C135&#038;w=600 600w"
+                        alt="Ovation’s Streaming Service Journy Moves Into Originals With Second Season Of ‘Chasing The Sun’ – Natpe"
+                        sizes="(max-width: 959px) 46%, (max-width: 1259px) 22%, 300px"
+                        class="c-crop__img" width="300" height="171"
+                    >
+
+                </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+                <h3 class="c-card__heading t-bold">
+                    Ovation’s Streaming Service Journy Moves Into Originals With Second Season Of ‘Chasing The Sun’ – Natpe             </h3><!-- .c-card__heading -->
+
+                <div class="c-card__brand t-bold">
+                    <span class="screen-reader-text">Posted on:</span> Deadline             </div><!-- c-card__tag -->
+
+                <div class="c-card__timestamp t-copy">
+                    <span class="screen-reader-text">Posted</span>
+                    5 hours ago             </div><!-- c-card__timestamp -->
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--brand -->
+
+</li><!-- /.c-newswire__item -->
+
+
+<li class="c-newswire__item">
+
+    <article class="c-card c-card--brand">
+        <a href="https://www.indiewire.com/2019/01/live-stream-oscar-nominations-watch-academy-award-2019-nominees-1202036450/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--ratio-7x4">
+
+                                        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                        data-src="//i0.wp.com/www.indiewire.com/wp-content/uploads/2019/01/shutterstock_9795192a.jpg?resize=230%2C135&#038;ssl=1&#038;w=300"
+                        data-srcset="//i0.wp.com/www.indiewire.com/wp-content/uploads/2019/01/shutterstock_9795192a.jpg?resize=230%2C135&#038;ssl=1&#038;w=300 300w, //i0.wp.com/www.indiewire.com/wp-content/uploads/2019/01/shutterstock_9795192a.jpg?resize=230%2C135&#038;ssl=1&#038;w=600 600w"
+                        alt="Live Stream the Oscar Nominations: Watch The Academy’s 2019 Nominees"
+                        sizes="(max-width: 959px) 46%, (max-width: 1259px) 22%, 300px"
+                        class="c-crop__img" width="300" height="171"
+                    >
+
+                </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+                <h3 class="c-card__heading t-bold">
+                    Live Stream the Oscar Nominations: Watch The Academy’s 2019 Nominees                </h3><!-- .c-card__heading -->
+
+                <div class="c-card__brand t-bold">
+                    <span class="screen-reader-text">Posted on:</span> Indiewire                </div><!-- c-card__tag -->
+
+                <div class="c-card__timestamp t-copy">
+                    <span class="screen-reader-text">Posted</span>
+                    2 hours ago             </div><!-- c-card__timestamp -->
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--brand -->
+
+</li><!-- /.c-newswire__item -->
+
+
+<li class="c-newswire__item">
+
+    <article class="c-card c-card--brand">
+        <a href="https://www.goldderby.com/article/2019/oscar-nominations-2019-academy-award-nominees-full-list/" class="c-card__wrap">
+            <figure class="c-card__image">
+
+                <div class="c-crop c-crop--ratio-7x4">
+
+                                        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                        data-src="//i2.wp.com/www.goldderby.com/wp-content/uploads/2016/06/Oscars-Logo-Statue.jpg?resize=230%2C135&#038;ssl=1&#038;w=300"
+                        data-srcset="//i2.wp.com/www.goldderby.com/wp-content/uploads/2016/06/Oscars-Logo-Statue.jpg?resize=230%2C135&#038;ssl=1&#038;w=300 300w, //i2.wp.com/www.goldderby.com/wp-content/uploads/2016/06/Oscars-Logo-Statue.jpg?resize=230%2C135&#038;ssl=1&#038;w=600 600w"
+                        alt="2019 Oscar nominations: Full list of Academy Awards nominees in all 24 categories [UPDATING LIVE]"
+                        sizes="(max-width: 959px) 46%, (max-width: 1259px) 22%, 300px"
+                        class="c-crop__img" width="300" height="171"
+                    >
+
+                </div><!-- .c-crop -->
+
+            </figure><!-- .c-card__image -->
+
+            <header class="c-card__header">
+
+                <h3 class="c-card__heading t-bold">
+                    2019 Oscar nominations: Full list of Academy Awards nominees in all 24 categories [UPDATING LIVE]               </h3><!-- .c-card__heading -->
+
+                <div class="c-card__brand t-bold">
+                    <span class="screen-reader-text">Posted on:</span> GoldDerby                </div><!-- c-card__tag -->
+
+                <div class="c-card__timestamp t-copy">
+                    <span class="screen-reader-text">Posted</span>
+                    5 hours ago             </div><!-- c-card__timestamp -->
+
+            </header><!-- .c-card__header -->
+        </a><!-- .c-card__wrap -->
+    </article><!-- .c-card--brand -->
+
+</li><!-- /.c-newswire__item -->
+
+                        </ul><!-- .c-newswire -->
+
+</div><!-- /.l-section -->
+<footer class="l-footer">
+    <div class="l-footer__wrap">
+        <div class="l-footer__nav">
+            <nav class="l-footer__menu l-footer__menu--wide">
+
+<div class="c-page-nav c-page-nav--footer c-page-nav--2-columns" data-dropdown>
+    <ul class="c-page-nav__list">
+        <li class="c-page-nav__item c-page-nav__item--heading is-active" data-ripple="inverted">
+            <span class="c-page-nav__link t-bold">Rolling Stone</span>
+        </li><!-- .c-page-nav__item -->
+
+        <li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/music/" class="c-page-nav__link t-semibold " title="Music">Music</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/tv/" class="c-page-nav__link t-semibold " title="TV">TV</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/movies/" class="c-page-nav__link t-semibold " title="Movies">Movies</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/politics/" class="c-page-nav__link t-semibold " title="Politics">Politics</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/culture/" class="c-page-nav__link t-semibold " title="Culture">Culture</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/rs-pro/" class="c-page-nav__link t-semibold " title="RS Pro">RS Pro</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/advertise/" class="c-page-nav__link t-semibold " title="Advertise">Advertise</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/contact/" class="c-page-nav__link t-semibold " title="Contact">Contact</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/rs-live-media/" class="c-page-nav__link t-semibold " title="Live Media Events">Live Media Events</a></li>
+    </ul><!-- .c-page-nav__list -->
+</div><!-- .c-page-nav--footer -->
+            </nav><!-- .l-footer__menu--wide -->
+            <nav class="l-footer__menu">
+
+<div class="c-page-nav c-page-nav--footer c-page-nav--1-column" data-dropdown>
+    <ul class="c-page-nav__list">
+        <li class="c-page-nav__item c-page-nav__item--heading is-active" data-ripple="inverted">
+            <span class="c-page-nav__link t-bold">Legal</span>
+        </li><!-- .c-page-nav__item -->
+
+        <li class="c-page-nav__item" data-ripple="inverted"><a href="https://pmc.com/privacy-policy" class="c-page-nav__link t-semibold " title="Privacy Policy">Privacy Policy</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://pmc.com/terms-of-use/" class="c-page-nav__link t-semibold " title="Terms of Use">Terms of Use</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://pmc.com/privacy-policy/#california" class="c-page-nav__link t-semibold " title="Your Privacy Rights">Your Privacy Rights</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://pmc.com/privacy-policy/#adchoices" class="c-page-nav__link t-semibold " title="Ad Choices">Ad Choices</a></li>        <li class="c-page-nav__item" data-ripple="inverted">
+            <a href="#" class="c-page-nav__link t-semibold privacy-consent" target="_blank">
+                Privacy Preferences         </a>
+        </li>
+    </ul><!-- .c-page-nav__list -->
+</div><!-- .c-page-nav--footer -->
+            </nav><!-- .l-footer__menu -->
+            <nav class="l-footer__menu">
+
+<div class="c-page-nav c-page-nav--footer c-page-nav--1-column" data-dropdown>
+    <ul class="c-page-nav__list">
+        <li class="c-page-nav__item c-page-nav__item--heading is-active" data-ripple="inverted">
+            <span class="c-page-nav__link t-bold">Connect With Us</span>
+        </li><!-- .c-page-nav__item -->
+
+        <li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.facebook.com/RollingStone/" class="c-page-nav__link t-semibold " title="Facebook"><span class="c-page-nav__icon c-icon c-icon--inline c-icon--inverted c-icon--round"><svg><use xlink:href="#svg-icon-facebook"></use></svg></span>Facebook</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://twitter.com/RollingStone" class="c-page-nav__link t-semibold " title="Twitter"><span class="c-page-nav__icon c-icon c-icon--inline c-icon--inverted c-icon--round"><svg><use xlink:href="#svg-icon-twitter"></use></svg></span>Twitter</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.youtube.com/channel/UC-JblcinswY50lrUdSaRNEg" class="c-page-nav__link t-semibold " title="YouTube"><span class="c-page-nav__icon c-icon c-icon--inline c-icon--inverted c-icon--round"><svg><use xlink:href="#svg-icon-youtube"></use></svg></span>YouTube</a></li>
+    </ul><!-- .c-page-nav__list -->
+</div><!-- .c-page-nav--footer -->
+            </nav><!-- .l-footer__menu -->
+            <nav class="l-footer__menu">
+
+<div class="c-page-nav c-page-nav--footer c-page-nav--cta c-page-nav--1-column" data-dropdown>
+    <ul class="c-page-nav__list">
+        <li class="c-page-nav__item c-page-nav__item--heading is-active" data-ripple="inverted">
+            <span class="c-page-nav__link t-bold">Get The Magazine</span>
+        </li><!-- .c-page-nav__item -->
+
+        <li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstone.com/subscribe-more/" class="c-page-nav__link t-semibold " title="SUBSCRIBE NOW">SUBSCRIBE NOW</a></li><li class="c-page-nav__item" data-ripple="inverted"><a href="https://www.rollingstonesubscriptions.com/storefront/site/rs-holiday2for1-0917.html" class="c-page-nav__link t-semibold " title="GIVE A GIFT">GIVE A GIFT</a></li>
+    </ul><!-- .c-page-nav__list -->
+</div><!-- .c-page-nav--footer -->
+            </nav><!-- .l-footer__menu -->
+        </div><!-- .l-footer__nav -->
+
+
+<div class="l-footer__newsletter">
+    <p class="l-footer__newsletter-heading t-bold">Newsletter Signup</p>
+    <div class="l-footer__newsletter-form">
+        <form class="c-form c-form--footer" action="https://pages.email.rollingstone.com/signup-api/" method="POST">
+            <div class="c-form__group">
+                <div class="c-form__field t-semibold">
+                    <input type="hidden" name="Editorial_RollingStone_Opted_In" value="Yes">
+<input type="hidden" name="Editorial_RollingStone_Source" value="rs site">
+<input name="__contextName" value="FormPost" type="hidden">
+<input name="__executionContext" value="POST" type="hidden">
+<input name="__successPage" class="js-newsletter-successpage" data-base-url="/signup?signup=success" value="/signup?signup=success" type="hidden">
+<input type="email" name="EmailAddress" class="js-newsletter-email c-form__input" placeholder="Your email" required>
+
+<script>
+jQuery( document ).ready(function($) {
+
+    // Validate email will return true if valid and false if invalid.
+    function validate_email( email ) {
+        const expr = /^([\w.+-]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
+        return expr.test( email );
+    }
+
+    $email_field = jQuery('.js-newsletter-email')
+    $success_page_field = jQuery('.js-newsletter-successpage');
+
+    if ( 0 === $email_field.length || 0 === $success_page_field.length ) {
+        return;
+    }
+
+    success_page_base_url = $success_page_field.data( 'base-url' );
+
+    $email_field.on( 'keyup blur', ( e ) => {
+
+        // validate email and check for empty value.
+        if ( '' === $( e.target ).val() || validate_email( $( e.target ).val() ) ) {
+            $( e.target ).removeClass( 'invalid' );
+        }
+
+        var email_address = encodeURIComponent( $( e.target ).val() );
+        $success_page_field.val( success_page_base_url + '&email=' + email_address );
+
+    } );
+
+});
+</script>
+                </div><!-- .c-form__field -->
+                <button class="c-form__button">
+                    <span class="t-bold t-bold--upper">
+                        Submit                  </span>
+                </button>
+            </div><!-- .c-form__group -->
+        </form><!-- .c-form -->
+    </div>
+</div><!-- .l-footer__newsletter -->
+        <div class="l-footer__tip">
+    <p class="l-footer__tip-heading t-bold">Have a Tip?</p>
+    <div class="l-footer__tip-body">
+    We want to hear from you! Send us a tip using our anonymous form.   </div>
+    <a class="l-footer__tip-link t-bold" href="https://www.rollingstone.com/tips/"><span>Send Us a Tip</span></a>
+    <svg class="l-footer__logo"><use xlink:href="#svg-rs-logo"></use></svg>
+</div><!-- .l-footer__tip -->
+
+
+<div class="l-footer__cover">
+    <a href="https://www.rollingstone.com/subscribe-more/">
+        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=300" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=300 1x, https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=600 2x" alt="Issue 1323: Travis Scott" class="l-footer__cover-image" />    </a>
+</div><!-- .l-footer__cover -->
+
+    </div><!-- .l-footer__wrap -->
+
+    <div class="c-pmc-footer">
+    <div class="c-pmc-footer__wrap">
+
+        <div class="c-pmc-footer__logo">
+            <a href="https://www.pmc.com">
+                <svg><use xlink:href="#svg-pmc-logo-black"></use></svg>
+            </a>
+        </div>
+
+        <div class="c-pmc-footer__legal">
+            &copy; Copyright 2018 Rolling Stone, LLC, a subsidiary of Penske Business Media, LLC. <br/>Powered by WordPress.com VIP
+        </div>
+
+        <div class="c-pmc-footer__dropdown c-pmc-footer--desktop" tabindex="0">
+            <h4 class="c-pmc-footer__dropdown-trigger t-bold--upper">Our Brands</h4>
+            <ul class="c-pmc-footer__dropdown-contents" tabindex="0">
+                            <li><a class="c-pmc-footer__brand t-bold--upper" href="https://variety.com/">Variety</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://deadline.com/">Deadline</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://www.rollingstone.com/">Rolling Stone</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://wwd.com/">WWD</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://hollywoodlife.com/">HollywoodLife</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://www.goldderby.com/">Gold Derby</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://spy.com/">Spy</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://robbreport.com/">Robb Report</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://footwearnews.com/">Footwear News</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://bgr.com/">BGR</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://www.indiewire.com/">IndieWire</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://sourcingjournal.com/">Sourcing Journal</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://tvline.com/">TVLine</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://fairchildlive.com/">Fairchild Media</a></li>
+                                <li><a class="c-pmc-footer__brand t-bold--upper" href="https://www.sheknows.com/">She Knows</a></li>
+
+            </ul>
+        </div>
+
+    </div>
+
+    <div class="l-footer__wrap c-pmc-footer--mobile">
+        <div class="l-footer__nav">
+            <nav class="l-footer__menu l-footer__menu--wide">
+                <div class="c-page-nav c-page-nav--footer c-page-nav--pmc-footer c-page-nav--cta c-page-nav--1-column" data-dropdown="" data-collapsed-height="46px" data-expanded-height="148px">
+                    <ul class="c-page-nav__list">
+                        <li class="c-page-nav__item c-page-nav__item--heading is-active" data-ripple="">
+                            <span class="c-page-nav__link t-bold">Our Brands</span>
+                        </li><!-- .c-page-nav__item -->
+                                                    <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://variety.com/">Variety</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://deadline.com/">Deadline</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://www.rollingstone.com/">Rolling Stone</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://wwd.com/">WWD</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://hollywoodlife.com/">HollywoodLife</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://www.goldderby.com/">Gold Derby</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://spy.com/">Spy</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://robbreport.com/">Robb Report</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://footwearnews.com/">Footwear News</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://bgr.com/">BGR</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://www.indiewire.com/">IndieWire</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://sourcingjournal.com/">Sourcing Journal</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://tvline.com/">TVLine</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://fairchildlive.com/">Fairchild Media</a></li>
+                                                        <li class="c-page-nav__item"><a class="c-page-nav__link" data-ripple="inverted" href="https://www.sheknows.com/">She Knows</a></li>
+                                                </ul><!-- .c-page-nav__list -->
+                </div><!-- .c-page-nav--footer -->
+            </nav>
+        </div>
+    </div>
+
+</div>
+
+
+</footer><!-- .l-footer -->
+
+    </div><!-- .l-page__content -->
+            <div class="l-page__mega">
+
+<div class="l-mega" data-mega-menu>
+    <div class="l-mega__close">
+
+
+<button class="c-close-button" data-flyout="is-mega-open" data-flyout-trigger="close">
+    <span class="screen-reader-text">Close the menu</span>
+</button><!-- .c-close-button -->
+
+    </div><!-- .l-mega__close -->
+    <div class="l-mega__wrap" data-mega-menu-wrap>
+
+        <div class="l-mega__row">
+            <a href="https://www.rollingstone.com/" class="l-mega__branding">
+                <svg class="l-mega__logo"><use xlink:href="#svg-rs-logo"></use></svg>
+                <span class="screen-reader-text">Rolling Stone</span>
+            </a><!-- .l-mega__branding -->
+
+            <div class="l-mega__search">
+                <div data-st-search-form="search_form"></div>
+            </div><!-- .l-mega__search -->
+        </div><!-- .l-mega__row -->
+
+        <div class="l-mega__nav">
+            <ul class="c-mega-nav" data-collapsible-group><li class="c-mega-nav__item" data-collapsible="collapsed"><a href="https://www.rollingstone.com/music/" class="c-mega-nav__link t-bold" data-ripple>Music</a><a href="#" class="c-mega-nav__expander" data-collapsible-toggle="always-show" data-ripple><span class="c-mega-nav__expander-icon"></span><span class="screen-reader-text">Expand the sub menu</span></a><ul class="c-mega-nav__submenu" data-collapsible-panel data-collapsible-breakpoint="mobile-only"><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-latin/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>RS Latin</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-country/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>RS Country</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-lists/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Lists</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-news/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>News</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-pictures/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Pictures</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-features/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Features</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-album-reviews/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Album Reviews</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-live-reviews/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Live Reviews</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/music/music-videos/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Videos</a></li></ul></li><li class="c-mega-nav__item" data-collapsible="collapsed"><a href="https://www.rollingstone.com/tv/" class="c-mega-nav__link t-bold" data-ripple>TV</a><a href="#" class="c-mega-nav__expander" data-collapsible-toggle="always-show" data-ripple><span class="c-mega-nav__expander-icon"></span><span class="screen-reader-text">Expand the sub menu</span></a><ul class="c-mega-nav__submenu" data-collapsible-panel data-collapsible-breakpoint="mobile-only"><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/tv/tv-lists/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Lists</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/tv/tv-news/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>News</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/tv/tv-features/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Features</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/tv/tv-pictures/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Pictures</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/tv/tv-recaps/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Recaps</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/tv/tv-reviews/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Reviews</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/tv/tv-videos/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Videos</a></li></ul></li><li class="c-mega-nav__item" data-collapsible="collapsed"><a href="https://www.rollingstone.com/movies/" class="c-mega-nav__link t-bold" data-ripple>Movies</a><a href="#" class="c-mega-nav__expander" data-collapsible-toggle="always-show" data-ripple><span class="c-mega-nav__expander-icon"></span><span class="screen-reader-text">Expand the sub menu</span></a><ul class="c-mega-nav__submenu" data-collapsible-panel data-collapsible-breakpoint="mobile-only"><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/movies/movie-lists/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Lists</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/movies/movie-pictures/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Pictures</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/movies/movie-news/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>News</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/movies/movie-reviews/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Reviews</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/movies/movie-features/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Features</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/movies/movie-videos/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Videos</a></li></ul></li><li class="c-mega-nav__item" data-collapsible="collapsed"><a href="https://www.rollingstone.com/politics/" class="c-mega-nav__link t-bold" data-ripple>Politics</a><a href="#" class="c-mega-nav__expander" data-collapsible-toggle="always-show" data-ripple><span class="c-mega-nav__expander-icon"></span><span class="screen-reader-text">Expand the sub menu</span></a><ul class="c-mega-nav__submenu" data-collapsible-panel data-collapsible-breakpoint="mobile-only"><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/politics/politics-features/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Features</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/politics/politics-news/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>News</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/politics/politics-lists/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Lists</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/politics/politics-pictures/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Pictures</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/politics/politics-videos/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Videos</a></li></ul></li><li class="c-mega-nav__item" data-collapsible="collapsed"><a href="https://www.rollingstone.com/culture/" class="c-mega-nav__link t-bold" data-ripple>Culture</a><a href="#" class="c-mega-nav__expander" data-collapsible-toggle="always-show" data-ripple><span class="c-mega-nav__expander-icon"></span><span class="screen-reader-text">Expand the sub menu</span></a><ul class="c-mega-nav__submenu" data-collapsible-panel data-collapsible-breakpoint="mobile-only"><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/culture/culture-features/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Features</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/culture/culture-lists/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Lists</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/culture/culture-news/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>News</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/culture/culture-videos/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Videos</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/culture/culture-sports/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Sports</a></li></ul></li><li class="c-mega-nav__item" data-collapsible="collapsed"><a href="#" class="c-mega-nav__link t-bold" data-ripple>More</a><a href="#" class="c-mega-nav__expander" data-collapsible-toggle="always-show" data-ripple><span class="c-mega-nav__expander-icon"></span><span class="screen-reader-text">Expand the sub menu</span></a><ul class="c-mega-nav__submenu" data-collapsible-panel data-collapsible-breakpoint="mobile-only"><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/t/ytm/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>This Week in Music</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/video/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Videos</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/rs-pro/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>RS Pro</a></li><li class="c-mega-nav__item c-mega-nav__item--sub"><a href="https://www.rollingstone.com/rs-live-media/" class="c-mega-nav__link c-mega-nav__link--sub t-semibold" data-ripple>Live Media Events</a></li></ul></li></ul>
+            <div class="l-mega__cover">
+                <div class="c-cover t-bold c-cover--mega">
+
+
+        <a href="https://www.rollingstone.com/subscribe-more/" class="c-cover__cta">
+            Subscribe Now       </a><!-- .c-cover__cta" -->
+
+
+    <a href="https://www.rollingstone.com/subscribe-more/">
+        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=80" data-srcset="https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=80 1x, https://www.rollingstone.com/wp-content/uploads/2018/12/R1323_COV-Travis-Scott.jpg?width=160 2x" alt="Issue 1323: Travis Scott" class="c-cover__image" /> </a>
+
+</div><!-- .c-cover -->
+            </div><!-- .l-mega__cover -->
+        </div><!-- .l-mega__nav -->
+
+        <div class="l-mega__row">
+            <div class="l-mega__block l-mega__block--social">
+                <p class="l-mega__heading t-bold">Follow Us</p>
+
+<ul class="c-social-bar c-social-bar--round">
+    <li class="c-social-bar__item"><a href="https://www.facebook.com/RollingStone/" class="c-social-bar__link" title="Facebook" rel="noopener noreferrer"><span class="c-icon c-icon--white c-icon--large"><svg><use xlink:href="#svg-icon-facebook"></use></svg></span><span class="screen-reader-text">Share onFacebook</span></a></li><li class="c-social-bar__item"><a href="https://twitter.com/RollingStone" class="c-social-bar__link" title="Twitter" rel="noopener noreferrer"><span class="c-icon c-icon--white c-icon--large"><svg><use xlink:href="#svg-icon-twitter"></use></svg></span><span class="screen-reader-text">Share onTwitter</span></a></li><li class="c-social-bar__item"><a href="https://www.youtube.com/channel/UC-JblcinswY50lrUdSaRNEg" class="c-social-bar__link" title="YouTube" rel="noopener noreferrer"><span class="c-icon c-icon--white c-icon--large"><svg><use xlink:href="#svg-icon-youtube"></use></svg></span><span class="screen-reader-text">Share onYouTube</span></a></li></ul><!-- .c-social-bar -->
+            </div><!-- .l-mega__block--social -->
+
+            <div class="l-mega__block l-mega__block--newsletter">
+                <p class="l-mega__heading t-bold">Alerts &amp; Newsletters</p>
+                <form class="c-form c-form--faded" action="https://pages.email.rollingstone.com/signup-api/" method="POST">
+
+    <div class="c-form__group">
+        <div class="c-form__field t-semibold">
+                <input type="hidden" name="Editorial_RollingStone_Opted_In" value="Yes">
+<input type="hidden" name="Editorial_RollingStone_Source" value="rs site">
+<input name="__contextName" value="FormPost" type="hidden">
+<input name="__executionContext" value="POST" type="hidden">
+<input name="__successPage" class="js-newsletter-successpage" data-base-url="/signup?signup=success" value="/signup?signup=success" type="hidden">
+<input type="email" name="EmailAddress" class="js-newsletter-email c-form__input" placeholder="Your email" required>
+
+<script>
+jQuery( document ).ready(function($) {
+
+    // Validate email will return true if valid and false if invalid.
+    function validate_email( email ) {
+        const expr = /^([\w.+-]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
+        return expr.test( email );
+    }
+
+    $email_field = jQuery('.js-newsletter-email')
+    $success_page_field = jQuery('.js-newsletter-successpage');
+
+    if ( 0 === $email_field.length || 0 === $success_page_field.length ) {
+        return;
+    }
+
+    success_page_base_url = $success_page_field.data( 'base-url' );
+
+    $email_field.on( 'keyup blur', ( e ) => {
+
+        // validate email and check for empty value.
+        if ( '' === $( e.target ).val() || validate_email( $( e.target ).val() ) ) {
+            $( e.target ).removeClass( 'invalid' );
+        }
+
+        var email_address = encodeURIComponent( $( e.target ).val() );
+        $success_page_field.val( success_page_base_url + '&email=' + email_address );
+
+    } );
+
+});
+</script>
+        </div><!-- .c-form__field -->
+        <button class="c-form__button">
+            <span class="t-bold t-bold--upper">
+                Sign Up         </span>
+        </button>
+    </div><!-- .c-form__group -->
+</form><!-- .c-form -->
+            </div><!-- .l-mega__block--newsletter -->
+        </div><!-- .l-mega__row -->
+
+        <div class="l-mega__row">
+            <div class="l-mega__block l-mega__block--footer"><ul class="l-mega__menu"><li id="menu-item-693595" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-693595 l-list__item l-mega__menu-item"><a href="https://www.rollingstone.com/advertise/" class="l-mega__menu-link">Advertise</a></li>
+<li id="menu-item-693737" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-693737 l-list__item l-mega__menu-item"><a href="https://www.rollingstone.com/contact/" class="l-mega__menu-link">Contact</a></li>
+<li id="menu-item-713015" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-713015 l-list__item l-mega__menu-item"><a href="/customerservice" class="l-mega__menu-link">Customer Service</a></li>
+<li id="menu-item-693597" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-693597 l-list__item l-mega__menu-item"><a href="https://www.rollingstone.com/tips/" class="l-mega__menu-link">Submit a Tip</a></li>
+</ul></div>         <!-- .l-mega__block--footer -->
+
+            <div class="l-mega__block l-mega__block--legal">
+                <svg class="l-mega__pmc-logo"><use xlink:href="#svg-pmc-logo-white"></use></svg>
+                <span class="screen-reader-text">PMC</span>
+                <p class="l-mega__copyright">
+                    &copy; 2019 Penske Media Corporation                </p>
+            </div><!-- .l-mega__block--legal -->
+        </div><!-- .l-mega__row -->
+
+    </div><!-- .l-mega__wrap -->
+</div><!-- .l-mega -->
+            </div><!-- .l-page__mega -->
+        </div><!-- .l-page -->
+
+                <div id="pmc-ad-bait" class="pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad text_ads text-ads text-ad-links" style="width: 0 !important; height: 0 !important; position: fixed !important; left: -99999px !important;">ad</div>
+
+        <script>
+            if ( 'undefined' !== typeof jQuery ) {
+                var $pmc_ad_bait = jQuery('#pmc-ad-bait');
+                if ( $pmc_ad_bait.length ) {
+                    if ( 'block' !== $pmc_ad_bait.css('display') ) {
+                        window.pmc_is_adblocked = true;
+                    }
+                }
+            }
+        </script>
+        <script type='text/javascript' class="script-mobile">
+pmc_adm_gpt.init({
+    "ad_targetings": {
+        "host": "www.rollingstone.com",
+        "kw": [],
+        "topic": [],
+        "featured-video": "no",
+        "content-video": "no"
+    },
+    "ad_list": {
+        "default": [
+            {
+                "targeting": {
+                    "pos": [
+                        "top",
+                        "atf",
+                        "leaderboard1",
+                        "leaderboard"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/leaderboard",
+                "id": "gpt-dsk-hp-leaderboard-uid1",
+                "width": [
+                    [
+                        970,
+                        90
+                    ],
+                    [
+                        970,
+                        250
+                    ],
+                    [
+                        728,
+                        90
+                    ],
+                    [
+                        970,
+                        125
+                    ]
+                ],
+                "adunit-order": "1",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "top",
+                        "atf",
+                        "skin"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/skin",
+                "id": "gpt-dsk-hp-skin-oop-uid0",
+                "adunit-order": "2",
+                "bidders": false,
+                "is_lazy_load": "no",
+                "oop": true
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "top",
+                        "atf",
+                        "rail1",
+                        "rail-top"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/rail1",
+                "id": "gpt-dsk-tab-hp-rail-top-uid2",
+                "width": [
+                    [
+                        300,
+                        250
+                    ],
+                    [
+                        300,
+                        251
+                    ]
+                ],
+                "adunit-order": "3",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "logo"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/logo",
+                "id": "gpt-dsk-tab-hp-logo1x1-uid3",
+                "adunit-order": "3",
+                "bidders": false,
+                "is_lazy_load": "no",
+                "oop": true
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "rail-bottom",
+                        "btf",
+                        "sticky",
+                        "railx",
+                        "bottom"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/railX",
+                "id": "gpt-dsk-tab-hp-railX-uid5",
+                "width": [
+                    [
+                        300,
+                        250
+                    ],
+                    [
+                        300,
+                        600
+                    ],
+                    [
+                        300,
+                        251
+                    ]
+                ],
+                "adunit-order": "4",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "rail-bottom",
+                        "btf",
+                        "sticky",
+                        "railx",
+                        "bottom"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/railX",
+                "id": "gpt-dsk-tab-hp-railX-uid7",
+                "width": [
+                    [
+                        300,
+                        250
+                    ],
+                    [
+                        300,
+                        600
+                    ],
+                    [
+                        300,
+                        251
+                    ]
+                ],
+                "adunit-order": "4",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "rail-bottom",
+                        "btf",
+                        "sticky",
+                        "railx",
+                        "bottom"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/railX",
+                "id": "gpt-dsk-tab-hp-railX-uid9",
+                "width": [
+                    [
+                        300,
+                        250
+                    ],
+                    [
+                        300,
+                        600
+                    ],
+                    [
+                        300,
+                        251
+                    ]
+                ],
+                "adunit-order": "4",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "rail-bottom",
+                        "btf",
+                        "sticky",
+                        "railx",
+                        "bottom"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/railX",
+                "id": "gpt-dsk-tab-hp-railX-uid11",
+                "width": [
+                    [
+                        300,
+                        250
+                    ],
+                    [
+                        300,
+                        600
+                    ],
+                    [
+                        300,
+                        251
+                    ]
+                ],
+                "adunit-order": "4",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "native",
+                        "btf"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/native",
+                "id": "gpt-dsk-tab-hp-native-uid4",
+                "width": [
+                    [
+                        3,
+                        3
+                    ]
+                ],
+                "adunit-order": "10",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "native",
+                        "btf"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/native",
+                "id": "gpt-dsk-tab-hp-native-uid6",
+                "width": [
+                    [
+                        3,
+                        3
+                    ]
+                ],
+                "adunit-order": "10",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "native",
+                        "btf"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/native",
+                "id": "gpt-dsk-tab-hp-native-uid8",
+                "width": [
+                    [
+                        3,
+                        3
+                    ]
+                ],
+                "adunit-order": "10",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "native",
+                        "btf"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/native",
+                "id": "gpt-dsk-tab-hp-native-uid10",
+                "width": [
+                    [
+                        3,
+                        3
+                    ]
+                ],
+                "adunit-order": "10",
+                "bidders": false,
+                "is_lazy_load": "no"
+            },
+            {
+                "targeting": {
+                    "pos": [
+                        "bottom",
+                        "btf",
+                        "leaderboardBottom1",
+                        "footer"
+                    ]
+                },
+                "slot": "3782/rstone.site/homepage/footer",
+                "id": "gpt-dsk-tab-hp-footer-uid12",
+                "width": [
+                    [
+                        728,
+                        90
+                    ],
+                    [
+                        728,
+                        91
+                    ]
+                ],
+                "adunit-order": "13",
+                "bidders": false,
+                "is_lazy_load": "no"
+            }
+        ]
+    },
+    "ad_vast_tags": []
+});
+</script>
+
+    <div style="display:none">
+    </div>
+<script type="text/liquid" id="ac_article">
+    <div class="ac_title">{{ result | highlight: 'title' | unescape }}</div>
+    <div class="ac_sub">{{ result.published_at | date: "%h %d, %Y" }}</div>
+</script>
+
+<script type="text/liquid" id="ac_tag">
+    <div class="ac_title">
+        <a href="{{ result.url }}">{{ result.name }}</a>
+    </div>
+</script>
+    <script type="text/javascript">
+    // <![CDATA[
+        var disqus_shortname = "rollingstone";
+        var disqus_domain = "disqus.com";
+        (function () {
+            var nodes = document.getElementsByTagName('span');
+            for (var i = 0, url; i < nodes.length; i++) {
+                if (nodes[i].className.indexOf('dsq-postid') != -1) {
+                    nodes[i].parentNode.setAttribute('data-disqus-identifier', nodes[i].getAttribute('rel'));
+                    url = nodes[i].parentNode.href.split('#', 1);
+                    if (url.length == 1) url = url[0];
+                    else url = url[1]
+                    nodes[i].parentNode.href = url + '#disqus_thread';
+                }
+            }
+            var s = document.createElement('script'); s.async = true;
+            s.type = 'text/javascript';
+            s.src = '//' + disqus_domain + '/forums/' + disqus_shortname + '/count.js';
+            (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+        }());
+    //]]>
+    </script>
+        <div hidden>
+            <svg id="svg-icon-arrow-down" viewBox="0 0 14 8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path d="M13.463 1.64L7.675 7.427c-.193.193-.386.29-.675.29-.29 0-.482-.097-.675-.29L.537 1.64a.932.932 0 0 1 0-1.35.932.932 0 0 1 1.35 0L7 5.401 12.112.289a.932.932 0 0 1 1.35 0 .932.932 0 0 1 0 1.35z" id="a"/>
+</svg><svg id="svg-icon-camera" viewBox="0 0 22 20" xmlns="http://www.w3.org/2000/svg"><g fill="#FFF"><path d="M20.6 12.88a.81.81 0 0 0 .82-.81V6.8a3.25 3.25 0 0 0-3.24-3.25h-1.23a.81.81 0 0 1-.77-.55l-.25-.72a2.43 2.43 0 0 0-2.3-1.64H8.45a2.44 2.44 0 0 0-2.29 1.6l-.28.78a.81.81 0 0 1-.76.53H3.9A3.25 3.25 0 0 0 .66 6.8v9.32a3.25 3.25 0 0 0 3.24 3.25h14.28a3.25 3.25 0 0 0 3.24-3.25.81.81 0 1 0-1.62 0c0 .9-.73 1.63-1.62 1.63H3.9a1.62 1.62 0 0 1-1.62-1.63V6.8c0-.9.73-1.62 1.62-1.62h1.22A2.44 2.44 0 0 0 7.4 3.57l.28-.78a.81.81 0 0 1 .76-.53h5.18a.81.81 0 0 1 .77.55l.24.72a2.43 2.43 0 0 0 2.3 1.65h1.24c.89 0 1.62.72 1.62 1.62v5.27c0 .45.36.8.8.8z"/><path d="M11.08 5.99a5.07 5.07 0 0 0-5.07 5.06 5.07 5.07 0 0 0 5.07 5.07 5.07 5.07 0 0 0 5.07-5.07A5.07 5.07 0 0 0 11.08 6zm0 8.51a3.45 3.45 0 0 1-3.45-3.44 3.45 3.45 0 0 1 3.45-3.45 3.45 3.45 0 0 1 3.45 3.44 3.45 3.45 0 0 1-3.45 3.45z"/></g></svg><svg id="svg-icon-chevron" width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13.7 4.7l-6 6c-.2.2-.4.3-.7.3-.3 0-.5-.1-.7-.3l-6-6c-.4-.4-.4-1 0-1.4.4-.4 1-.4 1.4 0L7 8.6l5.3-5.3c.4-.4 1-.4 1.4 0 .4.4.4 1 0 1.4z" fill="#D32531" />
+</svg><svg id="svg-icon-comments">
+  <path d="M2.338.374h10.925c.74 0 1.366.626 1.366 1.366v7.511c0 .74-.625 1.366-1.366 1.366h-6.5l-2.208 2.429a.228.228 0 0 1-.396-.153v-2.276h-1.82A1.384 1.384 0 0 1 .973 9.251V1.74C.973 1 1.598.374 2.338.374z" fill="#FFF"/>
+</svg><svg id="svg-icon-email" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 3v18h24v-18h-24zm21.518 2l-9.518 7.713-9.518-7.713h19.036zm-19.518 14v-11.817l10 8.104 10-8.104v11.817h-20z"/></svg>
+<svg id="svg-icon-external-link" viewbox="0 0 18 13" xmlns="http://www.w3.org/2000/svg"><path d="M17.3 3.95L14.18.81c-.14-.13-.3-.18-.5-.1a.42.42 0 0 0-.28.42v1.6c-1.15.2-2.21.6-3.18 1.18a8.14 8.14 0 0 0-2.8 2.7c-.12.2-.09.41.08.57.15.14.4.15.56.05l.02-.01c.11-.08.23-.14.34-.2a11.3 11.3 0 0 1 4.68-1.18h.3V7.4c0 .2.1.35.29.42.06.03.12.03.16.03.13 0 .23-.04.33-.13L17.3 4.6a.46.46 0 0 0 0-.65zm-4.65 7.16V8.4h.9v2.72a.99.99 0 0 1-1 1h-11a1 1 0 0 1-.99-.9v-8.2c.06-.51.48-.91 1-.91h9.1v.92h-9.1c-.06 0-.08.02-.08.08v8.01c0 .06.02.09.08.09h11c.04 0 .09-.05.09-.09z"/></svg><svg id="svg-icon-facebook" viewbox="0 0 8 15" xmlns="http://www.w3.org/2000/svg">
+    <path d="M1.803189 14.425508H4.50797V7.212754h2.45121l.253573-2.479384H4.507971V3.493678c0-.375666.05635-.638628.16905-.788895.112699-.150267.385052-.225399.81707-.225399h1.718663V0H4.73337C3.606372 0 2.836268.267658 2.423035.802982c-.413234.535325-.619846 1.357083-.619846 2.465297V4.73337H0v2.479384h1.803189v7.212754z" fill-rule="evenodd"/>
+</svg>
+<svg id="svg-icon-hamburger" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M22 12c0 .6-.4 1-1 1H3c-.6 0-1-.4-1-1s.4-1 1-1h18c.6 0 1 .4 1 1zM3 7h18c.6 0 1-.4 1-1s-.4-1-1-1H3c-.6 0-1 .4-1 1s.4 1 1 1zM21 17H3c-.6 0-1 .4-1 1s.4 1 1 1h18c.6 0 1-.4 1-1s-.4-1-1-1z"/></svg>
+<svg id="svg-icon-linkedin" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4.98 3.5c0 1.381-1.11 2.5-2.48 2.5s-2.48-1.119-2.48-2.5c0-1.38 1.11-2.5 2.48-2.5s2.48 1.12 2.48 2.5zm.02 4.5h-5v16h5v-16zm7.982 0h-4.968v16h4.969v-8.399c0-4.67 6.029-5.052 6.029 0v8.399h4.988v-10.131c0-7.88-8.922-7.593-11.018-3.714v-2.155z"/></svg>
+<svg id="svg-icon-key" viewBox=" 0 0 31 15" xmlns="http://www.w3.org/2000/svg">
+    <g fill-rule="nonzero" fill="none">
+        <path style="fill: #BEC8D6" d="M17.962 8.903L.363 7.633l2.125-2.191 14.969-.262z"/>
+        <path d="M30.783 7.102a6.819 6.819 0 1 0-13.636.238L.363 7.633l4.253 4.117 2-2.07 2.072 2 2-2.072 2.07 2 2-2.07 2.774-.05a6.819 6.819 0 0 0 13.25-2.386zm-4.654 2.144a2.062 2.062 0 1 1-.072-4.123 2.062 2.062 0 0 1 .072 4.123z" style="fill: #A2A9AF"/>
+    </g>
+</svg><svg id="svg-icon-list" xmlns="http://www.w3.org/2000/svg">
+  <path d="M19 .393C8.506.393 0 8.9 0 19.392c0 10.493 8.507 19 19 19s19-8.507 19-19-8.507-19-19-19zM11.44 26.29a1.312 1.312 0 1 1-.001-2.623 1.312 1.312 0 0 1 .001 2.623zm0-5.586a1.312 1.312 0 1 1 0-2.625 1.312 1.312 0 1 1 0 2.625zm0-5.586a1.312 1.312 0 1 1-.001-2.623 1.312 1.312 0 0 1 .001 2.623zm16.432 11.09H15.567a1.314 1.314 0 0 1 0-2.628h12.305a1.314 1.314 0 0 1 0 2.628zm0-5.544H15.567a1.314 1.314 0 0 1 0-2.628h12.305a1.314 1.314 0 1 1 0 2.628zm0-5.544H15.567a1.314 1.314 0 1 1 0-2.628h12.305a1.314 1.314 0 0 1 0 2.628z" fill-rule="evenodd"/>
+</svg><svg id="svg-icon-more" viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg"><path d="M2.53 5.27H.74V.6h4.67v1.78H2.53v2.89zm10.34 7.45H9.98v1.79h4.67V9.84h-1.78v2.88zM9.98 2.38h2.89v2.89h1.78V.6H9.98v1.78zM2.53 9.84H.74v4.67h4.67v-1.79H2.53V9.84zM11 6.66H8.59V4.24H6.8v2.42H4.39v1.78H6.8v2.42h1.78V8.44H11V6.66z" fill="#1389FE" fill-rule="evenodd"/></svg><svg id="svg-icon-pin-it" viewbox="0 0 12 15" xmlns="http://www.w3.org/2000/svg"><path d="M2.04 8.34c.17-.28.26-.54.26-.77a1 1 0 0 0-.13-.55l-.3-.5c-.1-.2-.18-.39-.2-.57-.1-.7-.03-1.37.23-2.02.27-.65.66-1.17 1.18-1.56.52-.4 1.09-.7 1.71-.9a3.5 3.5 0 0 1 3.65.87c.42.43.67 1.06.77 1.87.09.82.04 1.6-.16 2.34-.2.74-.56 1.37-1.08 1.88-.51.5-1.1.7-1.77.56-.49-.1-.79-.33-.9-.7-.11-.38-.1-.81.06-1.3.15-.49.3-.98.48-1.48.17-.5.23-.96.2-1.38a.94.94 0 0 0-.66-.86 1.3 1.3 0 0 0-1.14.08c-.35.21-.6.5-.77.9a3.26 3.26 0 0 0 .05 2.54c-.08.38-.2.85-.34 1.41l-.39 1.44a18.75 18.75 0 0 0-.46 3.07c0 .45.03 1.02.08 1.72a4.08 4.08 0 0 0 1.4-1.86c.31-.8.6-1.8.84-3.02l.45.28c.19.14.34.23.45.3a2.83 2.83 0 0 0 1.02.32 3.6 3.6 0 0 0 2.73-.81 5.1 5.1 0 0 0 1.66-2.48A7.1 7.1 0 0 0 11.22 4 4.15 4.15 0 0 0 9.1.86a6.5 6.5 0 0 0-4.2-.8 5.65 5.65 0 0 0-3.38 1.59A4.67 4.67 0 0 0 .01 5.02c-.08 1.9.6 3 2.03 3.32z" fill-rule="evenodd"/></svg>
+<svg id="svg-icon-play" viewBox="0 0 25 32" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3.16.754C2.528.286.838.286.702 2.05v19.743a.99.99 0 0 0 1.577.796 3.88 3.88 0 0 0 1.576-3.123V5.024l16.009 10.968-18.459 12.61c-.44.3-.703.799-.703 1.332a1.564 1.564 0 0 0 2.46 1.297L23.544 17.29c.528-.317 1.252-1.614 0-2.595L3.161.754z" fill="#FFF" fill-rule="evenodd"/>
+</svg><svg id="svg-icon-plus" viewbox="-2 -2 15 15" xmlns="http://www.w3.org/2000/svg"><path d="M11 4.75v1.5c0 .2-.07.39-.22.53a.72.72 0 0 1-.53.22H7v3.25c0 .2-.07.39-.22.53a.72.72 0 0 1-.53.22h-1.5a.72.72 0 0 1-.53-.22.72.72 0 0 1-.22-.53V7H.75a.72.72 0 0 1-.53-.22.72.72 0 0 1-.22-.53v-1.5c0-.2.07-.39.22-.53A.72.72 0 0 1 .75 4H4V.75c0-.2.07-.39.22-.53A.72.72 0 0 1 4.75 0h1.5c.2 0 .39.07.53.22A.7.7 0 0 1 7 .75V4h3.25c.2 0 .39.07.53.22a.7.7 0 0 1 .22.53z" fill-rule="evenodd"/></svg><svg id="svg-icon-print" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M24 5h-4v-5h-16v5h-4v13h4v6h9.519c2.947 0 6.029-3.577 6.434-6h4.047v-13zm-18-3h12v3h-12v-3zm8.691 16.648s1.469 3.352-2 3.352h-6.691v-8h12v2.648c0 3.594-3.309 2-3.309 2zm6.809-10.648c-.276 0-.5-.224-.5-.5s.224-.5.5-.5.5.224.5.5-.224.5-.5.5zm-5.5 9h-8v-1h8v1zm-3 1h-5v1h5v-1z"/></svg>
+<svg id="svg-icon-reddit" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M24 11.779c0-1.459-1.192-2.645-2.657-2.645-.715 0-1.363.286-1.84.746-1.81-1.191-4.259-1.949-6.971-2.046l1.483-4.669 4.016.941-.006.058c0 1.193.975 2.163 2.174 2.163 1.198 0 2.172-.97 2.172-2.163s-.975-2.164-2.172-2.164c-.92 0-1.704.574-2.021 1.379l-4.329-1.015c-.189-.046-.381.063-.44.249l-1.654 5.207c-2.838.034-5.409.798-7.3 2.025-.474-.438-1.103-.712-1.799-.712-1.465 0-2.656 1.187-2.656 2.646 0 .97.533 1.811 1.317 2.271-.052.282-.086.567-.086.857 0 3.911 4.808 7.093 10.719 7.093s10.72-3.182 10.72-7.093c0-.274-.029-.544-.075-.81.832-.447 1.405-1.312 1.405-2.318zm-17.224 1.816c0-.868.71-1.575 1.582-1.575.872 0 1.581.707 1.581 1.575s-.709 1.574-1.581 1.574-1.582-.706-1.582-1.574zm9.061 4.669c-.797.793-2.048 1.179-3.824 1.179l-.013-.003-.013.003c-1.777 0-3.028-.386-3.824-1.179-.145-.144-.145-.379 0-.523.145-.145.381-.145.526 0 .65.647 1.729.961 3.298.961l.013.003.013-.003c1.569 0 2.648-.315 3.298-.962.145-.145.381-.144.526 0 .145.145.145.379 0 .524zm-.189-3.095c-.872 0-1.581-.706-1.581-1.574 0-.868.709-1.575 1.581-1.575s1.581.707 1.581 1.575-.709 1.574-1.581 1.574z"/></svg>
+<svg id="svg-icon-share" viewBox="0 0 19 20" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12.782 14.109l-5.934-3.167c.078-.301.132-.613.132-.942 0-.36-.063-.697-.157-1.022l5.903-3.151c.64.885 1.64 1.458 2.782 1.458C17.44 7.285 19 5.658 19 3.645S17.44 0 15.508 0c-1.926 0-3.488 1.632-3.488 3.644 0 .33.055.64.132.942l-5.93 3.166c-.638-.845-1.618-1.396-2.73-1.396C1.564 6.356 0 7.987 0 10c0 2.014 1.564 3.644 3.492 3.644 1.142 0 2.143-.58 2.782-1.466l5.903 3.151a3.711 3.711 0 0 0-.162 1.027c0 2.014 1.567 3.644 3.493 3.644C17.438 20 19 18.37 19 16.356c0-2.012-1.562-3.645-3.492-3.645-1.112 0-2.087.551-2.726 1.398z" fill="#FEFEFE" fill-rule="evenodd"/>
+</svg><svg id="svg-icon-star" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path d="M7.875 0L5.883 5.546 0 5.73l4.651 3.61L3.008 15l4.867-3.314L12.742 15l-1.643-5.66 4.651-3.61-5.883-.184z" />
+</svg><svg id="svg-icon-star--half" viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7.9 0l-2 5.5-5.9.2 4.7 3.6L3 15 8 11.7 8.2 9 8 5.5z" />
+</svg><svg id="svg-icon-thumbnails" viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg"><path d="M4.001 0c.493 0 .74.226.74.677v3.324c0 .206-.073.38-.216.524A.712.712 0 0 1 4 4.74H.74c-.164 0-.329-.072-.493-.215A.67.67 0 0 1 0 4V.677C0 .226.246 0 .739 0H4zm7.88 0c.493 0 .739.226.739.677v3.324c0 .206-.072.38-.215.524a.712.712 0 0 1-.524.215H8.557c-.451 0-.677-.246-.677-.739V.677c0-.451.226-.677.677-.677h3.324zm8.557.677v3.324c0 .493-.225.74-.677.74h-3.324a.712.712 0 0 1-.523-.216.712.712 0 0 1-.216-.524V.677c0-.451.246-.677.739-.677h3.324c.452 0 .677.226.677.677zM4.001 7.88c.493 0 .74.226.74.677v3.324c0 .452-.247.677-.74.677H.74c-.493 0-.739-.225-.739-.677V8.557c0-.451.246-.677.739-.677H4zm7.88 0c.493 0 .739.226.739.677v3.324c0 .452-.246.677-.739.677H8.557c-.451 0-.677-.225-.677-.677V8.557c0-.451.226-.677.677-.677h3.324zm7.88 0c.452 0 .677.226.677.677v3.324c0 .452-.225.677-.677.677h-3.324c-.493 0-.739-.225-.739-.677V8.557c0-.451.246-.677.739-.677h3.324zm-15.76 7.818c.206 0 .38.072.524.216a.712.712 0 0 1 .215.523v3.324c0 .452-.246.677-.739.677H.74c-.493 0-.739-.225-.739-.677v-3.324a.67.67 0 0 1 .246-.523c.164-.144.329-.216.493-.216H4zm7.88 0c.205 0 .38.072.524.216a.712.712 0 0 1 .215.523v3.324c0 .452-.246.677-.739.677H8.557c-.451 0-.677-.225-.677-.677v-3.324c0-.493.226-.739.677-.739h3.324zm7.88 0c.452 0 .677.246.677.739v3.324c0 .452-.225.677-.677.677h-3.324c-.493 0-.739-.225-.739-.677v-3.324c0-.205.072-.38.216-.523a.712.712 0 0 1 .523-.216h3.324z" /></svg>
+<svg id="svg-icon-trending" viewBox="0 0 18 14" xmlns="http://www.w3.org/2000/svg"><path d="M.57 11.78l6.38-6.57 2.23 2.92 4.65-5.34h-1.49V.81h4.84v4.65h-1.74V3.91l-6.2 7.32-2.48-3.17-4.95 5.15z" fill="#D32531"/></svg><svg id="svg-icon-tumblr" viewbox="0 0 10 15" xmlns="http://www.w3.org/2000/svg"><path d="M1.95 10.96c0 .66.07 1.16.22 1.52.14.36.39.69.75.99a4.85 4.85 0 0 0 2.85.96 7.2 7.2 0 0 0 3.29-.77V11.5c-.59.39-1.22.59-1.9.59a2 2 0 0 1-1.1-.31 1.15 1.15 0 0 1-.54-.62 7.05 7.05 0 0 1-.09-1.55V6.3h3.63V3.6H5.43V0H3.1a5.2 5.2 0 0 1-.49 1.85 3.8 3.8 0 0 1-.99 1.22c-.34.3-.87.56-1.61.79v2.45h1.95v4.65z" fill-rule="evenodd"/></svg><svg id="svg-icon-twitter" viewbox="0 0 15 12" xmlns="http://www.w3.org/2000/svg"><path d="M14.1.23c-.59.33-1.22.57-1.9.7A2.88 2.88 0 0 0 10.02 0c-.81 0-1.5.3-2.1.87a2.84 2.84 0 0 0-.79 2.76A8.26 8.26 0 0 1 1.02.53c-.28.46-.43.95-.43 1.5 0 1.05.45 1.87 1.33 2.45-.47 0-.91-.12-1.33-.37v.06c0 .7.23 1.31.67 1.86.44.54 1.01.9 1.71 1.04a3.79 3.79 0 0 1-1.36.03c.21.6.56 1.1 1.07 1.48.5.38 1.07.58 1.7.58A5.8 5.8 0 0 1 0 10.4a8.37 8.37 0 0 0 4.56 1.32c1.32 0 2.53-.25 3.62-.76a7.63 7.63 0 0 0 2.68-1.99 9.36 9.36 0 0 0 1.6-2.7c.37-.99.56-1.98.56-2.97v-.37a6.06 6.06 0 0 0 1.47-1.55c-.54.24-1.11.4-1.7.48a2.9 2.9 0 0 0 1.3-1.63z" fill-rule="evenodd"/></svg><svg id="svg-icon-whatsapp" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M.057 24l1.687-6.163c-1.041-1.804-1.588-3.849-1.587-5.946.003-6.556 5.338-11.891 11.893-11.891 3.181.001 6.167 1.24 8.413 3.488 2.245 2.248 3.481 5.236 3.48 8.414-.003 6.557-5.338 11.892-11.893 11.892-1.99-.001-3.951-.5-5.688-1.448l-6.305 1.654zm6.597-3.807c1.676.995 3.276 1.591 5.392 1.592 5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.892-5.452 0-9.887 4.434-9.889 9.884-.001 2.225.651 3.891 1.746 5.634l-.999 3.648 3.742-.981zm11.387-5.464c-.074-.124-.272-.198-.57-.347-.297-.149-1.758-.868-2.031-.967-.272-.099-.47-.149-.669.149-.198.297-.768.967-.941 1.165-.173.198-.347.223-.644.074-.297-.149-1.255-.462-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.297-.347.446-.521.151-.172.2-.296.3-.495.099-.198.05-.372-.025-.521-.075-.148-.669-1.611-.916-2.206-.242-.579-.487-.501-.669-.51l-.57-.01c-.198 0-.52.074-.792.372s-1.04 1.016-1.04 2.479 1.065 2.876 1.213 3.074c.149.198 2.095 3.2 5.076 4.487.709.306 1.263.489 1.694.626.712.226 1.36.194 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.695.248-1.29.173-1.414z"/></svg>
+<svg id="svg-icon-youtube" xmlns="http://www.w3.org/2000/svg" viewBox="2 8 45 34"><path d="M44.898 14.5c-.398-2.2-2.296-3.8-4.5-4.3C37.102 9.5 31 9 24.398 9c-6.597 0-12.796.5-16.097 1.2-2.2.5-4.102 2-4.5 4.3C3.398 17 3 20.5 3 25s.398 8 .898 10.5c.403 2.2 2.301 3.8 4.5 4.3 3.5.7 9.5 1.2 16.102 1.2s12.602-.5 16.102-1.2c2.199-.5 4.097-2 4.5-4.3.398-2.5.898-6.102 1-10.5-.204-4.5-.704-8-1.204-10.5zM19 32V18l12.2 7z"/></svg>
+<svg id="svg-pmc-logo-black" viewbox="0 0 137 21" xmlns="http://www.w3.org/2000/svg">
+    <g fill="#000">
+        <path d="M137.3062 20.6972h-30.4185c-4.4206 0-7.7483-1.8544-7.7483-6.454V6.927c0-4.7149 2.7236-6.7825 7.9126-6.7825h30.2542V3.001h-30.1927c-2.8125 0-4.9328.8945-4.9328 3.9876v7.0493c0 2.4205 1.7498 3.8028 4.624 3.8028h30.5015v2.8565zM91 4v16h-3V5.7779zM46 4v16h3V5.7779zM46.1518.1236h2.7949L68.514 12.0648 88.573.1236h2.2817l-.0098 1.7059-20.493 12.2599c-1.2895.7723-4.7335-.3295-4.7335-.3295L46.1518 2.077V.1235z" />
+        <path d="M37.8174 7.5128c0 3.1214-2.6766 4.6855-5.7756 4.6855H3.124v8.4884H.0006l-.001-11.3038h32.186c1.7195 0 2.6072-.653 2.5905-2.2817l-.0205-1.9317c-.0186-1.7186-.8084-2.137-2.57-2.137H-.0004V.1232H32.515c2.8976 0 5.3024 1.1575 5.3024 4.101v3.2886z"/>
+    </g>
+    <g fill="#c92228">
+        <path d="M91.313 1.8296L91.3122.1237h-2.2905L66.066 13.76l.525.31a4.081 4.081 0 0 0 4.2183.0195l.5718-.3432 19.932-11.9167z" />
+    </g>
+</svg>
+<svg id="svg-pmc-logo-white" viewbox="0 0 137 21" xmlns="http://www.w3.org/2000/svg">
+    <g fill="#fff">
+        <path d="M137.3062 20.6972h-30.4185c-4.4206 0-7.7483-1.8544-7.7483-6.454V6.927c0-4.7149 2.7236-6.7825 7.9126-6.7825h30.2542V3.001h-30.1927c-2.8125 0-4.9328.8945-4.9328 3.9876v7.0493c0 2.4205 1.7498 3.8028 4.624 3.8028h30.5015v2.8565zM91 4v16h-3V5.7779zM46 4v16h3V5.7779zM46.1518.1236h2.7949L68.514 12.0648 88.573.1236h2.2817l-.0098 1.7059-20.493 12.2599c-1.2895.7723-4.7335-.3295-4.7335-.3295L46.1518 2.077V.1235z" />
+        <path d="M37.8174 7.5128c0 3.1214-2.6766 4.6855-5.7756 4.6855H3.124v8.4884H.0006l-.001-11.3038h32.186c1.7195 0 2.6072-.653 2.5905-2.2817l-.0205-1.9317c-.0186-1.7186-.8084-2.137-2.57-2.137H-.0004V.1232H32.515c2.8976 0 5.3024 1.1575 5.3024 4.101v3.2886z"/>
+    </g>
+    <g fill="#c92228">
+        <path d="M91.313 1.8296L91.3122.1237h-2.2905L66.066 13.76l.525.31a4.081 4.081 0 0 0 4.2183.0195l.5718-.3432 19.932-11.9167z" />
+    </g>
+</svg>
+<svg id="svg-rs-badge" viewBox="0 0 22 21" xmlns="http://www.w3.org/2000/svg"><path d="M2.11 14.75a1.65 1.65 0 0 1-.38.07l-.45.03a10.4 10.4 0 0 1-.7-6.7.9.9 0 0 0 .76.44c.38 0 .79-.17.97-.4.03-.04.06-.08.06-.15 0-.1-.05-.16-.1-.23a.37.37 0 0 1-.06-.21c0-.2.3-.45.58-.56a5.69 5.69 0 0 1 1.03-.29l-1.24 7.47c-.05.3-.24.45-.47.53zm4.3-3.07c1.14 3.9 4.5 6.63 9.58 6.63.53 0 1.07-.03 1.57-.1a10.32 10.32 0 0 1-6.89 2.62C7 20.83 3.75 18.9 1.91 16a42.28 42.28 0 0 1 1.65-.05c.91 0 1.83.04 2.66.09l.23-1.2-.57-.04c-.84-.06-.85-.2-.77-.68l.4-2.45h.9zm.72-6.53c-1.1 0-2.68.14-3.8.36-.67.13-1.56.39-2.17.86a10.36 10.36 0 0 1 17.46-2.55l-.2.01c-.8-.04-1.55-.27-2.43-.27-2.11 0-3.66 1.23-3.7 2.96-.01.98.32 1.68.84 2.21.26.27.57.5.89.7.31.22.65.44.99.66.76.5 1.17.83 1.16 1.63-.02.84-.59 1.36-1.66 1.36-1.63 0-2.38-.75-2.72-2.36l-1.3.3c.18.9.42 2.13.57 3.2l.2.1c.21-.13.54-.19.72-.19.34 0 .65.1.98.19.38.09.85.18 1.41.18 2.4 0 4.26-1.11 4.3-3.33.03-1.32-.67-2.1-1.84-2.92l-1.25-.89c-.72-.5-.93-.74-.92-1.31 0-.6.63-1.08 1.57-1.08.92 0 1.54.34 1.53.88 0 .23-.04.49-.16.9h1.26c.08-.55.25-1.33.43-2.03a10.31 10.31 0 0 1 1.74 5.75c0 1.73-.43 3.37-1.18 4.8-.46-.76-1.5-1.17-2.42-1.18l-.2.16c.46.3.7.6.7 1.33 0 .74-.92 1.33-2.15 1.33-3.25 0-5.79-2.47-6.82-5.7 1.36-.46 2.63-1.54 2.63-3.22 0-2.04-1.87-2.84-4.46-2.84zm.21 1.22c.94 0 1.66.66 1.66 1.71 0 1.36-1.3 2.38-2.86 2.38h-.43l.65-4.03c.2-.02.52-.06.98-.06z" fill-rule="evenodd"/></svg><svg id="svg-rs-logo" viewBox="0 0 203 37" xmlns="http://www.w3.org/2000/svg"><path d="M23.65 8.12c0-2.9-1.98-4.73-4.59-4.73-.61 0-2.16.02-2.7.08l-1.81 11.22c.33.03.9 0 1.2 0 4.3 0 7.9-2.8 7.9-6.57zm32.1-6.93l-3.61 22.03c-.15.9-.16 1.26 1.55 1.26l-.43 2.82h-2.97c1.63.75 3.22 1.92 3.22 3.46 0 2.95-2.9 5.3-10.5 5.3-14.07 0-23.36-7.18-26.55-17.97h-2.49l-1.08 6.79c-.2 1.3-.18 1.72 2.13 1.87l1.59.11-.65 3.32c-2.3-.14-4.84-.26-7.37-.25-2.3 0-4.72.12-7 .25l.54-3.32c.6-.03 1.01-.03 1.4-.07a4.57 4.57 0 0 0 1.06-.22c.64-.2 1.16-.61 1.3-1.44L9.32 4.44a15.1 15.1 0 0 0-2.86.8c-.76.3-1.59.99-1.59 1.55 0 .24.05.42.15.58.13.2.29.38.29.65 0 .19-.08.3-.18.43-.5.6-1.62 1.08-2.67 1.08A2.46 2.46 0 0 1 0 7.04c0-3.87 4.84-5.42 7.94-6.03A62.1 62.1 0 0 1 18.5 0c7.15 0 12.34 2.23 12.34 7.87 0 4.64-3.52 7.64-7.29 8.92 2.87 8.95 9.88 15.67 18.88 15.67 3.42 0 4.62-1.46 4.62-2.89a2.2 2.2 0 0 0-2.23-2.27H43.4l.54-2.82c1 0 2.1-.09 2.27-1.12l2.57-15.89c.04-.28-.07-.4-.36-.4h-2.39l.47-2.52L55.46.9l.29.3zm129.5 23.29l-.54 2.82h-9.64l.47-2.82c1.48 0 1.69-.13 1.88-1.4l1.05-6.94c.18-1.19-.54-1.59-1.23-1.59-1.4 0-2.85 1.46-3.1 3.14l-.87 5.63c-.13.8 0 1.16 1.66 1.16l-.44 2.82h-9.78l.5-2.82c1.77 0 2.07-.26 2.24-1.34l1.16-7.15c.08-.5 0-.57-.4-.57h-2.13l.44-2.46 8.73-3.75.26.25-.4 2.2c1.6-1.42 3.37-2.42 5.38-2.42 2.51 0 4.19 2.36 4.19 4.88 0 .59-.05 1.07-.18 1.91l-1.16 7.04c-.2 1.18.01 1.4 1.92 1.4zm-35.34-14.4l-1.66 3.53a5.5 5.5 0 0 0-1.99-.4h-1.98l-1.34 8.2c-.24 1.47.04 1.73.8 1.73.82 0 1.66-.42 3.17-1.8l1.3 2.56c-1.79 1.9-4.07 3.9-6.97 3.9-3.08 0-4.44-1.76-4.44-4.55 0-.59.1-1.39.18-1.95l1.3-8.09-2.27.04.54-3.1 2.16.03.51-3.28 5.96-2.42.4.4-.84 5.23 5.17-.04zm-11.88-8.85a73.34 73.34 0 0 0-1.84 8.05h-3.47c.32-1.15.42-1.87.43-2.5.03-1.5-1.68-2.45-4.22-2.45-2.6 0-4.34 1.33-4.37 3-.03 1.58.57 2.24 2.57 3.65l3.46 2.45c3.22 2.28 5.16 4.41 5.1 8.09-.11 6.11-5.29 9.2-11.92 9.2-1.55 0-2.84-.25-3.9-.5-.9-.22-1.77-.5-2.71-.5a4.4 4.4 0 0 0-2.02.54l-.54-.3a138.7 138.7 0 0 0-1.6-8.84l3.62-.87c.95 4.48 3.03 6.54 7.54 6.54 2.96 0 4.55-1.44 4.59-3.75.04-2.22-1.11-3.14-3.21-4.52-.94-.6-1.87-1.2-2.75-1.8a16.4 16.4 0 0 1-2.45-1.95 8.13 8.13 0 0 1-2.31-6.14c.08-4.8 4.38-8.2 10.21-8.2 2.44 0 4.34.61 6.54.73.73.03 1.96-.13 2.74-.33l.5.4zM75.64 4.15c0 2.27-2.46 4.26-5.02 4.26-1.3 0-2.81-.55-2.81-2.38 0-2.72 2.76-4.55 5.05-4.55 1.51 0 2.78 1.01 2.78 2.67zm-.58 5.31l-2.2 13.36c-.25 1.5-.28 1.66 1.88 1.66l-.44 2.82H64.23l.43-2.82c1.66 0 2.14-.4 2.28-1.3l1.12-7.3c.06-.42.07-.46-.36-.46h-2.31l.43-2.46 8.99-3.75.25.25zm-8.95-8.38l-3.54 21.63c-.26 1.61-.09 1.77 1.52 1.77l-.44 2.81h-9.82l.44-2.81c1.72 0 2.15-.33 2.34-1.55l2.46-15.28c.08-.5.02-.57-.36-.57h-2.28l.44-2.5L65.86.84l.25.25zM196.7 14.73c-.05-1.6-.7-2.06-1.63-2.06-1.06 0-2.57 1.3-3.14 4.2l4.77-2.14zm5.74.87l-10.98 5.05c.23 1.88 1.28 3.14 3 3.14 1.8 0 2.42-1.01 2.42-1.48a.97.97 0 0 0-.18-.57c-.14-.2-.25-.32-.25-.58a.63.63 0 0 1 .14-.44 3.31 3.31 0 0 1 2.46-1.04c1.28 0 2.42.96 2.42 2.42 0 3.17-3.11 5.74-7.98 5.74-4.8 0-8.23-2.91-8.23-8.42 0-4.93 4.4-10.25 9.89-10.25 4.6 0 6.6 2.31 7.29 6.43zm-42.9-.04c0-1.99-.65-2.89-1.83-2.89-1.72 0-3.58 3.64-3.58 8.81 0 1.98.67 2.85 1.84 2.85 1.82 0 3.58-4.2 3.58-8.77m6.24 1.45c0 5.42-3.9 10.86-10.1 10.86-4.72 0-7.73-2.75-7.73-8.23 0-5.59 4.22-10.54 10.04-10.54 4.53 0 7.8 2.86 7.8 7.9m-60.77 13.08c0-.41-.38-.69-1.26-.69-1.01 0-2.03.14-3.07.14a9.95 9.95 0 0 1-4.59-.93c-.7.55-1.12 1.18-1.12 2.09 0 1.17 1.53 2.13 3.22 2.13 4.47 0 6.82-1.63 6.82-2.74m1.01-15.78c0-1-.39-1.88-1.2-1.88-1.84 0-2.63 3.41-2.63 5.45 0 1.42.3 2.02 1.27 2.02 1.62 0 2.56-3.72 2.56-5.6m11.27-2.95c0 1.15-1.02 2.56-2 2.56-.32 0-.43-.23-.6-.47a.87.87 0 0 0-.44-.32 1.25 1.25 0 0 0-.43-.08c-1.05 0-1.8 1.19-1.8 2.24l.03.72a6.3 6.3 0 0 1-.94 3.22 8.74 8.74 0 0 1-7.33 4.04 9.37 9.37 0 0 1-3.28-.47 1.15 1.15 0 0 0-.3.72c0 .74.59.9 1.49.9 1.87 0 3.54-.28 5.27-.28 2.96 0 5.09 1.46 5.09 4.19 0 4.85-7.4 7.8-14.3 7.8-4.1 0-8.05-1.18-8.05-4.66 0-1.72 1-3.06 3.25-4.15h-8.16l.47-2.82c1.64-.04 1.8-.16 1.95-1.2l1.08-7.21c.14-.89-.46-1.52-1.22-1.52-1.42 0-2.87 1.6-3.07 2.89l-.94 5.96c-.12.74.04 1.08 1.59 1.08l-.44 2.82h-9.35l.47-2.82c1.62 0 1.67-.24 1.8-1.08l1.2-7.44c.08-.5 0-.54-.36-.54h-2.32l.47-2.5 8.96-3.71.25.25-.36 2.17c1.8-1.56 3.64-2.42 5.27-2.42 2.86 0 4.26 2.67 4.26 5.12 0 .27-.07.94-.1 1.2l-1.23 7.69c-.15.93.5 1.2 1.4 1.26.45-1.71 1.72-2.6 3.22-3.21a6 6 0 0 1-1.7-4.4c0-4.87 4.39-7.84 8.85-7.84 2.03 0 4.55.68 5.95 2.81 1.01-1.77 2.46-2.81 3.97-2.81 1.35 0 2.42.86 2.42 2.3m-77.66 4.23c0-1.99-.66-2.89-1.84-2.89-1.72 0-3.57 3.64-3.57 8.81 0 1.98.67 2.86 1.84 2.86 1.82 0 3.57-4.2 3.57-8.78m6.25 1.45c0 5.42-3.9 10.86-10.11 10.86-4.71 0-7.73-2.75-7.73-8.23 0-5.59 4.22-10.54 10.04-10.54 4.54 0 7.8 2.86 7.8 7.9"/></svg><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="393" height="88" viewBox="0 0 393 88">
+  <defs>
+    <polygon id="logo-rspro-a" points=".436 .355 34.04 .355 34.04 36.956 .436 36.956"/>
+    <polygon id="logo-rspro-c" points="0 88.043 392.931 88.043 392.931 1.937 0 1.937"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(0 -1)">
+    <polygon fill="#E93736" points="352.945 62.428 352.945 70.99 352.945 88.063 378.804 88.063 372.457 75.246 378.804 62.428"/>
+    <polygon fill="#B12024" points="352.945 85.591 352.945 88.064 362.003 85.591"/>
+    <g transform="translate(0 .02)">
+      <path fill="#FFF" d="M359.32605 49.9615435L358.270832 55.4632826 339.42905 55.4632826 340.343832 49.9615435C343.232515 49.9615435 343.624564 49.7130652 344.00101 47.2106739L346.039277 33.6011087C346.386465 31.2728478 344.993812 30.4980652 343.64797 30.4980652 340.930931 30.4980652 338.104663 33.3311087 337.601436 36.6337174L335.914257 47.7056739C335.676297 49.2728478 335.914257 49.9615435 339.148178 49.9615435L338.305564 55.4632826 319.182911 55.4632826 320.167911 49.9615435C323.608584 49.9615435 324.185931 49.4704565 324.525317 47.3535L326.776188 33.317413C326.932228 32.3411087 326.764485 32.1904565 326.001842 32.1904565L321.855089 32.1904565 322.697703 27.324587 339.780139 19.9915435 340.271663 20.484587 339.501218 24.7869783C342.643465 21.9950217 346.052931 20.0600217 349.975376 20.0600217 354.892574 20.0600217 358.202564 24.7243696 358.202564 29.6508913 358.202564 30.8071957 358.116743 31.7443696 357.849525 33.3878478L355.600604 47.2106739C355.222208 49.5311087 355.606455 49.9615435 359.32605 49.9615435M290.216694 21.6837391L286.982773 28.6646087C285.650585 28.0717826 283.994615 27.8174348 283.114942 27.8174348L279.178843 27.8174348 276.576882 43.898087C276.112664 46.782 276.654902 47.3513478 278.125575 47.3513478 279.736684 47.3513478 281.435565 46.4572174 284.380813 43.7552609L286.914506 48.8343913C283.415318 52.5693913 278.93308 56.4511304 273.272744 56.4511304 267.247664 56.4511304 264.626199 53.0350435 264.626199 47.5646087 264.626199 46.4102609 264.803694 44.7804783 264.979239 43.6848261L267.509031 27.8174348 263.079456 27.8898261 264.134674 21.8226522 268.351645 21.893087 269.336645 15.4756957 281.006456 10.6822174 281.780803 11.5274348 280.163843 21.7541739 290.216694 21.6837391z"/>
+      <path fill="#FFF" d="M267.016531 4.33486957C265.678491 8.87008696 264.155154 15.5476957 263.431521 20.1318261L256.61064 20.1318261C257.236749 17.874 257.433749 16.4868261 257.455204 15.2659565 257.503966 12.3213913 254.197877 10.400087 249.229966 10.400087 244.137224 10.400087 240.708253 13.0413913 240.651689 16.3244348 240.599026 19.4137826 241.823937 20.6796522 245.713224 23.4461739L252.463887 28.2416087C258.750333 32.7063913 262.503085 36.8913913 262.376303 44.109 262.16955 56.0966087 252.075739 62.1637826 239.104947 62.1637826 236.071927 62.1637826 233.581145 61.6726957 231.51362 61.1757391 229.748422 60.7511739 228.002729 60.1876957 226.169263 60.1876957 225.17256 60.1876957 223.411263 60.5144348 222.233164 61.2461739L221.177947 60.6826957C220.370442 54.8659565 219.108471 48.1961739 218.084461 43.3322609L225.115996 41.6398696C226.972867 50.4266087 231.053303 54.4746522 239.879293 54.4746522 245.66056 54.4746522 248.798907 51.6885652 248.876927 47.1416087 248.952996 42.7942174 246.661164 40.955087 242.549521 38.255087 240.725808 37.0596522 238.917699 35.8955217 237.207115 34.7294348 235.488729 33.5574783 233.819105 32.3444348 232.428402 30.920087 229.617739 28.047913 227.834986 24.1916087 227.926659 18.8620435 228.090501 9.46095652 236.481531 2.78334783 247.893877 2.78334783 252.662838 2.78334783 256.321966 3.969 260.618907 4.194 262.04862 4.26834783 264.496491 3.9416087 266.033481 3.56008696L267.016531 4.33486957zM148.413558 9.90626087C148.413558 14.331913 143.625093 18.2273478 138.641578 18.2273478 136.092281 18.2273478 133.156786 17.1532174 133.156786 13.5727826 133.156786 8.26669565 138.544053 4.68626087 143.000935 4.68626087 145.93838 4.68626087 148.413558 6.66430435 148.413558 9.90626087M146.725795 20.4838043L142.436656 46.7168478C141.956835 49.6555435 141.880765 49.9607609 146.091884 49.9607609L145.24927 55.4625 125.562924 55.4625 126.407488 49.9607609C129.641409 49.9607609 130.558142 49.1898913 130.837062 47.4231522L133.085983 33.1072826C133.220567 32.2581522 133.1523 32.1896739 132.313587 32.1896739L127.813795 32.1896739 128.656409 27.3238043 146.23427 19.9907609 146.725795 20.4838043zM129.219907 4.05195652L122.328808 46.5045652C121.815828 49.6682609 122.151313 49.9617391 125.281857 49.9617391L124.439244 55.4615217 105.244422 55.4615217 106.088986 49.9617391C109.463343 49.9617391 110.272798 49.3180435 110.658996 46.9291304L115.509877 16.9591304C115.671768 15.9573913 115.484521 15.8302174 114.737481 15.8302174L110.307907 15.8302174 111.152471 10.9623913 128.728382 3.55891304 129.219907 4.05195652z"/>
+      <g transform="translate(358.891 19.565)">
+        <mask id="logo-rspro-b" fill="#fff">
+          <use xlink:href="#logo-rspro-a"/>
+        </mask>
+        <path fill="#FFF" d="M34.0410149,12.9768261 L12.5972723,22.8513913 C13.0322327,26.5316087 15.0646485,29.0574783 18.4331535,29.0574783 C21.9420941,29.0574783 23.143599,27.0031304 23.143599,26.0953043 C23.143599,25.5592174 22.9602525,25.212913 22.7905594,24.9663913 C22.5272426,24.5770435 22.2990347,24.350087 22.2990347,23.8394348 C22.2990347,23.4696522 22.3887574,23.232913 22.5818564,22.9903043 C23.4888366,21.8555217 25.4783416,20.9457391 27.4307871,20.9457391 C29.9488762,20.9457391 32.1412327,22.8161739 32.1412327,25.6707391 C32.1412327,31.9061739 26.0576386,36.9559565 16.5333713,36.9559565 C7.16124257,36.9559565 0.435935644,31.239 0.435935644,20.4526957 C0.435935644,10.7796522 9.02591584,0.355304348 19.7692426,0.355304348 C28.7629752,0.355304348 32.6756683,4.90813043 34.0410149,12.9768261 Z M22.7905594,11.2844348 C22.6988861,8.14813043 21.4349653,7.19530435 19.6268564,7.19530435 C17.5534802,7.19530435 14.6199356,9.78769565 13.5120545,15.4459565 L22.7905594,11.2844348 Z" mask="url(#logo-rspro-b)"/>
+      </g>
+      <path fill="#FFF" d="M321.291396 35.2933043C321.291396 45.927 313.670812 56.5900435 301.536782 56.5900435 292.324594 56.5900435 286.420446 51.1841739 286.420446 40.440913 286.420446 29.4746087 294.657386 19.778087 306.036574 19.778087 314.907426 19.778087 321.291396 25.3893913 321.291396 35.2933043M309.059842 32.472C309.059842 28.5667826 307.788119 26.760913 305.474832 26.760913 302.114129 26.760913 298.511564 33.8904783 298.511564 44.0389565 298.511564 47.9246087 299.808644 49.6796087 302.098525 49.6796087 305.656228 49.6796087 309.059842 41.4328696 309.059842 32.472M227.084631 19.7080435L224.763542 29.9347826C223.679066 29.6941304 223.53668 29.651087 223.144631 29.651087 220.915215 29.651087 219.914611 31.2084783 219.348967 33.3176087 219.189027 33.9221739 219.04274 34.5169565 218.92766 35.01 218.590225 36.4715217 218.114304 38.1130435 217.240482 39.5941304 214.63072 44.0178261 209.015245 47.5630435 202.900443 47.5630435 200.516938 47.5630435 198.297274 47.343913 196.500868 46.6473913 196.219997 46.9291304 195.939126 47.5297826 195.939126 48.0580435 195.939126 49.503913 197.056759 49.8208696 198.820007 49.8208696 202.477185 49.8208696 205.781324 49.2573913 209.15568 49.2573913 214.94475 49.2573913 219.070047 52.0963043 219.070047 57.4376087 219.070047 66.9463043 204.659789 72.7395652 191.158462 72.7395652 183.128274 72.7395652 175.410165 70.3956522 175.410165 63.5732609 175.410165 60.1923913 177.32165 57.6058696 181.737571 55.4615217L165.77667 55.4615217 166.691452 49.9617391C169.890264 49.8913043 170.262809 49.6193478 170.559284 47.6334783L172.667769 33.4584783C172.925235 31.7308696 171.776393 30.4982609 170.276462 30.4982609 167.502858 30.4982609 164.627829 33.5993478 164.231878 36.138913L162.402314 47.8467391C162.174106 49.3082609 162.474482 49.9617391 165.495799 49.9617391L164.653185 55.4615217 146.375096 55.4615217 147.287928 49.9617391C150.457482 49.9617391 150.609621 49.5176087 150.872938 47.8467391L153.194027 33.2471739C153.350066 32.265 153.178423 32.1906522 152.489898 32.1906522L147.921839 32.1906522 148.83467 27.2523913 166.340363 19.9917391 166.831888 20.4828261 166.12971 24.7167391C169.632799 21.6567391 173.284126 19.9917391 176.463433 19.9917391 182.04575 19.9917391 184.758888 25.2665217 184.758888 30.0756522 184.758888 30.5902174 184.630155 31.8952174 184.548235 32.4L182.158878 47.4926087C181.866304 49.3356522 183.128274 49.8443478 184.901274 49.9617391 185.778997 46.6063043 188.306839 44.8004348 191.22868 43.6147826 189.527849 41.7834783 187.924542 39.3123913 187.924542 35.01 187.924542 25.4680435 196.504769 19.6376087 205.219581 19.6376087 211.152987 19.6376087 214.574155 21.6273913 217.170264 25.4915217 219.43869 21.9541304 221.490611 19.7080435 227.084631 19.7080435M207.328066 30.0032609C207.328066 28.0643478 206.582977 26.2682609 205.008928 26.2682609 201.398561 26.2682609 199.805007 32.9830435 199.805007 36.9841304 199.805007 39.7682609 200.36675 40.9343478 202.266532 40.9343478 205.443888 40.9343478 207.328066 33.6854348 207.328066 30.0032609M205.360017 60.8928261C205.360017 60.0906522 204.554462 59.5526087 202.828274 59.5526087 200.858274 59.5526087 198.892175 59.8363043 196.851957 59.8363043 193.444443 59.8363043 190.585017 59.3354348 187.924542 58.001087 186.53969 59.0928261 185.743888 60.3117391 185.743888 62.0902174 185.743888 64.3891304 188.70669 66.3221739 192.001076 66.3221739 200.739294 66.3221739 205.360017 63.0782609 205.360017 60.8928261M89.7091188 35.2933043C89.7091188 45.927 82.0865842 56.5900435 69.9525545 56.5900435 60.7423168 56.5900435 54.8381683 51.1841739 54.8381683 40.440913 54.8381683 29.4746087 63.0751089 19.778087 74.4523465 19.778087 83.323198 19.778087 89.7091188 25.3893913 89.7091188 35.2933043M77.4756139 32.472C77.4756139 28.5667826 76.2058416 26.760913 73.890604 26.760913 70.529901 26.760913 66.9292871 33.8904783 66.9292871 44.0389565 66.9292871 47.9246087 68.2263663 49.6796087 70.5162475 49.6796087 74.0739505 49.6796087 77.4756139 41.4328696 77.4756139 32.472"/>
+      <path fill="#FFF" d="M108.972208,4.26404348 L101.942624,47.4933913 C101.655901,49.2562174 101.624693,49.9605652 104.963941,49.9605652 L104.121327,55.4623043 L99.6215347,55.4623043 C102.395139,56.829913 105.244812,59.2168696 105.244812,62.2318696 C105.244812,68.0094783 99.1085545,72.1064348 84.2243267,72.1064348 C56.736,72.1064348 37.1978911,59.0427391 31.4965941,37.4075217 L27.3498416,37.4075217 L25.1691881,50.7373043 C24.7517822,53.2827391 24.8668614,54.0946957 29.3881089,54.4038261 L32.4815941,54.6151304 L31.2157228,61.104913 C26.7412871,60.8251304 21.7402178,60.5962174 16.8035149,60.609913 C12.2900693,60.6236087 7.55231683,60.8486087 3.09348515,61.104913 L4.14870297,54.6151304 C5.30729703,54.5446957 6.11090099,54.5427391 6.89109901,54.4742609 C7.65179208,54.4077391 8.3520198,54.2629565 8.99958416,54.0516522 C10.247901,53.6446957 11.2621584,52.8562174 11.5293762,51.2303478 L18.2098218,10.611 C15.9121386,11.0473043 13.9694455,11.6988261 12.6548119,12.2329565 C11.1704851,12.8355652 9.56132673,14.1679565 9.56132673,15.2655652 C9.56132673,15.7429565 9.64714851,16.0873043 9.84219802,16.3925217 C10.1055149,16.8092609 10.4058911,17.1418696 10.4058911,17.6642609 C10.4058911,18.0438261 10.255703,18.2551304 10.054802,18.5094783 C9.09710891,19.704913 6.84233663,20.6244783 4.78261386,20.6244783 C2.42446535,20.6244783 0,18.7716522 0,15.7586087 C0,8.16143478 9.46575248,5.11121739 15.5376436,3.90991304 C21.6290396,2.7086087 30.1878119,1.93773913 36.1368218,1.93773913 C50.1277228,1.93773913 60.2507921,6.31252174 60.2507921,17.3805652 C60.2507921,26.4803478 53.4221089,32.3518696 46.0492376,34.869913 C51.6549604,52.4218696 67.1379901,64.7714348 82.8180198,64.7714348 C89.4926139,64.7714348 91.7473861,61.5314348 91.7473861,59.6238261 C91.7473861,56.7105652 89.7052178,55.4623043 87.5986832,55.4623043 L84.8582376,55.4623043 L85.911505,49.9605652 C87.862,49.9605652 90.017297,49.7981739 90.3410792,47.7751304 L95.332396,16.6057826 C95.4240693,16.0403478 95.2075644,15.8290435 94.6302178,15.8290435 L89.9899901,15.8290435 L90.9047723,10.8927391 L108.408515,3.70056522 L108.972208,4.26404348 Z M46.2598911,17.8736087 C46.2598911,12.1742609 42.3647525,8.56447826 37.2622574,8.56447826 C36.058802,8.56447826 33.0589406,8.60556522 31.9881188,8.70730435 L28.4733267,30.7788261 C29.1169901,30.8257826 30.2326733,30.7788261 30.7924653,30.7788261 C39.2049505,30.7788261 46.2598911,25.2438261 46.2598911,17.8736087 Z"/>
+      <mask id="logo-rspro-d" fill="#fff">
+        <use xlink:href="#logo-rspro-c"/>
+      </mask>
+      <polygon fill="#DE2626" points="291.956 85.57 362.002 85.57 362.002 60.206 291.956 60.206" mask="url(#logo-rspro-d)"/>
+      <path fill="#FEFEFE" d="M308.788333 72.5149565C309.736273 72.5149565 310.444303 72.3016957 310.910471 71.8712609 311.374689 71.4427826 311.608749 70.8088696 311.608749 69.9675652L311.608749 69.8716957C311.608749 68.9853913 311.364937 68.3495217 310.873412 67.968 310.385788 67.5864783 309.691412 67.3947391 308.788333 67.3947391L306.878798 67.3947391 306.878798 72.5149565 308.788333 72.5149565zM303.127996 64.5206087L308.881956 64.5206087C310.918273 64.5206087 312.486471 64.9647391 313.590451 65.853 314.692481 66.7412609 315.244471 68.0736522 315.244471 69.8501739L315.244471 69.944087C315.244471 70.8323478 315.096234 71.5993043 314.801709 72.2449565 314.505234 72.8925652 314.085877 73.4345217 313.54364 73.8708261 312.997501 74.3071304 312.342135 74.6299565 311.57559 74.8393043 310.805145 75.0506087 309.946927 75.1582174 308.997036 75.1582174L306.878798 75.1582174 306.878798 81.2332174 303.127996 81.2332174 303.127996 64.5206087zM324.285601 72.2113043C325.233542 72.2113043 325.945472 72.0078261 326.421393 71.6028261 326.893413 71.1978261 327.131373 70.5971739 327.131373 69.8047826L327.131373 69.7108696C327.131373 68.8519565 326.885611 68.2571739 326.394086 67.9226087 325.906462 67.5880435 325.204284 67.4197826 324.285601 67.4197826L322.167363 67.4197826 322.167363 72.2113043 324.285601 72.2113043zM318.414611 64.5202174L324.379225 64.5202174C325.358373 64.5202174 326.245849 64.6219565 327.035799 64.8254348 327.8277 65.0269565 328.502571 65.3380435 329.064314 65.7586957 329.622155 66.1813043 330.053215 66.7095652 330.355542 67.3493478 330.661769 67.9871739 330.811957 68.7365217 330.811957 69.5934783L330.811957 69.6873913C330.811957 70.3252174 330.726136 70.8867391 330.554492 71.37 330.384799 71.8532609 330.144888 72.2719565 329.834759 72.6319565 329.52268 72.99 329.157938 73.2952174 328.738581 73.5436957 328.317274 73.7941304 327.86671 73.9878261 327.386888 74.1267391L331.791106 81.2328261 327.782839 81.2328261 323.797977 74.7821739 322.167363 74.7821739 322.167363 81.2328261 318.414611 81.2328261 318.414611 64.5202174zM342.302909 78.4762826C342.999236 78.4762826 343.635097 78.3451957 344.200741 78.0791087 344.768335 77.8130217 345.254008 77.4393261 345.65776 76.9560652 346.043958 76.4884565 346.346285 75.9112826 346.566691 75.2265 346.783196 74.5397609 346.892424 73.7767174 346.892424 72.935413L346.892424 72.747587C346.892424 71.937587 346.787097 71.1980217 346.576444 70.5288913 346.367741 69.8578043 346.069315 69.2806304 345.679216 68.7993261 345.275463 68.3160652 344.785889 67.9423696 344.212444 67.6743261 343.637048 67.4121522 342.985582 67.2771522 342.254147 67.2771522 341.526612 67.2771522 340.877097 67.4062826 340.309503 67.6645435 339.743859 67.9208478 339.256236 68.2847609 338.852483 68.750413 338.44678 69.2336739 338.142503 69.8147609 337.9338 70.4917174 337.721196 71.1706304 337.61782 71.9297609 337.61782 72.7730217L337.61782 72.9588913C337.61782 73.8158478 337.73485 74.5847609 337.966958 75.2617174 338.199067 75.9386739 338.52675 76.5119348 338.946107 76.977587 339.347909 77.4608478 339.839434 77.832587 340.412879 78.0908478 340.990226 78.3491087 341.616335 78.4762826 342.302909 78.4762826M342.230741 81.4912826C340.925859 81.4912826 339.743859 81.2780217 338.688642 80.847587 337.631473 80.4191087 336.738147 79.8223696 336.010612 79.0612826 335.265523 78.3119348 334.688176 77.4158478 334.286374 76.3710652 333.882622 75.3282391 333.67977 74.1973696 333.67977 72.9823696L333.67977 72.7965C333.67977 71.5482391 333.892374 70.4036739 334.319533 69.3608478 334.746691 68.3160652 335.349394 67.4199783 336.127642 66.6706304 336.888335 65.9232391 337.789463 65.3382391 338.831028 64.9156304 339.868691 64.4969348 341.011681 64.287587 342.254147 64.287587 343.512216 64.287587 344.666909 64.4910652 345.716275 64.8960652 346.765642 65.3010652 347.670671 65.8684565 348.431364 66.6021522 349.176453 67.3495435 349.761602 68.2378043 350.18876 69.2649783 350.615919 70.2941087 350.830473 71.4386739 350.830473 72.702587L350.830473 72.890413C350.830473 74.1347609 350.623721 75.2851957 350.214117 76.3358478 349.802562 77.3884565 349.223265 78.2962826 348.476226 79.0612826 347.731137 79.8223696 346.830008 80.4191087 345.77284 80.847587 344.715671 81.2780217 343.535622 81.4912826 342.230741 81.4912826" mask="url(#logo-rspro-d)"/>
+    </g>
+  </g>
+</svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="805px" height="159px" viewBox="0 0 805 159" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>RS Live Media Logo</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <polygon id="path-1" points="0.000431126332 0.492774194 205.626135 0.492774194 205.626135 133.887397 0.000431126332 133.887397"></polygon>
+        <polygon id="path-3" points="0.430003636 0.694690909 20.4566218 0.694690909 20.4566218 48 0.430003636 48"></polygon>
+        <polygon id="path-5" points="0.0561253133 0.447927273 39.1634937 0.447927273 39.1634937 48 0.0561253133 48"></polygon>
+        <polygon id="path-7" points="0.90684 0.694690909 21.27004 0.694690909 21.27004 48 0.90684 48"></polygon>
+        <polygon id="path-9" points="0.572390977 0.9186375 38.2323158 0.9186375 38.2323158 34 0.572390977 34"></polygon>
+    </defs>
+    <g id="RS-Live-Events" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Live-Events-/-Desktop-XL" transform="translate(-298.000000, -371.000000)">
+            <g id="RS-Live-Media-Logo" transform="translate(298.000000, 371.000000)">
+                <g>
+                    <path d="M679,90.5689271 L677.013515,101 L641.663933,101 L643.38684,90.5689271 C648.80628,90.5689271 649.569159,90.0862275 650.272036,85.3544729 L654.309295,58.139308 C654.958599,53.7517204 652.333524,52.2538365 649.807023,52.2538365 C644.713306,52.2538365 639.360296,57.6674313 638.421698,63.8884115 L635.044458,86.2895681 C634.596588,89.2507027 635.070173,90.5689271 641.134632,90.5689271 L639.54673,101 L604,101 L605.521472,90.5689271 C611.980228,90.5689271 612.96597,89.952024 613.598131,85.9540594 L617.834681,59.1415049 C618.126118,57.2951249 617.806823,57.0007431 616.377496,57.0007431 L608.697277,57.0007431 L610.289465,47.9095403 L642.328238,34 L643.251836,34.9372597 L641.796794,43.6301812 C647.691963,38.3572836 654.165719,34.1342035 661.524501,34.1342035 C671.851224,34.1342035 676.777794,41.911511 676.880654,52.1888993 C676.902083,54.3686234 676.719935,56.1738765 676.218492,59.2757083 L672.114803,84.817659 C671.409783,89.2030821 672.020515,90.5689271 679,90.5689271" id="Fill-1" fill="#FEFEFE"></path>
+                    <path d="M549,38.6343113 L542.842474,51.6815915 C540.318365,50.565408 537.144271,50.2163313 535.480309,50.2163313 L528.118144,50.2163313 L523.165258,80.4351682 C522.274778,85.8695598 523.325587,86.8262885 526.111857,86.8262885 C529.166787,86.8262885 532.306215,85.2511338 537.889587,80.1701285 L542.710311,89.6232116 C536.076129,96.6478414 527.606823,104 516.875568,104 C505.446663,104 500.409278,97.5248428 500.409278,87.2249255 C500.409278,85.0550475 500.74727,82.09436 501.078763,80.0365313 L505.897319,50.2163313 L498,50.0848889 L499.60763,39.0351031 L507.504949,39.0351031 L509.379073,26.9186941 L531.463401,18 L533.071031,19.4652602 L529.857938,38.7679086 L549,38.6343113 Z" id="Fill-3" fill="#FEFEFE"></path>
+                    <path d="M506,5.91017652 C502.164329,26.8531687 500.797223,35.4145269 500.797223,35.4145269 L487.985736,35.4145269 C489.169265,31.1980901 489.547217,28.5684383 489.588252,26.2878364 C489.68112,20.7822707 482.566987,17.2896306 473.176504,17.2896306 C463.550611,17.2896306 457.138389,22.1527732 457.030402,28.2707823 C456.928895,34.0483071 459.149092,36.4659593 466.505115,41.6331822 L479.314442,50.6292466 C491.195087,58.972181 498.363213,66.7926112 498.127803,80.264223 C497.732574,102.678364 481.716056,114 454.363142,114 C448.629073,114 444.532075,112.545982 440.618654,111.618752 C437.28188,110.828571 433.942945,109.768573 430.476587,109.768573 C428.593307,109.768573 425.232776,110.387441 423.00394,111.751519 L421.004035,110.691521 C419.47495,99.828147 416.939433,87.8962091 415,78.808064 L428.342779,75.6344941 C431.854492,92.0526864 438.871437,99.5797434 455.561789,99.5797434 C466.496476,99.5797434 472.362288,94.3204399 472.506989,85.8190412 C472.653851,77.6988135 468.403513,74.323951 460.632823,69.2830713 C457.188062,67.0452976 453.723864,64.8460693 450.495075,62.668255 C447.24253,60.475451 444.052617,58.1862834 441.419912,55.5223691 C436.111309,50.1538536 432.705423,42.9822707 432.878201,33.0354201 C433.187042,15.4801389 449.067497,3 470.640987,3 C479.655678,3 485.871366,5.22492524 493.989771,5.64678306 C496.693746,5.78597473 501.231328,5.17138999 504.133998,4.45615897 L506,5.91017652 Z" id="Fill-5" fill="#FEFEFE"></path>
+                    <path d="M278,16.6337043 C278,24.8068622 269.213188,32 260.065046,32 C255.382366,32 250,30.0167763 250,23.4053279 C250,13.6093408 259.889602,7 268.064449,7 C273.459347,7 278,10.6482044 278,16.6337043" id="Fill-7" fill="#FEFEFE"></path>
+                    <path d="M277,34.9372597 L268.86576,84.4172132 C267.944211,90.0321132 267.840617,90.5667625 275.800043,90.5667625 L274.198662,101 L237,101 L238.601381,90.5667625 C244.709075,90.5667625 246.489587,89.0861952 247.001079,85.7549187 L251.134024,58.741059 C251.3779,57.1436048 251.384375,57.0007431 249.800259,57.0007431 L241.266753,57.0007431 L242.865976,47.9095403 L276.065501,34 L277,34.9372597 Z" id="Fill-9" fill="#FEFEFE"></path>
+                    <path d="M243,4.92531908 L230.028706,84.1943205 C229.056127,90.1467783 229.718081,90.6779799 235.587832,90.6779799 L233.998286,101 L198,101 L199.587404,90.6779799 C205.915596,90.6779799 207.468723,89.4913439 208.19066,84.9868392 L217.192374,29.0114605 C217.492288,27.1415448 217.269494,26.8930795 215.866324,26.8930795 L207.528706,26.8930795 L209.118252,17.7619794 L242.07455,4 L243,4.92531908 Z" id="Fill-11" fill="#FEFEFE"></path>
+                    <path d="M721.755067,54.4504555 C721.581542,48.6235872 719.040805,46.6287843 715.203992,46.6287843 C711.315764,46.6287843 705.767274,51.8340064 703.689268,62.3445102 L721.755067,54.4504555 Z M743,57.4117905 L702.761663,75.8248646 C703.582155,82.6608434 707.433964,87.2678376 713.749388,87.2678376 C720.330454,87.2678376 722.614119,83.5613788 722.614119,81.87527 C722.614119,80.878933 722.269212,80.2296108 721.954298,79.7718919 C721.457291,79.0480574 721.026693,78.6201434 721.026693,77.6663849 C721.026693,76.9829999 721.193791,76.5380545 721.557977,76.0888513 C723.258943,73.9769575 726.894382,72.2738174 730.555529,72.2738174 C735.277101,72.2738174 739.424544,75.784415 739.424544,81.0875677 C739.424544,92.6710497 728.03193,102 710.176075,102 C692.600857,102 680,91.3894368 680,71.3541217 C680,50.7056761 696.142036,34 715.469634,34 C732.335759,34 740.439982,42.4177703 743,57.4117905 Z" id="Fill-13" fill="#FEFEFE"></path>
+                    <path d="M584.191635,58.0945029 C584.191635,50.6730997 581.793,47.3262778 577.46735,47.3262778 C571.193342,47.3262778 564.413572,60.8748055 564.413572,80.1713254 C564.413572,87.5600448 566.863423,90.8066364 571.139991,90.8066364 C577.783184,90.8066364 584.191635,75.1314823 584.191635,58.0945029 M607,63.4786155 C607,83.6968188 592.74904,104 570.085787,104 C552.879215,104 542,94.27112 542,73.8459192 C542,52.5099297 557.27102,34 578.521554,34 C595.087921,34 607,44.6505634 607,63.4786155" id="Fill-15" fill="#FEFEFE"></path>
+                    <path d="M387.681841,110.957031 C387.681841,109.461434 386.279556,108.448701 383.02978,108.448701 C379.321895,108.448701 373.843947,109.241367 370.009168,109.241367 C363.595646,109.241367 358.143507,108.03207 353.134422,105.545105 C350.527718,107.576981 349.013594,109.882338 349.013594,113.200427 C349.013594,117.484246 354.639943,120.988217 360.842692,120.988217 C377.289441,120.988217 387.681841,115.031466 387.681841,110.957031 M389.675582,53.2718405 C389.675582,48.6547177 388.25394,46.4113217 385.288062,46.4113217 C378.491707,46.4113217 375.590352,58.8803306 375.590352,66.341225 C375.590352,71.5309479 376.665725,73.7337491 380.238112,73.7337491 C386.221485,73.7337491 389.675582,60.1344959 389.675582,53.2718405 M431,42.4501252 C431,46.6719829 427.2491,51.821111 423.691768,51.821111 C422.491652,51.821111 422.055051,50.9686205 421.429184,50.1054472 C421.138833,49.6994993 420.689328,49.2230447 419.835482,48.915379 C419.291343,48.7209513 418.749355,48.6525811 418.24393,48.6525811 C414.389795,48.6525811 411.733625,52.9855404 411.733625,56.8356354 C411.733625,57.6902624 411.86482,58.5662552 411.86482,59.476433 C411.86482,63.6299206 410.578675,67.5825708 408.410723,71.2232821 C403.498421,79.4682968 392.953318,85.8758633 381.436077,85.8758633 C376.951774,85.8758633 372.194325,85.4592326 368.815505,84.1601994 C368.28212,84.6857951 367.750886,86.4762388 367.750886,87.4590599 C367.750886,90.1575449 370.409207,90.8925242 373.729957,90.8925242 C380.610191,90.8925242 388.505577,89.8370597 394.856727,89.8370597 C405.752402,89.8370597 413.591869,94.5289624 413.591869,104.489641 C413.591869,122.216743 384.664346,133 359.246839,133 C344.131402,133 329.613872,128.69268 329.613872,115.973692 C329.613872,109.675091 333.259385,104.786624 341.574166,100.793379 L311.543311,100.793379 L313.27036,90.4972592 C319.292446,90.364792 319.888203,89.9267956 320.445246,86.1407977 L324.563923,58.1560342 C325.039237,54.9276804 322.869135,52.6116411 320.049508,52.6116411 C314.825348,52.6116411 309.480747,58.4423343 308.753795,63.1726951 L305.164201,86.5360627 C304.744806,89.2580499 305.321206,90.4972592 311.012077,90.4972592 L309.416224,100.793379 L275,100.793379 L276.729199,90.4972592 C282.695366,90.4972592 282.87818,89.6127201 283.372851,86.5360627 L287.75822,59.3439658 C288.050722,57.5300199 287.743165,57.3633676 286.42906,57.3633676 L277.927164,57.3633676 L279.652062,48.2573161 L312.474584,34.6601994 L313.534901,35.5853332 L311.941199,44.229886 C318.539685,38.5295235 325.617788,34.8589002 331.609764,34.8589002 C342.769981,34.8589002 347.288696,42.3155214 347.288696,53.4043077 C347.288696,54.3678997 347.04136,56.8185428 346.888658,57.7586326 L342.372093,85.8758633 C341.821502,89.3029178 344.217432,90.2793292 347.553238,90.4972592 C349.202859,84.241389 353.878579,80.959621 359.380186,78.7482735 C356.179877,75.3340383 353.134422,70.6635014 353.134422,62.6449629 C353.134422,44.8559004 369.284367,34 385.688101,34 C393.1899,34 402.429501,36.510467 407.612797,44.2961196 C411.333586,37.8287293 416.514731,34 422.095915,34 C427.051232,34 431,37.1685299 431,42.4501252" id="Fill-17" fill="#FEFEFE"></path>
+                    <path d="M146.237967,58.0945029 C146.237967,50.6730997 143.842076,47.3262778 139.527342,47.3262778 C133.266079,47.3262778 126.500082,60.8748055 126.500082,80.1713254 C126.500082,87.5600448 128.942826,90.8066364 133.212837,90.8066364 C139.842535,90.8066364 146.237967,75.1314823 146.237967,58.0945029 M169,63.4786155 C169,83.6968188 154.777989,104 132.158645,104 C114.989155,104 104,93.7307477 104,73.3055469 C104,52.4598145 119.369909,34 140.579404,34 C157.114249,34 169,44.6505634 169,63.4786155" id="Fill-19" fill="#FEFEFE"></path>
+                    <g id="Group-23">
+                        <mask id="mask-2" fill="white">
+                            <use xlink:href="#path-1"></use>
+                        </mask>
+                        <g id="Clip-22"></g>
+                        <path d="M87.2323775,30.5366548 C87.2323775,19.7842355 79.9484981,13.0453323 70.3192915,13.0453323 C66.1891012,13.0453323 62.1947158,13.445171 60.3300944,13.7110097 L53.6713482,54.8382032 C54.8849688,54.9268161 57.008266,54.8382032 58.0666811,54.8382032 C73.938597,54.8382032 87.2323775,44.4359129 87.2323775,30.5366548 Z M205.626135,4.89942903 L192.308643,86.3519774 C191.765424,89.6760419 191.735245,91.0246871 198.036156,91.0246871 L196.438833,101.442106 L185.518403,101.442106 C192.843239,103.9773 197.370066,108.570042 197.370066,114.258558 C197.370066,125.153623 186.699689,133.887397 158.618275,133.887397 C106.751622,133.887397 72.4878569,106.916655 60.7310419,66.9911387 L51.5394285,67.3909774 L47.545043,92.4943645 C46.7797938,97.2967516 46.8724859,98.8550419 55.4023204,99.4385903 L61.2634829,99.8362677 L58.8642648,112.123203 C50.4228113,111.59801 41.0134791,111.161429 31.696839,111.187365 C23.182094,111.211139 14.2728683,111.639074 5.85943798,112.123203 L7.85770852,99.8362677 C10.0456747,99.704429 11.5804844,99.6979452 13.0527808,99.570429 C14.4905871,99.4450742 15.691274,99.1662677 16.9135171,98.7707516 C19.2717782,97.999171 21.2010685,96.4689774 21.7097976,93.4302032 L34.4926933,16.6503645 C30.1598737,17.4716548 26.4543428,18.5825581 23.9732108,19.5875581 C21.1708896,20.7243968 17.9805548,23.525429 17.9805548,25.5981065 C17.9805548,26.4972032 18.1443828,27.1542355 18.5129958,27.7313 C19.0109467,28.5158484 19.5778779,29.153429 19.5778779,30.1368161 C19.5778779,30.8543645 19.2933345,31.2606871 18.9117877,31.7404935 C17.1096796,33.9925581 12.9449992,35.7432032 9.05623973,35.7432032 C4.60917161,35.7432032 0.000431126332,32.2138161 0.000431126332,26.5317839 C0.000431126332,12.2067516 17.8425944,6.49446129 29.2997766,4.23159032 C40.7957603,1.96223548 56.9629977,0.492558065 68.1873718,0.492558065 C94.5852371,0.492558065 113.733713,8.72923548 113.733713,29.6029774 C113.733713,46.7657839 100.743877,57.8380742 86.83143,62.5842677 C97.4112702,95.6865903 123.283161,120.534945 156.486356,120.534945 C169.075245,120.534945 173.533091,115.125235 173.533091,109.851687 C173.533091,104.359848 169.249851,101.442106 165.27271,101.442106 L160.081949,101.442106 L162.078064,91.0246871 C165.757728,91.0246871 169.855583,90.6983323 170.467783,86.8858161 L179.924539,28.1333 C180.094834,27.0699452 179.683108,26.6636226 178.592358,26.6636226 L169.803848,26.6636226 L171.53482,17.3182032 L204.561253,3.83175161 L205.626135,4.89942903 Z" id="Fill-21" fill="#FEFEFE" mask="url(#mask-2)"></path>
+                    </g>
+                    <path d="M486.24264,156.970074 L487.776469,156.546113 C490.41301,155.818098 490.597156,155.696049 491.333741,151.636299 L496.546162,122.36156 C497.15926,118.847821 496.914454,118.119806 494.767526,117.453887 L493.296523,117.029926 L493.480669,116 L516.167481,116 L515.985502,117.029926 L513.959893,117.513841 C511.568159,118.119806 511.202033,118.665817 510.586768,122.36156 L505.315854,151.878256 C504.763415,155.03013 506.110932,156.24206 509.302078,156.24206 C512.857183,156.24206 514.267526,155.636095 517.211699,151.696253 C519.35646,148.848432 521.382069,145.394647 523.895123,141.090798 L525,141.090798 L521.440562,158 L486,158 L486.24264,156.970074 Z" id="Fill-24" fill="#FEFEFE"></path>
+                    <g id="Group-28" transform="translate(525.000000, 111.000000)">
+                        <mask id="mask-4" fill="white">
+                            <use xlink:href="#path-3"></use>
+                        </mask>
+                        <g id="Clip-27"></g>
+                        <path d="M8.20827636,6.37614545 C8.20827636,2.97905455 10.9020036,0.694690909 14.3313673,0.694690909 C17.7607309,0.694690909 20.4566218,2.97905455 20.4566218,6.37614545 C20.4566218,9.77323636 17.7607309,12.0576 14.3313673,12.0576 C10.9020036,12.0576 8.20827636,9.77323636 8.20827636,6.37614545 M1.04231273,43.0590545 C1.04231273,41.5143273 1.34954909,39.8474182 2.14360364,36.5746909 L5.33064,23.2961455 C5.57296727,22.3710545 5.57296727,21.8757818 5.57296727,21.5681455 C5.57296727,19.9012364 4.47167636,19.9623273 1.83853091,21.6292364 L1.16564,22.0612364 L0.430003636,21.1361455 C4.83949455,16.3797818 9.55405818,14.0343273 13.1089127,14.0343273 C16.5988582,14.0343273 18.37304,15.8256 18.37304,18.9739636 C18.37304,20.8263273 18.0679673,22.1856 17.2717491,25.4583273 L13.77964,39.4765091 C13.6584764,40.0328727 13.5957309,40.5259636 13.5957309,40.9601455 C13.5957309,42.6881455 15.0670036,42.5026909 16.7221855,41.4532364 L17.8840582,40.7114182 L18.6196945,41.6386909 C15.37424,45.2823273 10.2896945,48.0008727 6.30860364,48.0008727 C2.63474909,48.0008727 1.04231273,46.0241455 1.04231273,43.0590545" id="Fill-26" fill="#FEFEFE" mask="url(#mask-4)"></path>
+                    </g>
+                    <path d="M552.820167,135.101599 C552.521665,131.917541 552.225266,130.56994 549.427341,132.406397 L548.773581,132.836851 L548,131.856974 C551.273005,127.937467 555.973351,125.121133 559.364074,125.121133 C562.517258,125.121133 564.362921,126.589866 564.71818,131.000393 C565.1344,136.325905 564.89686,143.122313 564.5395,150.286445 L564.838001,150.286445 C572.27531,141.346421 574.774734,137.366348 574.774734,134.610579 C574.774734,132.345831 570.96779,132.038673 570.96779,128.612349 C570.96779,126.773728 572.27531,125 574.596053,125 C577.154336,125 579,126.652596 579,130.325511 C579,135.897614 573.643792,143.304012 560.436157,158 L553.116566,158 C553.116566,148.142829 553.234285,139.877687 552.820167,135.101599" id="Fill-29" fill="#FEFEFE"></path>
+                    <path d="M591.8215,141.014209 C594.2884,140.21339 596.393771,139.227599 597.718666,137.686892 C599.16478,136.024322 599.945256,132.884153 599.945256,129.987711 C599.945256,127.58743 599.40509,126.66257 598.260959,126.66257 C595.553749,126.66257 592.723194,133.069124 591.8215,141.014209 M579,147.603559 C579,134.731695 589.833093,125 599.766619,125 C606.02744,125 610,127.770225 610,131.959293 C610,138.056836 603.439322,140.398361 591.640735,142.369944 C591.58119,143.599462 591.519517,144.833333 591.519517,146.065028 C591.519517,151.668587 593.325033,153.640169 596.455444,153.640169 C599.526309,153.640169 602.054881,152.347542 605.123619,149.514209 L605.906222,150.315028 C603.560541,154.134153 598.68416,159 590.617823,159 C582.791795,159 579,154.256016 579,147.603559" id="Fill-31" fill="#FEFEFE"></path>
+                    <path d="M621.24177,156.970074 L622.770103,156.606067 C625.153265,156.060056 625.641123,155.454091 626.314625,151.636299 L631.508365,122.36156 C632.179709,118.725771 631.691851,118.059852 629.736104,117.453887 L628.270372,117.029926 L628.453859,116 L646.539126,116 L650.388019,138.058833 L650.631948,138.058833 L662.975175,116 L681,116 L680.816514,117.029926 L679.29034,117.453887 C676.965461,118.119806 676.721533,118.361764 675.987588,122.36156 L670.796006,151.636299 C670.062062,155.576141 670.185105,155.940148 672.32218,156.546113 L673.727469,156.970074 L673.543983,158 L651.426336,158 L651.609822,156.970074 L653.198597,156.546113 C655.704803,155.878053 656.071775,155.514045 656.803562,151.636299 L661.936859,122.665613 L661.690772,122.665613 L642.506746,157.089982 L640.063141,157.089982 L634.135456,122.665613 L633.889369,122.665613 L628.637345,151.636299 C627.963842,155.332042 628.393416,156.000102 630.77442,156.546113 L632.669725,156.970074 L632.486239,158 L621,158 L621.24177,156.970074 Z" id="Fill-33" fill="#FEFEFE"></path>
+                    <path d="M689.8215,141.014209 C692.2884,140.21339 694.393771,139.227599 695.718666,137.686892 C697.16478,136.024322 697.945256,132.884153 697.945256,129.987711 C697.945256,127.58743 697.40509,126.66257 696.260959,126.66257 C693.553749,126.66257 690.723194,133.069124 689.8215,141.014209 M677,147.603559 C677,134.731695 687.833093,125 697.766619,125 C704.02744,125 708,127.770225 708,131.959293 C708,138.056836 701.439322,140.398361 689.640735,142.369944 C689.58119,143.599462 689.519517,144.833333 689.519517,146.065028 C689.519517,151.668587 691.325033,153.640169 694.455444,153.640169 C697.526309,153.640169 700.054881,152.347542 703.123619,149.514209 L703.906222,150.315028 C701.560541,154.134153 696.68416,159 688.617823,159 C680.791795,159 677,154.256016 677,147.603559" id="Fill-35" fill="#FEFEFE"></path>
+                    <g id="Group-39" transform="translate(708.000000, 111.000000)">
+                        <mask id="mask-6" fill="white">
+                            <use xlink:href="#path-5"></use>
+                        </mask>
+                        <g id="Clip-38"></g>
+                        <path d="M19.213218,38.6122909 L23.2394837,18.2341091 C22.9959248,16.9359273 22.3859499,15.8253818 20.9224411,15.8253818 C17.1397343,15.8253818 12.9906115,29.0406545 12.9906115,37.9337455 C12.9906115,40.8355636 13.6609373,42.1337455 15.0640952,42.1337455 C16.2236942,42.1337455 17.9932682,40.7744727 19.213218,38.6122909 Z M31.5980802,39.4152 C31.4752231,39.9715636 31.4148722,40.5257455 31.4148722,40.9599273 C31.4148722,42.3170182 32.3912632,42.7490182 34.221188,41.5162909 L35.5036441,40.6501091 L36.2968271,41.6384727 C32.3309123,45.8995636 27.8153734,48.0006545 24.0326667,48.0006545 C21.0452982,48.0006545 19.1528672,46.3926545 19.1528672,43.6762909 C19.1528672,43.0588364 19.213218,42.0093818 19.2735689,41.3919273 L19.03001,41.3919273 C16.1029925,45.1577455 12.5638446,48.0006545 7.98795489,48.0006545 C2.92279198,48.0006545 0.0561253133,44.3548364 0.0561253133,38.6122909 C0.0561253133,26.6319273 8.29402005,14.0341091 20.4956742,14.0341091 C21.4699098,14.0341091 22.9959248,14.2806545 23.7891078,14.5904727 L24.0326667,14.5904727 C24.0326667,14.5904727 24.278381,12.7359273 24.7051479,10.5148364 L25.1297594,8.22829091 C25.8022406,4.89229091 25.7397343,4.46247273 24.1555238,3.59629091 L22.3859499,2.61010909 L22.5691579,1.86829091 L38.5535188,0.447927273 L39.1634937,0.879927273 C39.1634937,0.879927273 38.2474536,4.15265455 37.4542707,8.22829091 L31.5980802,39.4152 Z" id="Fill-37" fill="#FEFEFE" mask="url(#mask-6)"></path>
+                    </g>
+                    <g id="Group-42" transform="translate(747.000000, 111.000000)">
+                        <mask id="mask-8" fill="white">
+                            <use xlink:href="#path-7"></use>
+                        </mask>
+                        <g id="Clip-41"></g>
+                        <path d="M8.81584,6.37614545 C8.81584,2.97905455 11.55484,0.694690909 15.04184,0.694690909 C18.52884,0.694690909 21.27004,2.97905455 21.27004,6.37614545 C21.27004,9.77323636 18.52884,12.0576 15.04184,12.0576 C11.55484,12.0576 8.81584,9.77323636 8.81584,6.37614545 M1.52944,43.0590545 C1.52944,41.5143273 1.84184,39.8474182 2.64924,36.5746909 L5.88984,23.2961455 C6.13624,22.3710545 6.13624,21.8757818 6.13624,21.5681455 C6.13624,19.9012364 5.01644,19.9623273 2.33904,21.6292364 L1.65484,22.0612364 L0.90684,21.1361455 C5.39044,16.3797818 10.18424,14.0343273 13.79884,14.0343273 C17.34744,14.0343273 19.15144,15.8256 19.15144,18.9739636 C19.15144,20.8263273 18.84124,22.1856 18.03164,25.4583273 L14.48084,39.4765091 C14.35764,40.0328727 14.29384,40.5259636 14.29384,40.9601455 C14.29384,42.6881455 15.78984,42.5026909 17.47284,41.4532364 L18.65424,40.7114182 L19.40224,41.6386909 C16.10224,45.2823273 10.93224,48.0008727 6.88424,48.0008727 C3.14864,48.0008727 1.52944,46.0241455 1.52944,43.0590545" id="Fill-40" fill="#FEFEFE" mask="url(#mask-8)"></path>
+                    </g>
+                    <g id="Group-45" transform="translate(766.000000, 123.000000)">
+                        <mask id="mask-10" fill="white">
+                            <use xlink:href="#path-9"></use>
+                        </mask>
+                        <g id="Clip-44"></g>
+                        <path d="M20.1193083,24.8567625 L24.2890827,4.7670125 C24.1043459,3.6237625 23.3566015,2.6632625 22.1118271,2.6632625 C17.7551165,2.6632625 13.7700789,15.8340125 13.7700789,24.1958875 C13.7700789,27.0221375 14.3924662,28.2865125 15.8857556,28.2865125 C17.1943083,28.2865125 19.1230489,26.7203875 20.1193083,24.8567625 M0.572390977,24.8567625 C0.572390977,12.1067625 10.4074286,0.9186375 22.6704361,0.9186375 C25.9715075,0.9186375 29.3319586,2.2403875 31.6983496,3.8660125 L31.9468647,3.8660125 L37.4251917,0.9781375 L38.2323158,1.3393875 C38.2323158,1.3393875 36.9281617,4.4673875 35.681188,10.7233875 L32.694609,25.6387625 C32.5692519,26.1806375 32.5076729,26.7203875 32.5076729,27.1432625 C32.5076729,28.4055125 33.5655113,28.9473875 35.371094,27.6851375 L36.6774474,26.8415125 L37.4867707,27.8041375 C33.6908684,31.6546375 29.0834436,34.0006375 25.0368271,34.0006375 C21.8017331,34.0006375 19.9323722,32.4345125 19.9323722,29.6082625 C19.9323722,29.0068875 19.9939511,28.1653875 20.0577293,27.5640125 L19.807015,27.5640125 C16.7588571,31.7141375 13.0223346,34.0006375 8.54026692,34.0006375 C3.74810526,34.0006375 0.572390977,30.6303875 0.572390977,24.8567625" id="Fill-43" fill="#FEFEFE" mask="url(#mask-10)"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg><svg id="svg-icon-instagram" width="19" height="19" xmlns="http://www.w3.org/2000/svg">
+  <path d="M9.5 0c2.58 0 2.904.01 3.917.057 1.011.046 1.702.207 2.306.442a4.657 4.657 0 0 1 1.683 1.095A4.657 4.657 0 0 1 18.5 3.277c.235.604.396 1.295.442 2.306C18.989 6.596 19 6.92 19 9.5s-.01 2.904-.057 3.917c-.046 1.011-.207 1.702-.442 2.306a4.657 4.657 0 0 1-1.095 1.683 4.657 4.657 0 0 1-1.683 1.095c-.604.235-1.295.396-2.306.442-1.013.046-1.337.057-3.917.057s-2.904-.01-3.917-.057c-1.011-.046-1.702-.207-2.306-.442a4.657 4.657 0 0 1-1.683-1.095A4.657 4.657 0 0 1 .5 15.723c-.235-.604-.396-1.295-.442-2.306C.011 12.404 0 12.08 0 9.5s.01-2.904.057-3.917C.103 4.572.264 3.881.5 3.277a4.657 4.657 0 0 1 1.095-1.683A4.657 4.657 0 0 1 3.277.5C3.881.264 4.572.103 5.583.057 6.596.011 6.92 0 9.5 0zm0 1.712c-2.537 0-2.837.01-3.839.055-.926.042-1.43.197-1.764.327-.443.173-.76.378-1.092.71a2.943 2.943 0 0 0-.71 1.093c-.13.335-.286.838-.328 1.764-.046 1.002-.055 1.302-.055 3.839s.01 2.837.055 3.839c.042.926.197 1.43.327 1.764.173.443.378.76.71 1.092.333.333.65.538 1.093.71.335.13.838.286 1.764.328 1.002.046 1.302.055 3.839.055s2.837-.01 3.839-.055c.926-.042 1.43-.197 1.764-.327.443-.173.76-.378 1.092-.71.333-.333.538-.65.71-1.093.13-.335.286-.838.328-1.764.046-1.002.055-1.302.055-3.839s-.01-2.837-.055-3.839c-.042-.926-.197-1.43-.327-1.764a2.943 2.943 0 0 0-.71-1.092 2.943 2.943 0 0 0-1.093-.71c-.335-.13-.838-.286-1.764-.328-1.002-.046-1.302-.055-3.839-.055zm0 2.91a4.878 4.878 0 1 1 0 9.756 4.878 4.878 0 0 1 0-9.756zm0 8.045a3.167 3.167 0 1 0 0-6.334 3.167 3.167 0 0 0 0 6.334zm6.211-8.238a1.14 1.14 0 1 1-2.28 0 1.14 1.14 0 0 1 2.28 0z" fill="#000" fill-rule="evenodd"/>
+</svg>
+        </div>
+        <noscript><img src="https://s3.amazonaws.com/heartbeat.pmc.com/track?host=www.rollingstone.com&#038;path=%2F&#038;query=redirurl%253D%252Fpolitics%252Fnews%252Fgreed-and-debt-the-true-story-of-mitt-romney-and-bain-capital-20120829&#038;ct=home&#038;lob=rollingstone&#038;loc=us&#038;env=desktop" border="0" width="0" height="0" style="z-index: 0; bottom: -1px; left: -1px; display: inline; position: fixed;" /></noscript><script type='text/javascript' defer='defer' src='https://s0.wp.com/wp-content/js/devicepx-jetpack.js?ver=201904'></script>
+<script type='text/javascript' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-global-functions/js/waypoints.js?ver=1.1.7'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var krux_event_pixels = {"gallery_slide_view":""};
+/* ]]> */
+</script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-krux-tag/js/krux-pixel.js'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-js-libraries/vendor/pmc-jquery-extensions/1.0/pmc-jquery-extensions.min.js?ver=1.0'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-js-libraries/vendor/jquery-inview/1.0/jquery-inview.min.js?ver=1.0'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-includes/js/underscore.min.js?ver=1.8.3'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-google-universal-analytics/js/event-tracking.min.js?ver=2'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var pmc_share_bar_lob_ga_tracking = {"permalink":"https:\/\/www.rollingstone.com\/politics\/politics-features\/roe-v-wade-2019-781520\/","is_mobile":"","share_list":{"facebook":{"name":"Facebook","title":"Share on Facebook","class":"btn-facebook","url":"https:\/\/www.facebook.com\/sharer.php","popup":true,"javascript":false,"popup_title":"Share on Facebook"},"twitter":{"name":"Twitter","title":"Tweet","class":"btn-twitter","url":"https:\/\/twitter.com\/intent\/tweet","popup":true,"javascript":false,"popup_title":"Share on Twitter"},"tumblr":{"name":"Tumblr","title":"Post to Tumblr","class":"btn-tumblr","url":"https:\/\/www.tumblr.com\/widgets\/share\/tool\/preview","popup":true,"javascript":false,"popup_title":"Share on Tumblr"},"pinit":{"name":"Pin It","title":"Pin it","class":"btn-pinterest","url":"http:\/\/pinterest.com\/pin\/create\/link\/","popup":true,"javascript":false,"popup_title":"Share on Pinterest"},"reddit":{"name":"Reddit","title":"Submit to Reddit","class":"btn-reddit","url":"http:\/\/www.reddit.com\/submit","popup":true,"javascript":false,"popup_title":"Share on Reddit"},"linkedin":{"name":"LinkedIn","title":"Share on LinkedIn","class":"btn-linkedin","url":"http:\/\/www.linkedin.com\/shareArticle","popup":true,"javascript":false,"popup_title":"Share on LinkedIn"},"whatsapp":{"name":"WhatsApp","title":"Share on WhatsApp","class":"btn-whatsapp","url":"whatsapp:\/\/send","popup":false,"javascript":false,"popup_title":"Share on Whats App"},"email":{"name":"Email","title":"Email","class":"btn-email","url":"mailto:","popup":true,"javascript":false,"popup_title":"Send an Email"},"print":{"name":"Print","title":"Print This Page","class":"btn-print","url":"javascript:window.print()","popup":false,"javascript":true,"popup_title":"Print the Article"},"comment":{"name":"Talk","title":"Talk","class":"btn-comment","url":"","popup":false,"javascript":false,"popup_title":"Post a Comment"}}};
+/* ]]> */
+</script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-social-share-bar/_build/js/frontend.js?ver=1.0'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-social-share-bar/_build/js/tracking.js?ver=1.0'></script>
+<script type='text/javascript' defer='defer' src='https://s.swiftypecdn.com/cc/sy-RP6d1-C3sS-PmMs6w.js?ver=2.0'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-swiftype/assets/js/SwiftypeComponents.min.js?ver=2.0'></script>
+<!--[if lt IE 10]>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-swiftype/assets/js/swiftypecomponents-ie.js?ver=2.0'></script>
+<![endif]-->
+<script type='text/javascript'>
+/* <![CDATA[ */
+var SwiftypeConfigs = {"engine_key":"sy-RP6d1-C3sS-PmMs6w","redirect_to":"\/results","home_url":"https:\/\/www.rollingstone.com\/","placeholder_image":"","image_size":"","sort_field":"_score","specific_dates":"","sort_direction":"desc","autocomplete":{"tags":{"include":false,"name":"Tags"},"articles":{"include":true,"name":"Content"}},"author_list":[],"date_filters":{"date_options:radio-options":{"title":"Date Filter","default_option":0},"0":"content_type_facet:checkbox-facet","topics_facet:checkbox-facet":{"limit":7,"allowed_items":[],"disallowed_items":[]},"tags_facet:checkbox-facet":{"limit":7,"allowed_items":[],"disallowed_items":[]},"author_facet:checkbox-facet":[]},"custom_facet_settings":[],"meta_tags":{"post_types":{"post":"Article","pmc-gallery":"Gallery","pmc_list":"List","pmc_list_item":"List Item","pmc_top_video":"Video"},"show_content_type_meta_tag":true,"tags":["post_tag"],"topics":["category"],"custom_topics":[],"comment_count":true,"appeared_in_print":false},"trans":{"search":"Search","search_button":"Search","reference":"Relevance","pub_date_new":"Published Date (newest first)","pub_date_old":"Published Date (oldest first)","most_commented":"Most Commented","clear":"Clear","content_type":"Content Type","topics":"Topics","tags":"Tags","all":"All","twentyfour_hours":"Past 24 Hours","seven_days":"Past 7 Days","thirty_days":"Past 30 Days","twelve_months":"Past 12 Months","specific_dates":"Specific Dates"},"q":"","from_str":"From:","to_str":"To:","refine_search_str":"Refine Search","author":"Author","appeared_in_print":"Appeared in Print?"};
+/* ]]> */
+</script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-swiftype/assets/js/configuration.min.js?ver=2.0'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-video-player//js/ga-ytplayer.min.js?ver=1.0'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var pmc_video_player_ads = {"is_jwplayer_midroll_enable":"1","first_jwplayer_midroll_call_time":"25","second_jwplayer_midroll_call_time":"500","bidders":{"indexExchange":{"mvt":"","bids":"","config":{"siteID":290296,"videoCommonArgs":{"protocols":[2,3,5,6],"mimes":["video\/mp4","video\/webm","application\/javascript"],"apiList":[1,2]}}}}};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-video-player/js/video-ads.min.js?ver=1.0.0'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-video-player/js/ga-jwplayer.min.js?ver=1'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-js-libraries/vendor/scrolltofixed/1.0/jquery-scrolltofixed.min.js?ver=1.0'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var pmc_sticky_rail_ads = {"rail_selector":".l-blog__secondary","first_ad_selector":"#adm-right-rail-1","second_ad_selector":"#adm-right-rail-2","nav_bar_selector":".l-header__content l-header__content--sticky","admin_bar_selector":"#wpadminbar","first_ad_limit":"2","ad_container_width":"320","is_dynamic_content":""};
+/* ]]> */
+</script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-content/plugins/pmc-plugins/pmc-sticky-rail-ads//assets/js/sticky-rail-ads.min.js?ver=1.0.0'></script>
+<script type='text/javascript' defer='defer' src='https://cdn.roiq.ranker.com/client/assets/minified/roiq_dfp_targeting.js?ver=5.0.3'></script>
+<script type='text/javascript' defer='defer' src='https://www.rollingstone.com/wp-includes/js/wp-embed.min.js?ver=5.0.3'></script>
+<script type='text/javascript' src='https://stats.wp.com/e-201904.js' async='async' defer='defer'></script>
+<script type='text/javascript'>
+    _stq = window._stq || [];
+    _stq.push([ 'view', {v:'ext',j:'1:6.9',blog:'148354167',post:'0',tz:'-5',srv:'www.rollingstone.com'} ]);
+    _stq.push([ 'clickTrackerInit', '148354167', '0' ]);
+</script>
+        <!-- Start: Localize Video Player Events -->
+<script type="text/javascript">
+/* <![CDATA[ */
+    var pmc_video_player_event_tracking = {"basic":{"autoplay":"0","content_consumed":"1","play":"1","_100_percent_played":"1","error":"1","show_ad":"1","skip_ad":"1"},"advanced":{"pause":"0","seconds_played":{"_5":"0","_10":"0","_30":"0","_60":"0","_90":"0","_120":"0","_300":"0","_600":"0"},"percent_played":{"_5":"0","_10":"0","_25":"0","_50":"0","_75":"0","_95":"0"},"jump_forward":"0","jump_backward":"0","mute":"0","unmute":"0","volume_up":"0","volume_down":"0","settings":"0","full_screen":"0","watch_on_youtube":"0"}};
+/* ]]> */
+</script>
+<!-- End: Localize Video Player Events -->
+
+<!-- pmc-adm targeting -->
+<script>
+if ( typeof pmc !== 'undefined' && typeof pmc.hooks !== 'undefined' ) {
+    pmc.hooks.add_filter( 'pmc-adm-set-targeting-keywords', function( keywords ) {
+        try {
+            if ( typeof Krux !== 'undefined' ) {
+                if ( typeof keywords['ksg'] === 'undefined' ) {
+                    keywords['ksg']  = Krux.segments;
+                }
+                if ( typeof keywords['kuid'] === 'undefined' ) {
+                    keywords['kuid']  = Krux.user;
+                }
+            }
+        } catch(e) {}
+        return keywords;
+    } );
+}
+
+(function() {
+    if( window.hasOwnProperty('pmc_krux' ) ) {
+        window.pmc_krux['destination-url'] = window.location.href;
+        if( document.hasOwnProperty('referrer') && document.referrer.length ) {
+            window.pmc_krux['referrer'] = document.referrer;
+        }
+        if( 'undefined' !== typeof pmc_meta && 'string' === typeof pmc_meta.omni_visit_id ) {
+            window.pmc_krux['omni_visit_id'] = pmc_meta.omni_visit_id;
+        }
+    }
+})();
+
+</script>
+
+        <!-- pmc-tags-bottom Comscore -->
+    <script type="text/javascript">
+var _comscore = _comscore || []; _comscore.push({ c1: "2", c2: "6035310", c3: "", c4: "", c5: "", c6: "", c15: "" }); (function() { var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true; s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js"; el.parentNode.insertBefore(s, el); })();
+    </script>
+<!-- end pmc-tags-bottom Comscore --><!-- pmc-tags-bottom Instinctive -->   <script async src="https://load.instinctiveads.com/i.js" class="script-mobile"></script>
+<!-- end pmc-tags-bottom Instinctive --><!-- pmc-tags-bottom Global --><!-- START callback function for onhashchange(when the hash tag in the url gets updated) -->
+<script type="text/javascript">
+function global_urlhashchanged() {
+    /**
+     * Track pageview
+     */
+    // Build the current domain name
+    var tmp_td = document.domain.split('.');
+    var tracking_domain = tmp_td[tmp_td.length-2] + "." + tmp_td[tmp_td.length-1];
+
+    // Build the current image
+    var imgname = location.hash.replace('#','');
+    try {
+        ga( 'send', 'pageview', location.pathname + location.hash );
+    } catch(err) {}
+
+    try {
+        if ( typeof window.snowplowKW == 'function' ) {
+            console.log('sending tracking code');
+            window.snowplowKW( 'trackPageView' );
+        }
+    } catch ( err ) {
+    }
+
+    // Track Quantcast
+    try {
+
+        // need to reset the array containing the options previously sent
+        // as quantcast does not send the same key twice.
+        if (__qc && __qc.qpixelsent && __qc.qpixelsent.length > 0) {
+            __qc.qpixelsent.length = 0;
+        }
+        // First Quantcast Tag
+        _qoptions={
+            qacct:""
+        };
+
+        quantserve();
+
+    } catch(err) {}
+
+    // Track Comscore
+    try {
+        setTimeout(function(){ var url = "http" + (/^https:/.test(document.location.href) ? "s" : "") + "://beacon.scorecardresearch.com/scripts/beacon.dll" + "?c1=2&amp;c2=6035310&amp;c3=&amp;c4=&amp;c5=&amp;c6=&amp;c7=" + escape(document.location.href) + "&amp;c8=" + escape(document.title) + "&amp;c9=" + escape(document.referrer) + "&amp;c10=" + escape(screen.width+'x'+screen.height) + "&amp;rn=" + (new Date()).getTime(); var i = new Image(); i.src = url; }, 1);
+
+        COMSCORE.beacon({c1:2,c2:"6035310",c3:"6035310",c4:"",c5:"",c6:"",c15:""});
+
+    } catch(err) {}
+
+    /**
+    * Track pageview end
+    */
+}
+</script>
+<!-- end pmc-tags-bottom Global --><!-- pmc-tags-bottom Keywee --><script src="//dc8xl0ndzn2cb.cloudfront.net/js/rollingstonecom/v0/keywee.min.js" type="text/javascript" async></script>
+<!-- end pmc-tags-bottom Keywee --><!-- pmc-tags-bottom SkimLinks -->
+<script type="text/javascript" src="https://s.skimresources.com/js/87443X1590823.skimlinks.js" async></script>
+<!-- end pmc-tags-bottom SkimLinks --><!-- pmc-tags-bottom Quantcast -->
+    <script type="text/javascript">
+        _qevents.push( { qacct:"p-31f3D02tYU8zY" } ); // Blog network operator  </script>
+    <noscript>
+        <div style="display:none;">
+        <img src="//pixel.quantserve.com/pixel?a.1=&#038;a.2=p-31f3D02tYU8zY" border="0" height="1" width="1" alt="Quantcast"/>
+        </div>
+    </noscript>
+<!-- end pmc-tags-bottom Quantcast --><!-- pmc-tags-bottom Pinit --><!-- end pmc-tags-bottom Pinit --><!-- pmc-tags-bottom Pingdom --><!-- Pingdom RUM - Start -->
+<script>
+    var _prum = [['id', '55133c47abe53d890db40683'],
+        ['mark', 'firstbyte', (new Date()).getTime()]];
+    (function() {
+        var s = document.getElementsByTagName('script')[0]
+            , p = document.createElement('script');
+        p.async = 'async';
+        p.src = '//rum-static.pingdom.net/prum.min.js';
+        s.parentNode.insertBefore(p, s);
+    })();
+</script>
+<!-- Pingdom RUM - End -->
+<!-- DO NOT REMOVE, comment for engineering, 4BAfe4nkpyAktm3S -->
+<!-- end pmc-tags-bottom Pingdom -->
+    <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"c8454aa091","applicationID":"117771757","transactionName":"ZwYHYhBRC0JWURILX15MJFUWWQpfGFQUDV5EThVXBVU=","queueTime":0,"applicationTime":1375,"atts":"S0EQFFhLGB0VU0RYS00e","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+
+</html>

--- a/tests/fixtures/site_config/rollingstone.com.txt
+++ b/tests/fixtures/site_config/rollingstone.com.txt
@@ -1,0 +1,2 @@
+next_page_link: //link[@rel="next"]/@href
+if_page_contains: //a[contains(@class, 'pagination-collection')]


### PR DESCRIPTION
`single_page_link` has priority over `next_page_link` when both are defined the site config file and `if_page_contains` rules are defined.

Problem appear when you want to fetch the homepage of `rollingstone.com` for example (yeah bad idea anyway). The source contains the `next_page_link` defined in [the site config](https://github.com/fivefilters/ftr-site-config/commits/7baf9d42bd05e5c20a41241b3c6e1693c975f21a/rollingstone.com.txt). But as graby doesn't handle `if_page_contains` for `next_page_link` it started to fetch endlessly all pages from rollingstone homepage. Gasp.

Following https://github.com/j0k3r/graby/pull/190