### PR TITLE
Add support of referrerpolicy for img tags

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -35,6 +35,8 @@ class Graby
     private $configBuilder;
     private $punycode;
 
+    private $imgNoReferrer = false;
+
     /**
      * @param array         $config
      * @param Client|null   $client        Guzzle client
@@ -171,6 +173,13 @@ class Graby
         return $infos;
     }
 
+    public function toggleImgNoReferrer($toggle)
+    {
+        if (\is_bool($toggle)) {
+            $this->imgNoReferrer = $toggle;
+        }
+    }
+
     /**
      * Cleanup HTML from a DOMElement or a string.
      *
@@ -226,6 +235,14 @@ class Graby
             }
 
             $contentBlock = $contentBlock->firstChild;
+        }
+
+        // set or replace referrerpolicy to no-referrer in img tags
+        if ($this->imgNoReferrer) {
+            $imgTags = $contentBlock->getElementsByTagName('img');
+            foreach ($imgTags as $img) {
+                $img->setAttribute('referrerpolicy', 'no-referrer');
+            }
         }
 
         // convert content block to HTML string


### PR DESCRIPTION
Use `Graby::toggleImgNoReferrer(true)` in your client to automatically set
`referrerpolicy="no-referrer"` to all `img` tags.

Relates to https://github.com/wallabag/wallabag/issues/3889

Depends on https://github.com/fossar/HTMLawed/pull/3