### PR TITLE
Remove the wallabag's fork of tcpdf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
     - nightly
 
 # run build against nightly but allow them to fail

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "symfony/options-resolver": "~2.6|~3.0|~4.0",
         "monolog/monolog": "^1.13.1",
         "smalot/pdfparser": "~0.11",
-        "wallabag/tcpdf": "^6.2.26",
         "true/punycode": "~2.1",
         "psr/http-message": "^1.0",
         "php-http/httplug": "^2.0",


### PR DESCRIPTION
This PR removes the explicit dependency to wallabag/tcpdf as graby does not use it itself and it may prevent wallabag from moving back to the former package (`tecnickcom/TCPDF`).