### PR TITLE
Handle meta refresh when attributes are reversed

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -515,7 +515,10 @@ class HttpClient
 
         // <meta HTTP-EQUIV="REFRESH" content="0; url=http://www.bernama.com/bernama/v6/newsindex.php?id=943513">
         if (!preg_match('!<meta http-equiv=["\']?refresh["\']? content=["\']?[0-9];\s*url=["\']?([^"\'>]+)["\']?!i', $html, $match)) {
-            return false;
+            // let's try in a reverse mode (switch content & http-equiv attributes)
+            if (!preg_match('!<meta content=["\']?[0-9];\s*url=["\']?([^"\'>]+)["\']? http-equiv=["\']?refresh["\']?!i', $html, $match)) {
+                return false;
+            }
         }
 
         $redirectUrl = str_replace('&amp;', '&', trim($match[1]));

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -137,6 +137,11 @@ class HttpClientTest extends TestCase
                 'http://www.bernama.com/bernama/v6/newsindex.php?id=943513',
             ],
             [
+                'https://www.google.com/url?sa=t&source=web&rct=j&url=https://databox.com/google-my-business-seo',
+                '<html><meta content="0;url=https://databox.com/google-my-business-seo" http-equiv="refresh"></html>',
+                'https://databox.com/google-my-business-seo',
+            ],
+            [
                 'http://www.example.com/wiki/Copyright',
                 '<html><meta HTTP-EQUIV="REFRESH" content="0; url=/bernama/v6/newsindex.php?id=943513"></html>',
                 'http://www.example.com/bernama/v6/newsindex.php?id=943513',


### PR DESCRIPTION
We already handled meta refresh url but only when attributes are in the following order: `http-equiv` THEN `content`.
That PR will make the meta refresh url fetched works when they are in reverse: `content` THEN `http-equiv`

Fix https://github.com/wallabag/wallabag/issues/4259 & fix https://github.com/wallabag/android-app/issues/899