### PR TITLE
Change the way to merge config for find & replace string

### DIFF
--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -250,4 +250,28 @@ class ConfigBuilderTest extends TestCase
 
         $this->assertInstanceOf('Graby\SiteConfig\SiteConfig', $res);
     }
+
+    /**
+     * Ensure merging config multiples times doesn't generate duplicate in replace_string / find_string.
+     */
+    public function testMergeConfigMultipleTimes()
+    {
+        $configBuilder = new ConfigBuilder([
+            'site_config' => [__DIR__ . '/../fixtures/site_config'],
+        ]);
+
+        $config1 = new SiteConfig();
+        $config1->find_string = ['toto'];
+        $config1->replace_string = ['titi'];
+
+        $config2 = new SiteConfig();
+        $config2->find_string = ['papa'];
+        $config2->replace_string = ['popo'];
+
+        $config3 = $configBuilder->mergeConfig($config1, $config2);
+        $config4 = $configBuilder->mergeConfig($config3, $config2);
+
+        $this->assertCount(2, $config4->find_string);
+        $this->assertCount(2, $config4->replace_string);
+    }
 }


### PR DESCRIPTION
`find_string` & `replace_string` had special case when merging them.
But it failed when merging multiple times some site config.

Update it to a bit more complex solution to ensure `find_string` & `replace_string` aren't duplicated when merging config multiple times.

We can't perform an `array_unique` on these values (looks like fabrizio got the point years ago) mostly because `replace_string` can have same values, example:

```
find_string: <amp-img
replace_string: <img

find_string: <other-img
replace_string: <img
```

To fix that issue, we combine find & replace as key & value in one array, we merge them (so we can't have duplicates keys) and then rebuild find & replace string in the current config.

@fivefilters, you might be interested by applying that fix on FullTextRSS I think.

Fix https://github.com/wallabag/wallabag/issues/4025