### PR TITLE
Support for Monolog v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "simplepie/simplepie": "^1.3.1",
         "fossar/htmlawed": "^1.2.4",
         "symfony/options-resolver": "~2.6|~3.0|~4.0|~5.0",
-        "monolog/monolog": "^1.13.1",
+        "monolog/monolog": "^1.13.1|^2.0",
         "smalot/pdfparser": "~0.11",
         "true/punycode": "~2.1",
         "psr/http-message": "^1.0",

--- a/src/Monolog/Formatter/GrabyFormatter.php
+++ b/src/Monolog/Formatter/GrabyFormatter.php
@@ -18,9 +18,9 @@ class GrabyFormatter extends HtmlFormatter
      *
      * @param array $record A record to format
      *
-     * @return mixed The formatted record
+     * @return string The formatted record
      */
-    public function format(array $record)
+    public function format(array $record): string
     {
         $output = '<table cellspacing="1" width="100%" class="monolog-output">';
 
@@ -47,7 +47,7 @@ class GrabyFormatter extends HtmlFormatter
         return $output . '</table>';
     }
 
-    protected function convertToString($data)
+    protected function convertToString($data): string
     {
         if (\is_bool($data)) {
             return $data ? '(bool) true' : '(bool) false';

--- a/src/Monolog/Handler/GrabyHandler.php
+++ b/src/Monolog/Handler/GrabyHandler.php
@@ -40,7 +40,7 @@ class GrabyHandler extends AbstractProcessingHandler
         return isset($this->recordsByLevel[$level]);
     }
 
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $this->recordsByLevel[$record['level']][] = $record;
         $this->records[] = $record;


### PR DESCRIPTION
Hi.
This PR allows you to use `graby` in the latest versions of Laravel, there is such `"monolog/monolog": "^2.0"` dependency in this beautiful framework
https://github.com/laravel/framework/blob/7.x/composer.json#L27

This will increase the reach of this package.