### PR TITLE
Define lowest working deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ log/graby.log
 log/html.log
 composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ php:
     - 7.4
     - nightly
 
-# run build against nightly but allow them to fail
 jobs:
     fast_finish: true
     allow_failures:
         - php: nightly
-    # only one build will send the coverage, this'll speed up other one
     include:
         - php: 7.3
           env: PHPUNIT_FLAGS="--coverage-clover build/logs/clover.xml" CS_FIXER=run
@@ -20,18 +18,18 @@ jobs:
           env: GUZZLE5=run
         - php: 7.2
           env: CURL=run
+        - php: 7.2
+          env: COMPOSER_FLAGS="--prefer-lowest"
 
-# cache vendor dirs
 cache:
     directories:
-        - vendor
-        - $HOME/.composer/cache
+        - $HOME/.composer/cache/files
 
 before_install:
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
 
     # because php-coveralls require Guzzle 6
-    - if [ "$GUZZLE5" = "run" ]; then composer remove php-coveralls/php-coveralls php-http/guzzle6-adapter --dev -n ; fi;
+    - if [ "$GUZZLE5" = "run" ]; then composer remove guzzlehttp/guzzle php-http/guzzle6-adapter --dev -n ; fi;
     - if [ "$GUZZLE5" = "run" ]; then composer require php-http/guzzle5-adapter '^2.0' --dev -n ; fi;
 
     - if [ "$CURL" = "run" ]; then composer remove php-http/guzzle6-adapter --dev -n ; fi;
@@ -39,7 +37,7 @@ before_install:
     - if [ "$CURL" = "run" ]; then composer require zendframework/zend-diactoros --dev -n ; fi;
 
 install:
-    - composer up --no-interaction --prefer-dist -o
+    - composer update --prefer-dist --no-progress --no-suggest -o $COMPOSER_FLAGS
 
 before_script:
     - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -53,5 +51,8 @@ script:
 after_success:
     - |
         if [[ "$PHPUNIT_FLAGS" != "" ]]; then
-            travis_retry php vendor/bin/php-coveralls -v -x build/logs/clover.xml
+            wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.2.0/php-coveralls.phar
+            chmod +x php-coveralls.phar
+
+            php php-coveralls.phar -v -x build/logs/clover.xml
         fi

--- a/composer.json
+++ b/composer.json
@@ -18,30 +18,29 @@
         "php": ">=7.1",
         "ext-curl": "*",
         "ext-tidy": "*",
-        "j0k3r/php-readability": "^1.1",
-        "j0k3r/graby-site-config": "^1.0",
-        "simplepie/simplepie": "^1.3.1",
-        "fossar/htmlawed": "^1.2.4",
-        "symfony/options-resolver": "~2.6|~3.0|~4.0|~5.0",
-        "monolog/monolog": "^1.13.1|^2.0",
-        "smalot/pdfparser": "~0.11",
-        "true/punycode": "~2.1",
-        "psr/http-message": "^1.0",
-        "php-http/httplug": "^2.0",
-        "php-http/discovery": "^1.0",
-        "php-http/client-common": "^2.0",
-        "php-http/message": "^1.7",
+        "fossar/htmlawed": "^1.2.7",
+        "guzzlehttp/psr7": "^1.5",
+        "j0k3r/graby-site-config": "^1.0.100",
         "j0k3r/httplug-ssrf-plugin": "^2.0",
-        "guzzlehttp/psr7": "^1.5"
+        "j0k3r/php-readability": "^1.2.3",
+        "monolog/monolog": "^1.18.0|^2.0",
+        "php-http/client-common": "^2.0",
+        "php-http/discovery": "^1.5",
+        "php-http/httplug": "^2.0",
+        "php-http/message": "^1.7",
+        "simplepie/simplepie": "^1.5",
+        "smalot/pdfparser": "^0.15.1",
+        "symfony/options-resolver": "^3.4|^4.0|^5.0",
+        "true/punycode": "^2.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.14",
-        "symfony/phpunit-bridge": "~2.6|~3.0|~4.0|^5.0",
-        "php-http/mock-client": "^1.2",
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "guzzlehttp/guzzle": "^6.3.0",
         "php-http/guzzle6-adapter": "^2.0",
-        "php-coveralls/php-coveralls": "^2.0",
-        "phpstan/phpstan": "^0.11",
-        "phpstan/phpstan-phpunit": "^0.11"
+        "php-http/mock-client": "^1.3",
+        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "extra": {
         "branch-alias": {
@@ -57,5 +56,8 @@
         "psr-4": {
             "Tests\\Graby\\": "tests/"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,19 +5,19 @@ includes:
 parameters:
     # https://github.com/phpstan/phpstan/issues/694#issuecomment-350724288
     autoload_files:
-        - vendor/bin/.phpunit/phpunit-7.4-0/vendor/autoload.php
+        - vendor/bin/.phpunit/phpunit-8.3-0/vendor/autoload.php
 
     ignoreErrors:
         # because we check for some HTTP client to exist or not (Guzzle 5/6 & cURL)
         -
-            message: '#Instantiated class (.*) not found.#'
-            path: %currentWorkingDirectory%/tests/Extractor/HttpClientTest.php
-        -
             message: '#Http\\Adapter\\Guzzle5\\Client\\|Http\\Adapter\\Guzzle6\\Client\\|Http\\Client\\Curl\\Client given#'
             path: %currentWorkingDirectory%/tests/Extractor/HttpClientTest.php
-        # because DOMXpath->query can return false
+        # we don't want to BC by defining typehint everywhere
+        # TODO: remove when jumping to 3.0
         -
-            message: '#between false and DOMNodeList will always evaluate to false#'
-            path: %currentWorkingDirectory%/src/Extractor/ContentExtractor.php
+            message: '#typehint specified.#'
+            path: %currentWorkingDirectory%/src/
 
     inferPrivatePropertyTypeFromConstructor: true
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,11 +10,6 @@
     bootstrap="vendor/autoload.php"
     >
 
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="7.4" />
-    </php>
-
     <testsuites>
         <testsuite name="Graby Test Suite">
             <directory>./tests</directory>

--- a/src/SiteConfig/SiteConfig.php
+++ b/src/SiteConfig/SiteConfig.php
@@ -14,81 +14,162 @@ namespace Graby\SiteConfig;
  */
 class SiteConfig
 {
-    // Use first matching element as title (0 or more xpath expressions)
+    /**
+     * Use first matching element as title (0 or more xpath expressions).
+     *
+     * @var array
+     */
     public $title = [];
 
-    // Use first matching element as body (0 or more xpath expressions)
+    /**
+     * Use first matching element as body (0 or more xpath expressions).
+     *
+     * @var array
+     */
     public $body = [];
 
-    // Use first matching element as author (0 or more xpath expressions)
+    /**
+     * Use first matching element as author (0 or more xpath expressions).
+     *
+     * @var array
+     */
     public $author = [];
 
-    // Use first matching element as date (0 or more xpath expressions)
+    /**
+     * Use first matching element as date (0 or more xpath expressions).
+     *
+     * @var array
+     */
     public $date = [];
 
-    // Strip elements matching these xpath expressions (0 or more)
+    /**
+     * Strip elements matching these xpath expressions (0 or more).
+     *
+     * @var array
+     */
     public $strip = [];
 
-    // Attribute used to replace lazyload image (like `data-lazy-src`)
+    /**
+     * Attribute used to replace lazyload image (like `data-lazy-src`).
+     *
+     * @var ?string
+     */
     public $src_lazy_load_attr = null;
 
-    // Strip elements which contain these strings (0 or more) in the id or class attribute
+    /**
+     * Strip elements which contain these strings (0 or more) in the id or class attribute.
+     *
+     * @var array
+     */
     public $strip_id_or_class = [];
 
-    // Strip images which contain these strings (0 or more) in the src attribute
+    /**
+     * Strip images which contain these strings (0 or more) in the src attribute.
+     *
+     * @var array
+     */
     public $strip_image_src = [];
 
-    // Mark article as a native ad if any of these expressions match (0 or more xpath expressions)
+    /**
+     * Mark article as a native ad if any of these expressions match (0 or more xpath expressions).
+     *
+     * @var array
+     */
     public $native_ad_clue = [];
 
-    // Additional HTTP headers to send (associative array)
+    /**
+     * Additional HTTP headers to send (associative array).
+     *
+     * @var array
+     */
     public $http_header = [];
 
-    // Process HTML with tidy before creating DOM (bool or null if undeclared)
+    /**
+     * Process HTML with tidy before creating DOM (bool or null if undeclared).
+     *
+     * @var ?bool
+     */
     public $tidy = null;
 
-    // Autodetect title/body if xpath expressions fail to produce results.
-    // Note that this applies to title and body separately, ie.
-    //   * if we get a body match but no title match, this option will determine whether we autodetect title
-    //   * if neither match, this determines whether we autodetect title and body.
-    // Also note that this only applies when there is at least one xpath expression in title or body, ie.
-    //   * if title and body are both empty (no xpath expressions), this option has no effect (both title and body will be auto-detected)
-    //   * if there's an xpath expression for title and none for body, body will be auto-detected and this option will determine whether we auto-detect title if the xpath expression for it fails to produce results.
-    // Usage scenario: you want to extract something specific from a set of URLs, e.g. a table, and if the table is not found, you want to ignore the entry completely. Auto-detection is unlikely to succeed here, so you construct your patterns and set this option to false. Another scenario may be a site where auto-detection has proven to fail (or worse, picked up the wrong content).
-    // bool or null if undeclared
+    /**
+     * Autodetect title/body if xpath expressions fail to produce results.
+     *     Note that this applies to title and body separately, ie.
+     *       * if we get a body match but no title match, this option will determine whether we autodetect title
+     *       * if neither match, this determines whether we autodetect title and body.
+     *     Also note that this only applies when there is at least one xpath expression in title or body, ie.
+     *       * if title and body are both empty (no xpath expressions), this option has no effect (both title and body will be auto-detected)
+     *       * if there's an xpath expression for title and none for body, body will be auto-detected and this option will determine whether we auto-detect title if the xpath expression for it fails to produce results.
+     *     Usage scenario: you want to extract something specific from a set of URLs, e.g. a table, and if the table is not found, you want to ignore the entry completely. Auto-detection is unlikely to succeed here, so you construct your patterns and set this option to false. Another scenario may be a site where auto-detection has proven to fail (or worse, picked up the wrong content).
+     *
+     * @var ?bool
+     */
     public $autodetect_on_failure = null;
 
-    // Clean up content block - attempt to remove elements that appear to be superfluous
-    // bool or null if undeclared
+    /**
+     * Clean up content block - attempt to remove elements that appear to be superfluous.
+     *
+     * @var ?bool
+     */
     public $prune = null;
 
-    // Test URL - if present, can be used to test the config above
+    /**
+     * Test URL - if present, can be used to test the config above.
+     *
+     * @var array
+     */
     public $test_url = [];
 
-    // If page contains - XPath expression. Used to determine if the preceding rule gets evaluated or not.
-    // Currently only works with single_page_link & next_page_link (first one has priority over the second one).
+    /**
+     * If page contains - XPath expression. Used to determine if the preceding rule gets evaluated or not.
+     * Currently only works with single_page_link & next_page_link (first one has priority over the second one).
+     *
+     * @var array
+     */
     public $if_page_contains = [];
 
-    // Single-page link - should identify a link element or URL pointing to the page holding the entire article
-    // This is useful for sites which split their articles across multiple pages. Links to such pages tend to
-    // display the first page with links to the other pages at the bottom. Often there is also a link to a page
-    // which displays the entire article on one page (e.g. 'print view').
-    // This should be an XPath expression identifying the link to that page. If present and we find a match,
-    // we will retrieve that page and the rest of the options in this config will be applied to the new page.
+    /**
+     * Single-page link - should identify a link element or URL pointing to the page holding the entire article
+     * This is useful for sites which split their articles across multiple pages. Links to such pages tend to
+     * display the first page with links to the other pages at the bottom. Often there is also a link to a page
+     * which displays the entire article on one page (e.g. 'print view').
+     * This should be an XPath expression identifying the link to that page. If present and we find a match,
+     * we will retrieve that page and the rest of the options in this config will be applied to the new page.
+     *
+     * @var array
+     */
     public $single_page_link = [];
 
+    /**
+     * @var array
+     */
     public $next_page_link = [];
 
-    // Which parser to use for turning raw HTML into a DOMDocument (either 'libxml' or 'html5lib')
-    // string or null if undeclared
+    /**
+     * Which parser to use for turning raw HTML into a DOMDocument (either 'libxml' or 'html5lib').
+     *
+     * @var ?string
+     */
     public $parser = null;
 
-    // Strings to search for in HTML before processing begins (used with $replace_string)
+    /**
+     * Strings to search for in HTML before processing begins (used with $replace_string).
+     *
+     * @var array
+     */
     public $find_string = [];
-    // Strings to replace those found in $find_string before HTML processing begins
+
+    /**
+     * Strings to replace those found in $find_string before HTML processing begins.
+     *
+     * @var array
+     */
     public $replace_string = [];
 
-    // the options below cannot be set in the config files which this class represents
+    /**
+     * the options below cannot be set in the config files which this class represents.
+     *
+     * @var ?string
+     */
     public $cache_key = null;
 
     /**
@@ -140,10 +221,33 @@ class SiteConfig
      */
     public $skip_json_ld = false;
 
-    protected $default_tidy = true; // used if undeclared
-    protected $default_autodetect_on_failure = true; // used if undeclared
-    protected $default_prune = true; // used if undeclared
-    protected $default_parser = 'libxml'; // used if undeclared
+    /**
+     * Used if undeclared.
+     *
+     * @var bool
+     */
+    protected $default_tidy = true;
+
+    /**
+     * Used if undeclared.
+     *
+     * @var bool
+     */
+    protected $default_autodetect_on_failure = true;
+
+    /**
+     * Used if undeclared.
+     *
+     * @var bool
+     */
+    protected $default_prune = true;
+
+    /**
+     * Used if undeclared.
+     *
+     * @var string
+     */
+    protected $default_parser = 'libxml';
 
     /**
      * Process HTML with tidy before creating DOM (bool or null if undeclared).
@@ -222,5 +326,7 @@ class SiteConfig
         if (isset($this->if_page_contains[$name]) && isset($this->if_page_contains[$name][$value])) {
             return $this->if_page_contains[$name][$value];
         }
+
+        return null;
     }
 }

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -10,16 +10,17 @@ use PHPUnit\Framework\TestCase;
 
 class ContentExtractorTest extends TestCase
 {
+    /** @var array */
     protected static $contentExtractorConfig;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$contentExtractorConfig = ['config_builder' => [
             'site_config' => [__DIR__ . '/../fixtures/site_config'],
         ]];
     }
 
-    public function testConstructDefault()
+    public function testConstructDefault(): void
     {
         $contentExtractor = new ContentExtractor(['config_builder' => ['site_config' => [__DIR__]]]);
         $contentExtractor->reset();
@@ -34,7 +35,7 @@ class ContentExtractorTest extends TestCase
         $this->assertNull($contentExtractor->getNextPageUrl());
     }
 
-    public function dataFingerPrints()
+    public function dataFingerPrints(): array
     {
         return [
             'blogger double quote' => [
@@ -57,7 +58,7 @@ class ContentExtractorTest extends TestCase
      *
      * @dataProvider dataFingerPrints
      */
-    public function testFingerPrints($html, $fingerprints)
+    public function testFingerPrints(string $html, string $fingerprints): void
     {
         $contentExtractor = new ContentExtractor([
             'config_builder' => ['site_config' => [__DIR__]],
@@ -74,12 +75,12 @@ class ContentExtractorTest extends TestCase
 
     /**
      * With a non-existent config directory, it fails.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage directory does not exist
      */
-    public function testBuildSiteConfigUnknownSite()
+    public function testBuildSiteConfigUnknownSite(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('directory does not exist');
+
         $contentExtractor = new ContentExtractor(['config_builder' => [
             'site_config' => [__DIR__ . '/../../wrong_site_config'],
         ]]);
@@ -89,7 +90,7 @@ class ContentExtractorTest extends TestCase
     /**
      * With a good configuration, SiteConfig must have some value defined.
      */
-    public function testBuildSiteConfig()
+    public function testBuildSiteConfig(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
         $res = $contentExtractor->buildSiteConfig('https://www.en.wikipedia.org/wiki/Metallica');
@@ -112,7 +113,7 @@ class ContentExtractorTest extends TestCase
     /**
      * Multiple call to a same SiteConfig will use the cached version.
      */
-    public function testBuildSiteConfigCached()
+    public function testBuildSiteConfigCached(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
         $res = $contentExtractor->buildSiteConfig('https://nofailure.io/wiki/Metallica');
@@ -128,7 +129,7 @@ class ContentExtractorTest extends TestCase
     /**
      * Test both fingerprint and custom SiteConfig for wordpress.
      */
-    public function testWithFingerPrints()
+    public function testWithFingerPrints(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -145,7 +146,7 @@ class ContentExtractorTest extends TestCase
     /**
      * Test config find_string / replace_string.
      */
-    public function testProcessFindString()
+    public function testProcessFindString(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -164,7 +165,7 @@ class ContentExtractorTest extends TestCase
 
         $content_block = $contentExtractor->getContent();
 
-        $this->assertContains('<iframe class="video"', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<iframe class="video"', $content_block->ownerDocument->saveXML($content_block));
         $this->assertCount(1, $contentExtractor->getAuthors());
         $this->assertEquals('CaTV', $contentExtractor->getAuthors()[0]);
     }
@@ -173,7 +174,7 @@ class ContentExtractorTest extends TestCase
      * Test config find_string / replace_string.
      * But with a count different between the two, so replacement will be skipped.
      */
-    public function testProcessFindStringBadCount()
+    public function testProcessFindStringBadCount(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -192,10 +193,10 @@ class ContentExtractorTest extends TestCase
 
         $content_block = $contentExtractor->getContent();
 
-        $this->assertContains('<iframe src="">[embedded content]</iframe>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<iframe src="">[embedded content]</iframe>', $content_block->ownerDocument->saveXML($content_block));
     }
 
-    public function dataForNextPage()
+    public function dataForNextPage(): array
     {
         return [
             // return the link as string
@@ -210,7 +211,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForNextPage
      */
-    public function testExtractNextPageLink($pattern, $html, $urlExpected)
+    public function testExtractNextPageLink(string $pattern, string $html, string $urlExpected): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -226,7 +227,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame($urlExpected, $contentExtractor->getNextPageUrl());
     }
 
-    public function dataForTitle()
+    public function dataForTitle(): array
     {
         return [
             // return the link as string
@@ -239,7 +240,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForTitle
      */
-    public function testExtractTitle($pattern, $html, $titleExpected)
+    public function testExtractTitle(string $pattern, string $html, string $titleExpected): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -255,7 +256,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame($titleExpected, $contentExtractor->getTitle());
     }
 
-    public function dataForAuthor()
+    public function dataForAuthor(): array
     {
         return [
             // return author node
@@ -270,7 +271,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForAuthor
      */
-    public function testExtractAuthor($pattern, $html, $authorExpected)
+    public function testExtractAuthor(string $pattern, string $html, array $authorExpected): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -286,7 +287,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame($authorExpected, $contentExtractor->getAuthors());
     }
 
-    public function dataForLanguage()
+    public function dataForLanguage(): array
     {
         return [
             ['<html><meta name="DC.language" content="en" />from <a rel="author" href="/user8412228">CaTV</a></html>', 'en'],
@@ -297,7 +298,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForLanguage
      */
-    public function testExtractLanguage($html, $languageExpected)
+    public function testExtractLanguage(string $html, string $languageExpected): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -312,7 +313,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame($languageExpected, $contentExtractor->getLanguage());
     }
 
-    public function dataForDate()
+    public function dataForDate(): array
     {
         return [
             // good time format
@@ -329,7 +330,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForDate
      */
-    public function testExtractDate($pattern, $html, $dateExpected)
+    public function testExtractDate(string $pattern, string $html, ?string $dateExpected): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -345,7 +346,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame($dateExpected, $contentExtractor->getDate());
     }
 
-    public function dataForStrip()
+    public function dataForStrip(): array
     {
         return [
             // strip nav element and keep only the p
@@ -358,7 +359,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForStrip
      */
-    public function testApplyStrip($pattern, $html, $removedContent)
+    public function testApplyStrip(string $pattern, string $html, string $removedContent): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -374,10 +375,10 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->readability->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertNotContains($removedContent, $content);
+        $this->assertStringNotContainsString($removedContent, $content);
     }
 
-    public function dataForStripIdOrClass()
+    public function dataForStripIdOrClass(): array
     {
         return [
             ['commentlist', '<html><body><nav id="commentlist">hello !hello !hello !hello !hello !hello !hello !hello !hello !</nav><p>' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', 'hello !'],
@@ -389,7 +390,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForStripIdOrClass
      */
-    public function testApplyStripIdOrClass($pattern, $html, $removedContent, $matchContent = null)
+    public function testApplyStripIdOrClass(string $pattern, string $html, ?string $removedContent, string $matchContent = null): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -406,13 +407,13 @@ class ContentExtractorTest extends TestCase
         $content = $domElement->ownerDocument->saveXML($domElement);
 
         if (null === $removedContent) {
-            $this->assertContains($matchContent, $content);
+            $this->assertStringContainsString((string) $matchContent, $content);
         } else {
-            $this->assertNotContains($removedContent, $content);
+            $this->assertStringNotContainsString($removedContent, $content);
         }
     }
 
-    public function dataForStripImageSrc()
+    public function dataForStripImageSrc(): array
     {
         return [
             ['doubleclick.net', '<html><body><img src="https://www.doubleclick.net/pub.jpg"/></nav><p>' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', 'https://www.doubleclick.net/pub.jpg'],
@@ -423,7 +424,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForStripImageSrc
      */
-    public function testApplyStripImageSrc($pattern, $html, $removedContent)
+    public function testApplyStripImageSrc(string $pattern, string $html, string $removedContent): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -441,10 +442,10 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->readability->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertNotContains($removedContent, $content);
+        $this->assertStringNotContainsString($removedContent, $content);
     }
 
-    public function dataForStripDisplayNoneAndInstapaper()
+    public function dataForStripDisplayNoneAndInstapaper(): array
     {
         return [
             // remove element with class "instapaper_ignore"
@@ -457,7 +458,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForStripDisplayNoneAndInstapaper
      */
-    public function testApplyStripDisplayNoneAndInstapaper($html, $removedContent)
+    public function testApplyStripDisplayNoneAndInstapaper(string $html, string $removedContent): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -474,10 +475,10 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->readability->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertNotContains($removedContent, $content);
+        $this->assertStringNotContainsString($removedContent, $content);
     }
 
-    public function dataForStripAttr()
+    public function dataForStripAttr(): array
     {
         return [
             [['//*/@class'], '<html><body><div class="hello world"><i class="class">bar</i>class="foo"' . str_repeat('this is the best part of the show', 10) . ' <a class="hc" href="void">link</a></div></body></html>', [
@@ -496,7 +497,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForStripAttr
      */
-    public function testApplyStripAttr($patterns, $html, $assertions)
+    public function testApplyStripAttr(array $patterns, string $html, array $assertions): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -513,15 +514,15 @@ class ContentExtractorTest extends TestCase
         $content = $domElement->ownerDocument->saveXML($domElement);
 
         foreach ($assertions['removedContent'] as $removedContent) {
-            $this->assertNotContains($removedContent, $content);
+            $this->assertStringNotContainsString($removedContent, $content);
         }
 
         foreach ($assertions['keptContent'] as $keptContent) {
-            $this->assertContains($keptContent, $content);
+            $this->assertStringContainsString($keptContent, $content);
         }
     }
 
-    public function dataForExtractBody()
+    public function dataForExtractBody(): array
     {
         return [
             // extract one element
@@ -542,7 +543,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForExtractBody
      */
-    public function testExtractBody($pattern, $html, $expectedContent)
+    public function testExtractBody(string $pattern, string $html, string $expectedContent): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -563,7 +564,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame($expectedContent, $content);
     }
 
-    public function dataForExtractHNews()
+    public function dataForExtractHNews(): array
     {
         return [
             // the all hNews tested
@@ -604,7 +605,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForExtractHNews
      */
-    public function testExtractHNews($html, $expectedContent, $expectedElements)
+    public function testExtractHNews(string $html, string $expectedContent, array $expectedElements): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -631,7 +632,7 @@ class ContentExtractorTest extends TestCase
     /**
      * Extract content from instapaper class.
      */
-    public function testExtractInstapaper()
+    public function testExtractInstapaper(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -652,7 +653,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame($contentExtractor->getTitle(), 'hello !');
     }
 
-    public function dataForExtractSchemaOrg()
+    public function dataForExtractSchemaOrg(): array
     {
         return [
             // articleBody on one element
@@ -676,7 +677,7 @@ class ContentExtractorTest extends TestCase
     /**
      * @dataProvider dataForExtractSchemaOrg
      */
-    public function testExtractSchemaOrg($html, $expectedContent)
+    public function testExtractSchemaOrg(string $html, string $expectedContent): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -699,7 +700,7 @@ class ContentExtractorTest extends TestCase
     /**
      * Test that if the first h* found in the body is the same as the extracted title, it'll be removed.
      */
-    public function testRemoveHFromBody()
+    public function testRemoveHFromBody(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -718,11 +719,11 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertNotContains('My Title', $content);
+        $this->assertStringNotContainsString('My Title', $content);
         $this->assertSame('My Title', $contentExtractor->getTitle());
     }
 
-    public function dataForlazyLoad()
+    public function dataForlazyLoad(): array
     {
         return [
             // test with img attribute data-src
@@ -763,7 +764,7 @@ class ContentExtractorTest extends TestCase
      *
      * @dataProvider dataForlazyLoad
      */
-    public function testConvertLazyLoadImages($html, $htmlExpected)
+    public function testConvertLazyLoadImages(string $html, string $htmlExpected): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -782,10 +783,10 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertContains($htmlExpected, $content);
+        $this->assertStringContainsString($htmlExpected, $content);
     }
 
-    public function testIframeEmbeddedContent()
+    public function testIframeEmbeddedContent(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -806,10 +807,10 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertContains('<iframe src="http://www.dailymotion.com/embed/video/x2kjh59" frameborder="0" width="534" height="320">[embedded content]</iframe>', $content);
+        $this->assertStringContainsString('<iframe src="http://www.dailymotion.com/embed/video/x2kjh59" frameborder="0" width="534" height="320">[embedded content]</iframe>', $content);
     }
 
-    public function testLogMessage()
+    public function testLogMessage(): void
     {
         $logger = new Logger('foo');
         $handler = new TestHandler($level = Logger::INFO);
@@ -840,7 +841,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame('Attempting to parse HTML with {parser}', $records[9]['message']);
     }
 
-    public function testWithCustomFiltersForReadability()
+    public function testWithCustomFiltersForReadability(): void
     {
         $contentExtractor = new ContentExtractor(
             self::$contentExtractorConfig
@@ -905,11 +906,11 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertNotContains('<head>', $content);
-        $this->assertNotContains('<base>', $content);
+        $this->assertStringNotContainsString('<head>', $content);
+        $this->assertStringNotContainsString('<base>', $content);
     }
 
-    public function testNativeAd()
+    public function testNativeAd(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -923,10 +924,10 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $content_block = $contentExtractor->getContent();
 
         $this->assertTrue($contentExtractor->isNativeAd());
-        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
     }
 
-    public function testJsonLd()
+    public function testJsonLd(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -941,12 +942,12 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
 
         $this->assertSame('title !!', $contentExtractor->getTitle());
         $this->assertSame('2017-10-23T16:05:38+02:00', $contentExtractor->getDate());
-        $this->assertContains('bob', $contentExtractor->getAuthors());
+        $this->assertStringContainsString('bob', $contentExtractor->getAuthors()[0]);
         $this->assertSame('https://static.jsonld.io/medias.jpg', $contentExtractor->getImage());
-        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
     }
 
-    public function testJsonLdWithMultipleAuthors()
+    public function testJsonLdWithMultipleAuthors(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -963,7 +964,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         ], $contentExtractor->getAuthors());
     }
 
-    public function testNoDefinedHtml()
+    public function testNoDefinedHtml(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -974,7 +975,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertEmpty($contentExtractor->getImage());
     }
 
-    public function testOpenGraph()
+    public function testOpenGraph(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1001,10 +1002,10 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertSame('2017-10-23T17:04:21+00:00', $contentExtractor->getDate());
         $this->assertSame('fr_FR', $contentExtractor->getLanguage());
         $this->assertSame('https://static.opengraph.io/medias_11570.jpg', $contentExtractor->getImage());
-        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
     }
 
-    public function testAvoidDataUriImageInOpenGraph()
+    public function testAvoidDataUriImageInOpenGraph(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1018,10 +1019,10 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $content_block = $contentExtractor->getContent();
 
         $this->assertEmpty($contentExtractor->getImage());
-        $this->assertContains('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
     }
 
-    public function testJsonLdIgnoreList()
+    public function testJsonLdIgnoreList(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1033,10 +1034,10 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertTrue($res, 'Extraction went well');
 
         $this->assertSame('The Foobar Company is launching globally', $contentExtractor->getTitle());
-        $this->assertContains('Foobar CEO', $contentExtractor->getAuthors());
+        $this->assertStringContainsString('Foobar CEO', $contentExtractor->getAuthors()[0]);
     }
 
-    public function testJsonLdIgnoreListWithPeriodical()
+    public function testJsonLdIgnoreListWithPeriodical(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1050,7 +1051,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertSame('Hello world, this is title', $contentExtractor->getTitle());
     }
 
-    public function testJsonLdSkipper()
+    public function testJsonLdSkipper(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1070,10 +1071,10 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertEmpty($contentExtractor->getTitle());
         $this->assertNull($contentExtractor->getDate());
         $this->assertEmpty($contentExtractor->getAuthors());
-        $this->assertContains('this is the best part of the show', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('this is the best part of the show', $content_block->ownerDocument->saveXML($content_block));
     }
 
-    public function testJsonLdName()
+    public function testJsonLdName(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1085,7 +1086,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertSame('name !!', $contentExtractor->getTitle());
     }
 
-    public function testJsonLdDateArray()
+    public function testJsonLdDateArray(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1097,7 +1098,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertSame('2014-05-29T00:00:00+02:00', $contentExtractor->getDate());
     }
 
-    public function testJsonLdImageUrlArray()
+    public function testJsonLdImageUrlArray(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1109,7 +1110,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertSame('https://statics.estadao.com.br/s2016/portal/img/json-ld/estadao_1x1.png', $contentExtractor->getImage());
     }
 
-    public function testUniqueAuthors()
+    public function testUniqueAuthors(): void
     {
         $url = 'https://www.lemonde.fr/pixels/article/2018/05/30/bloodstained-curse-of-the-moon-delicieux-jeu-de-vampires-a-la-mode-des-annees-1980_5307173_4408996.html';
         $html = '<script type="application/ld+json">{"author":{"@type":"Person","name":"William Audureau"}}</script><a class="auteur" target="_blank" href="/journaliste/william-audureau/">William Audureau</a>';
@@ -1128,7 +1129,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertTrue(\count($authors) === \count($authorsUnique), 'There is no duplicate authors');
     }
 
-    public function testBodyAsDomAttribute()
+    public function testBodyAsDomAttribute(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
@@ -1145,7 +1146,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertFalse($res, 'Extraction failed');
     }
 
-    public function testBadDate()
+    public function testBadDate(): void
     {
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -12,38 +12,20 @@ use Psr\Http\Message\RequestInterface;
 
 class HttpClientTest extends TestCase
 {
-    public function dataForFetchGet()
+    public function dataForFetchGet(): array
     {
         return [
             [
                 'http://fr.m.wikipedia.org/wiki/Copyright#bottom',
                 'http://fr.wikipedia.org/wiki/Copyright',
-                [
-                    'headers' => [
-                        'User-Agent' => 'Mozilla/5.2',
-                        'Referer' => 'http://www.google.co.uk/url?sa=t&source=web&cd=1',
-                    ],
-                ],
             ],
             [
                 'http://bjori.blogspot.fr/2015/04/next-gen-mongodb-driver.html/#!test',
                 'http://bjori.blogspot.fr/2015/04/next-gen-mongodb-driver.html/?_escaped_fragment_=test',
-                [
-                    'headers' => [
-                        'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.92 Safari/535.2',
-                        'Referer' => 'http://www.google.co.uk/url?sa=t&source=web&cd=1',
-                    ],
-                ],
             ],
             [
                 'http://www.example.com/my-map.html',
                 'http://www.example.com/my-map.html',
-                [
-                    'headers' => [
-                        'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.874.92 Safari/535.2',
-                        'Referer' => 'http://www.google.co.uk/url?sa=t&source=web&cd=1',
-                    ],
-                ],
             ],
         ];
     }
@@ -51,7 +33,7 @@ class HttpClientTest extends TestCase
     /**
      * @dataProvider dataForFetchGet
      */
-    public function testFetchGet($url, $urlEffective)
+    public function testFetchGet(string $url, string $urlEffective): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, [], 'yay'));
@@ -64,7 +46,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function testFetchHeadGoodContentType()
+    public function testFetchHeadGoodContentType(): void
     {
         $url = 'http://fr.wikipedia.org/wiki/Copyright.jpg';
 
@@ -86,7 +68,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function testFetchHeadBadContentType()
+    public function testFetchHeadBadContentType(): void
     {
         $url = 'http://fr.wikipedia.org/wiki/Copyright.jpg';
 
@@ -107,7 +89,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function testFetchHeadReallyBadContentType()
+    public function testFetchHeadReallyBadContentType(): void
     {
         $url = 'http://fr.wikipedia.org/wiki/Copyright.jpg';
 
@@ -128,7 +110,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function dataForMetaRefresh()
+    public function dataForMetaRefresh(): array
     {
         return [
             [
@@ -157,7 +139,7 @@ class HttpClientTest extends TestCase
     /**
      * @dataProvider dataForMetaRefresh
      */
-    public function testFetchGetWithMetaRefresh($url, $body, $metaUrl)
+    public function testFetchGetWithMetaRefresh(string $url, string $body, string $metaUrl): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/html'], $body));
@@ -178,7 +160,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function testFetchGetWithHeaderRefresh()
+    public function testFetchGetWithHeaderRefresh(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/html', 'refresh' => '0; url=http://example.com/my-new-map.html'], ''));
@@ -193,7 +175,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function testWith404ResponseWithResponse()
+    public function testWith404ResponseWithResponse(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(404, ['Content-Type' => 'text/html'], 'test'));
@@ -207,7 +189,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(404, $res['status']);
     }
 
-    public function testWithUrlencodedContentType()
+    public function testWithUrlencodedContentType(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'image%2Fjpeg'], 'test'));
@@ -221,7 +203,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function testWithUrlContainingPlusSymbol()
+    public function testWithUrlContainingPlusSymbol(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200));
@@ -232,7 +214,7 @@ class HttpClientTest extends TestCase
         $this->assertSame('https://example.com/foo/+bar/baz/+quuz/corge', $res['effective_url']);
     }
 
-    public function testWith404ResponseWithoutResponse()
+    public function testWith404ResponseWithoutResponse(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(404));
@@ -246,7 +228,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(404, $res['status']);
     }
 
-    public function testLogMessage()
+    public function testLogMessage(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, [], 'yay'));
@@ -280,7 +262,7 @@ class HttpClientTest extends TestCase
         ], $records[3]['context']['data']);
     }
 
-    public function testTimeout()
+    public function testTimeout(): void
     {
         $logger = new Logger('foo');
         $handler = new TestHandler();
@@ -324,13 +306,13 @@ class HttpClientTest extends TestCase
         // cURL error 28 is: CURLE_OPERATION_TIMEDOUT
         // "cURL error 28: Connection timed out after"
         if ($isGuzzle) {
-            $this->assertContains('cURL error 28', $records[3]['formatted']);
+            $this->assertStringContainsString('cURL error 28', $records[3]['formatted']);
         } else {
-            $this->assertContains('Connection timed out after', $records[3]['formatted']);
+            $this->assertStringContainsString('Connection timed out after', $records[3]['formatted']);
         }
     }
 
-    public function testNbRedirectsReached()
+    public function testNbRedirectsReached(): void
     {
         $maxRedirect = 3;
         $httpMockClient = new HttpMockClient();
@@ -363,7 +345,7 @@ class HttpClientTest extends TestCase
         $this->assertSame('Endless redirect: 4 on "{url}"', $record['message']);
     }
 
-    public function dataForConditionalComments()
+    public function dataForConditionalComments(): array
     {
         return [
             [
@@ -431,7 +413,7 @@ class HttpClientTest extends TestCase
     /**
      * @dataProvider dataForConditionalComments
      */
-    public function testWithMetaRefreshInConditionalComments($url, $html, $removeData)
+    public function testWithMetaRefreshInConditionalComments(string $url, string $html, string $removeData): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/html'], $html));
@@ -440,14 +422,14 @@ class HttpClientTest extends TestCase
         $res = $http->fetch($url);
 
         $this->assertSame($url, $res['effective_url']);
-        $this->assertNotContains($removeData, $res['body']);
-        $this->assertNotContains('<!--[if ', $res['body']);
-        $this->assertNotContains('endif', $res['body']);
+        $this->assertStringNotContainsString($removeData, $res['body']);
+        $this->assertStringNotContainsString('<!--[if ', $res['body']);
+        $this->assertStringNotContainsString('endif', $res['body']);
         $this->assertSame('text/html', $res['headers']['content-type']);
         $this->assertSame(200, $res['status']);
     }
 
-    public function dataForUserAgent()
+    public function dataForUserAgent(): array
     {
         return [
             [
@@ -476,7 +458,7 @@ class HttpClientTest extends TestCase
     /**
      * @dataProvider dataForUserAgent
      */
-    public function testUserAgent($url, $httpHeader, $expectedUa)
+    public function testUserAgent(string $url, array $httpHeader, string $expectedUa): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, [], ''));
@@ -501,7 +483,7 @@ class HttpClientTest extends TestCase
         $this->assertSame($url, $records[1]['context']['url']);
     }
 
-    public function dataForReferer()
+    public function dataForReferer(): array
     {
         return [
             [
@@ -530,7 +512,7 @@ class HttpClientTest extends TestCase
     /**
      * @dataProvider dataForReferer
      */
-    public function testReferer($url, $httpHeader, $expectedReferer)
+    public function testReferer(string $url, array $httpHeader, string $expectedReferer): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, [], ''));
@@ -552,7 +534,7 @@ class HttpClientTest extends TestCase
         $this->assertSame($url, $records[2]['context']['url']);
     }
 
-    public function dataForCookie()
+    public function dataForCookie(): array
     {
         return [
             [
@@ -580,8 +562,10 @@ class HttpClientTest extends TestCase
 
     /**
      * @dataProvider dataForCookie
+     *
+     * @param string|false $expectedCookie
      */
-    public function testCookie($url, $httpHeader, $expectedCookie)
+    public function testCookie(string $url, array $httpHeader, $expectedCookie): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, [], ''));
@@ -606,7 +590,7 @@ class HttpClientTest extends TestCase
         }
     }
 
-    public function dataForAccept()
+    public function dataForAccept(): array
     {
         return [
             [
@@ -634,8 +618,10 @@ class HttpClientTest extends TestCase
 
     /**
      * @dataProvider dataForAccept
+     *
+     * @param string|false $expectedAccept
      */
-    public function testAccept($url, $httpHeader, $expectedAccept)
+    public function testAccept(string $url, array $httpHeader, $expectedAccept): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, [], ''));

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class GrabyFunctionalTest extends TestCase
 {
-    public function testRealFetchContent()
+    public function testRealFetchContent(): void
     {
         $logger = new Logger('foo');
         $handler = new TestHandler($level = Logger::INFO);
@@ -43,7 +43,7 @@ class GrabyFunctionalTest extends TestCase
         $this->assertSame('fr', $res['language']);
         $this->assertSame('https://www.lemonde.fr/actualite-medias/article/2015/04/12/radio-france-vers-une-sortie-du-conflit_4614610_3236.html', $res['url']);
         $this->assertSame('Grève à Radio France : vers une sortie du conflit ?', $res['title']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
 
         $records = $handler->getRecords();
 
@@ -69,7 +69,7 @@ class GrabyFunctionalTest extends TestCase
         $this->assertSame('Looking for site config files to see if single page link exists', $records[18]['message']);
     }
 
-    public function testRealFetchContent2()
+    public function testRealFetchContent2(): void
     {
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('https://bjori.blogspot.com/2015/04/next-gen-mongodb-driver.html');
@@ -93,11 +93,11 @@ class GrabyFunctionalTest extends TestCase
         $this->assertEmpty($res['language']);
         $this->assertSame('https://bjori.blogspot.com/2015/04/next-gen-mongodb-driver.html', $res['url']);
         $this->assertSame('Next Generation MongoDB Driver for PHP!', $res['title']);
-        $this->assertContains('For the past few months I\'ve been working on a "next-gen" MongoDB driver for PHP', $res['html']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('For the past few months I\'ve been working on a "next-gen" MongoDB driver for PHP', $res['html']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
     }
 
-    public function testPdfFile()
+    public function testPdfFile(): void
     {
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://img3.free.fr/im_tv/telesites/documentation.pdf');
@@ -122,13 +122,13 @@ class GrabyFunctionalTest extends TestCase
         $this->assertSame('2008-03-05T17:56:07+01:00', $res['date']);
         $this->assertSame('http://img3.free.fr/im_tv/telesites/documentation.pdf', $res['url']);
         $this->assertSame('PDF', $res['title']);
-        $this->assertContains('Free 2008', $res['html']);
-        $this->assertContains('Free 2008', $res['summary']);
-        $this->assertContains('application/pdf', $res['headers']['content-type']);
+        $this->assertStringContainsString('Free 2008', $res['html']);
+        $this->assertStringContainsString('Free 2008', $res['summary']);
+        $this->assertStringContainsString('application/pdf', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
     }
 
-    public function testImageFile()
+    public function testImageFile(): void
     {
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('https://i.imgur.com/KQQ7D9z.jpg');
@@ -154,11 +154,11 @@ class GrabyFunctionalTest extends TestCase
         $this->assertSame('Image', $res['title']);
         $this->assertSame('<a href="https://i.imgur.com/KQQ7D9z.jpg"><img src="https://i.imgur.com/KQQ7D9z.jpg" alt="image" /></a>', $res['html']);
         $this->assertEmpty($res['summary']);
-        $this->assertContains('image/jpeg', $res['headers']['content-type']);
+        $this->assertStringContainsString('image/jpeg', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
     }
 
-    public function dataWithAccent()
+    public function dataWithAccent(): array
     {
         return [
             // ['http://pérotin.com/post/2015/08/31/Le-cadran-solaire-amoureux'],
@@ -170,7 +170,7 @@ class GrabyFunctionalTest extends TestCase
     /**
      * @dataProvider dataWithAccent
      */
-    public function testAccentuedUrls($url)
+    public function testAccentuedUrls(string $url): void
     {
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent($url);
@@ -192,7 +192,7 @@ class GrabyFunctionalTest extends TestCase
         $this->assertSame(200, $res['status']);
     }
 
-    public function testYoutubeOembed()
+    public function testYoutubeOembed(): void
     {
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml');
@@ -217,35 +217,35 @@ class GrabyFunctionalTest extends TestCase
         $this->assertSame('[Review] The Matrix Falling (Rain) Source Code C++', $res['title']);
         $this->assertSame('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="allowfullscreen">[embedded content]</iframe>', $res['html']);
         $this->assertSame('[embedded content]', $res['summary']);
-        $this->assertContains('text/xml', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/xml', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
     }
 
-    public function testEncodedUrl()
+    public function testEncodedUrl(): void
     {
         $this->markTestSkipped('Still need to find a way to handle / in query string (https://github.com/j0k3r/graby/pull/45).');
 
-        $graby = new Graby(['debug' => true]);
-        $res = $graby->fetchContent('http://blog.niqnutn.com/index.php?article49/commandes-de-base');
+        // $graby = new Graby(['debug' => true]);
+        // $res = $graby->fetchContent('http://blog.niqnutn.com/index.php?article49/commandes-de-base');
 
-        $this->assertCount(11, $res);
+        // $this->assertCount(11, $res);
 
-        $this->assertArrayHasKey('status', $res);
-        $this->assertArrayHasKey('html', $res);
-        $this->assertArrayHasKey('title', $res);
-        $this->assertArrayHasKey('language', $res);
-        $this->assertArrayHasKey('date', $res);
-        $this->assertArrayHasKey('authors', $res);
-        $this->assertArrayHasKey('url', $res);
-        $this->assertArrayHasKey('summary', $res);
-        $this->assertArrayHasKey('image', $res);
-        $this->assertArrayHasKey('native_ad', $res);
-        $this->assertArrayHasKey('headers', $res);
+        // $this->assertArrayHasKey('status', $res);
+        // $this->assertArrayHasKey('html', $res);
+        // $this->assertArrayHasKey('title', $res);
+        // $this->assertArrayHasKey('language', $res);
+        // $this->assertArrayHasKey('date', $res);
+        // $this->assertArrayHasKey('authors', $res);
+        // $this->assertArrayHasKey('url', $res);
+        // $this->assertArrayHasKey('summary', $res);
+        // $this->assertArrayHasKey('image', $res);
+        // $this->assertArrayHasKey('native_ad', $res);
+        // $this->assertArrayHasKey('headers', $res);
 
-        $this->assertSame(200, $res['status']);
+        // $this->assertSame(200, $res['status']);
     }
 
-    public function testKoreanPage()
+    public function testKoreanPage(): void
     {
         $graby = new Graby(['debug' => true]);
         $res = $graby->fetchContent('http://www.newstown.co.kr/news/articleView.html?idxno=243722');
@@ -265,12 +265,12 @@ class GrabyFunctionalTest extends TestCase
         $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
-        $this->assertContains('에르보리앙', $res['title']);
-        $this->assertContains('프랑스 현대적 자연주의 브랜드', $res['summary']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('에르보리앙', $res['title']);
+        $this->assertStringContainsString('프랑스 현대적 자연주의 브랜드', $res['summary']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
     }
 
-    public function testMultipage()
+    public function testMultipage(): void
     {
         $graby = new Graby([
             'debug' => true,
@@ -297,13 +297,13 @@ class GrabyFunctionalTest extends TestCase
         $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
-        $this->assertContains('Radeon HD 7750/7770', $res['title']);
+        $this->assertStringContainsString('Radeon HD 7750/7770', $res['title']);
         // which should be on the page 6
-        $this->assertContains('2560x1600', $res['html']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('2560x1600', $res['html']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
     }
 
-    public function testCookie()
+    public function testCookie(): void
     {
         $graby = new Graby([
             'debug' => true,

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -17,7 +17,7 @@ class GrabyTest extends TestCase
      */
     const AN_IPV4 = '93.184.216.34';
 
-    public function testConstructDefault()
+    public function testConstructDefault(): void
     {
         $graby = new Graby(['debug' => true]);
 
@@ -25,18 +25,17 @@ class GrabyTest extends TestCase
         $this->assertSame('info', $graby->getConfig('log_level'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No config found for key:
-     */
-    public function testGetBadConfig()
+    public function testGetBadConfig(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No config found for key:');
+
         $graby = new Graby();
 
         $graby->getConfig('does_not_exists');
     }
 
-    public function dataForConfigOverride()
+    public function dataForConfigOverride(): array
     {
         return [
             ['http_client', ['http_client' => ['rewrite_url' => ['dummy.io' => ['/foo' => '/bar'], 'docs.google.com' => ['/foo' => '/bar']]]]],
@@ -46,7 +45,7 @@ class GrabyTest extends TestCase
     /**
      * @dataProvider dataForConfigOverride
      */
-    public function testConfigOverride($key, $config)
+    public function testConfigOverride(string $key, array $config): void
     {
         $graby = new Graby($config);
 
@@ -56,7 +55,7 @@ class GrabyTest extends TestCase
     /**
      * Parsing method inspired from Twig_Test_IntegrationTestCase.
      */
-    public function dataForFetchContent()
+    public function dataForFetchContent(): array
     {
         $tests = [];
 
@@ -92,7 +91,7 @@ class GrabyTest extends TestCase
     /**
      * @dataProvider dataForFetchContent
      */
-    public function testFetchContent($url, $urlEffective, $header, $language, $author, $title, $summary, $rawContent, $parsedContent)
+    public function testFetchContent(string $url, string $urlEffective, string $header, string $language, string $author, string $title, string $summary, string $rawContent, string $parsedContent): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => $header], $rawContent));
@@ -131,11 +130,11 @@ class GrabyTest extends TestCase
 
         $this->assertSame($parsedContent, $res['html'], 'Same html');
 
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
         $this->assertFalse($res['native_ad']);
     }
 
-    public function dataForAllowed()
+    public function dataForAllowed(): array
     {
         return [
             ['feed://wikipedia.org', 'http://wikipedia.org'],
@@ -146,7 +145,7 @@ class GrabyTest extends TestCase
     /**
      * @dataProvider dataForAllowed
      */
-    public function testAllowedUrls($url, $urlChanged)
+    public function testAllowedUrls(string $url, string $urlChanged): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(301, ['Location' => $urlChanged]));
@@ -161,7 +160,7 @@ class GrabyTest extends TestCase
         $this->assertSame($res['url'], $urlChanged);
     }
 
-    public function dataForBlocked()
+    public function dataForBlocked(): array
     {
         return [
             ['feed://lexpress.fr'],
@@ -171,12 +170,12 @@ class GrabyTest extends TestCase
 
     /**
      * @dataProvider dataForBlocked
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage is not allowed to be parsed.
      */
-    public function testBlockedUrls($url)
+    public function testBlockedUrls(string $url): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be parsed.');
+
         $graby = new Graby([
             'blocked_urls' => ['t411.io', 'lexpress.fr'],
         ]);
@@ -184,7 +183,7 @@ class GrabyTest extends TestCase
         $graby->fetchContent($url);
     }
 
-    public function dataForNotValid()
+    public function dataForNotValid(): array
     {
         return [
             ['http://lexpress devant.fr'],
@@ -195,21 +194,20 @@ class GrabyTest extends TestCase
 
     /**
      * @dataProvider dataForNotValid
-     *
-     * @expectedException \InvalidArgumentException
      */
-    public function testNotValidUrls($url)
+    public function testNotValidUrls(string $url): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $graby = new Graby();
         $graby->fetchContent($url);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage is not allowed to be parsed.
-     */
-    public function testBlockedUrlsAfterFetch()
+    public function testBlockedUrlsAfterFetch(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is not allowed to be parsed.');
+
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200));
 
@@ -220,7 +218,7 @@ class GrabyTest extends TestCase
         $graby->fetchContent('t411.io');
     }
 
-    public function testMimeTypeActionLink()
+    public function testMimeTypeActionLink(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'image/jpeg']));
@@ -240,12 +238,11 @@ class GrabyTest extends TestCase
         $this->assertFalse($res['native_ad']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage is blocked by mime action.
-     */
-    public function testMimeTypeActionExclude()
+    public function testMimeTypeActionExclude(): void
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is blocked by mime action.');
+
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(
             200,
@@ -269,7 +266,7 @@ class GrabyTest extends TestCase
         $this->assertEquals('GET', $httpMockClient->getRequests()[1]->getMethod());
     }
 
-    public function dataForExtension()
+    public function dataForExtension(): array
     {
         return [
             ['http://example.com/test.jpg', 'image/jpeg', 'Image', '', '<a href="http://example.com/test.jpg"><img src="http://example.com/test.jpg" alt="Image" /></a>'],
@@ -279,7 +276,7 @@ class GrabyTest extends TestCase
     /**
      * @dataProvider dataForExtension
      */
-    public function testAssetExtension($url, $header, $title, $summary, $html)
+    public function testAssetExtension(string $url, string $header, string $title, string $summary, string $html): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(
@@ -304,7 +301,7 @@ class GrabyTest extends TestCase
         $this->assertFalse($res['native_ad']);
     }
 
-    public function testAssetExtensionPDF()
+    public function testAssetExtensionPDF(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(
@@ -320,16 +317,16 @@ class GrabyTest extends TestCase
         $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('Document1', $res['title']);
-        $this->assertContains('Document title', $res['html']);
-        $this->assertContains('Morbi vulputate tincidunt ve nenatis.', $res['html']);
-        $this->assertContains('http://example.com/test.pdf', $res['url']);
-        $this->assertContains('Document title Calibri : Lorem ipsum dolor sit amet', $res['summary']);
+        $this->assertStringContainsString('Document title', $res['html']);
+        $this->assertStringContainsString('Morbi vulputate tincidunt ve nenatis.', $res['html']);
+        $this->assertStringContainsString('http://example.com/test.pdf', $res['url']);
+        $this->assertStringContainsString('Document title Calibri : Lorem ipsum dolor sit amet', $res['summary']);
         $this->assertSame('application/pdf', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
-    public function testAssetExtensionZIP()
+    public function testAssetExtensionZIP(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(
@@ -352,13 +349,13 @@ class GrabyTest extends TestCase
         $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('ZIP', $res['title']);
-        $this->assertContains('<a href="https://github.com/nathanaccidentally/Cydia-Repo-Template/archive/master.zip">Download ZIP</a>', $res['html']);
+        $this->assertStringContainsString('<a href="https://github.com/nathanaccidentally/Cydia-Repo-Template/archive/master.zip">Download ZIP</a>', $res['html']);
         $this->assertSame('application/zip', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
-    public function testAssetExtensionPDFWithArrayDetails()
+    public function testAssetExtensionPDFWithArrayDetails(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(
@@ -375,15 +372,15 @@ class GrabyTest extends TestCase
         $this->assertSame('2013-09-01T22:20:38+02:00', $res['date']);
         $this->assertSame(['Sebastien MALOT'], $res['authors']);
         $this->assertSame('Document1', $res['title']);
-        $this->assertContains('orem ipsum dolor sit amet', $res['html']);
-        $this->assertContains('http://example.com/test.pdf', $res['url']);
-        $this->assertContains('orem ipsum dolor sit amet', $res['summary']);
+        $this->assertStringContainsString('orem ipsum dolor sit amet', $res['html']);
+        $this->assertStringContainsString('http://example.com/test.pdf', $res['url']);
+        $this->assertStringContainsString('orem ipsum dolor sit amet', $res['summary']);
         $this->assertSame('application/pdf', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
-    public function testAssetExtensionTXT()
+    public function testAssetExtensionTXT(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/plain'], 'plain text :)'));
@@ -403,7 +400,7 @@ class GrabyTest extends TestCase
         $this->assertFalse($res['native_ad']);
     }
 
-    public function dataForSinglePage()
+    public function dataForSinglePage(): array
     {
         return [
             'single_page_link will return a string (ie the text content of <a> node)' => ['singlepage1.com', 'http://singlepage1.com/printed view', 'http://moreintelligentlife.com/print/content'],
@@ -418,7 +415,7 @@ class GrabyTest extends TestCase
      * @group dns-sensitive
      * @dataProvider dataForSinglePage
      */
-    public function testSinglePage($url, $expectedUrl, $singlePageUrl)
+    public function testSinglePage(string $url, string $expectedUrl, string $singlePageUrl): void
     {
         DnsMock::withMockedHosts([
             'singlepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
@@ -457,7 +454,7 @@ HTML
         $this->assertSame('my content', $res['html']);
         $this->assertSame($expectedUrl, $res['url']);
         $this->assertSame('my content', $res['summary']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
@@ -465,7 +462,7 @@ HTML
     /**
      * @group dns-sensitive
      */
-    public function testSinglePageMimeAction()
+    public function testSinglePageMimeAction(): void
     {
         DnsMock::withMockedHosts([
             'singlepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
@@ -503,7 +500,7 @@ HTML
     /**
      * @group dns-sensitive
      */
-    public function testMultiplePageOk()
+    public function testMultiplePageOk(): void
     {
         DnsMock::withMockedHosts([
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
@@ -532,7 +529,7 @@ HTML
         $this->assertSame('my content<div class="story">my content</div>', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content my content', $res['summary']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
@@ -540,7 +537,7 @@ HTML
     /**
      * @group dns-sensitive
      */
-    public function testMultiplePageMimeAction()
+    public function testMultiplePageMimeAction(): void
     {
         DnsMock::withMockedHosts([
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
@@ -566,7 +563,7 @@ HTML
         $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
-        $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
+        $this->assertStringContainsString('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
         $this->assertSame('application/pdf', $res['headers']['content-type']);
@@ -577,7 +574,7 @@ HTML
     /**
      * @group dns-sensitive
      */
-    public function testMultiplePageExtractFailed()
+    public function testMultiplePageExtractFailed(): void
     {
         DnsMock::withMockedHosts([
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
@@ -603,10 +600,10 @@ HTML
         $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
-        $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
+        $this->assertStringContainsString('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
@@ -614,7 +611,7 @@ HTML
     /**
      * @group dns-sensitive
      */
-    public function testMultiplePageBadAbsoluteUrl()
+    public function testMultiplePageBadAbsoluteUrl(): void
     {
         DnsMock::withMockedHosts([
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
@@ -645,10 +642,10 @@ HTML
         $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
-        $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
+        $this->assertStringContainsString('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
@@ -656,7 +653,7 @@ HTML
     /**
      * @group dns-sensitive
      */
-    public function testMultiplePageSameUrl()
+    public function testMultiplePageSameUrl(): void
     {
         DnsMock::withMockedHosts([
             'multiplepage1.com' => [['type' => 'A', 'ip' => self::AN_IPV4]],
@@ -682,15 +679,15 @@ HTML
         $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('my title', $res['title']);
-        $this->assertContains('This article appears to continue on subsequent pages which we could not extract', $res['html']);
+        $this->assertStringContainsString('This article appears to continue on subsequent pages which we could not extract', $res['html']);
         $this->assertSame('http://multiplepage1.com', $res['url']);
         $this->assertSame('my content This article appears to continue on subsequent pages which we could not extract', $res['summary']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
-    public function dataForExcerpt()
+    public function dataForExcerpt(): array
     {
         return [
             ['hello you are fine', 35, null, 'hello you are fine'],
@@ -708,7 +705,7 @@ HTML
     /**
      * @dataProvider dataForExcerpt
      */
-    public function testGetExcerpt($text, $length, $separator, $expectedResult)
+    public function testGetExcerpt(string $text, int $length, ?string $separator, string $expectedResult): void
     {
         $graby = new Graby();
 
@@ -721,7 +718,7 @@ HTML
         $this->assertSame($expectedResult, $res);
     }
 
-    public function dataForMakeAbsoluteStr()
+    public function dataForMakeAbsoluteStr(): array
     {
         return [
             ['example.org', '/test', false],
@@ -734,8 +731,10 @@ HTML
 
     /**
      * @dataProvider dataForMakeAbsoluteStr
+     *
+     * @param string|false $expectedResult
      */
-    public function testMakeAbsoluteStr($base, $url, $expectedResult)
+    public function testMakeAbsoluteStr(string $base, string $url, $expectedResult): void
     {
         $graby = new Graby();
 
@@ -748,7 +747,7 @@ HTML
         $this->assertSame($expectedResult, $res);
     }
 
-    public function dataForMakeAbsoluteAttr()
+    public function dataForMakeAbsoluteAttr(): array
     {
         return [
             ['http://example.org', '<a href="/lol">test</a>', 'href', 'href', 'http://example.org/lol'],
@@ -763,7 +762,7 @@ HTML
     /**
      * @dataProvider dataForMakeAbsoluteAttr
      */
-    public function testMakeAbsoluteAttr($base, $string, $attr, $expectedAttr, $expectedResult)
+    public function testMakeAbsoluteAttr(string $base, string $string, string $attr, string $expectedAttr, string $expectedResult): void
     {
         $graby = new Graby();
 
@@ -782,7 +781,7 @@ HTML
         $this->assertSame($expectedResult, $e->getAttribute($expectedAttr));
     }
 
-    public function dataForMakeAbsolute()
+    public function dataForMakeAbsolute(): array
     {
         return [
             ['http://example.org', '<a href="/lol">test</a>', 'href', 'http://example.org/lol'],
@@ -796,7 +795,7 @@ HTML
     /**
      * @dataProvider dataForMakeAbsolute
      */
-    public function testMakeAbsolute($base, $string, $expectedAttr, $expectedResult)
+    public function testMakeAbsolute(string $base, string $string, string $expectedAttr, string $expectedResult): void
     {
         $graby = new Graby();
 
@@ -818,7 +817,7 @@ HTML
     /**
      * Test on nested element: image inside a link.
      */
-    public function testMakeAbsoluteMultiple()
+    public function testMakeAbsoluteMultiple(): void
     {
         $graby = new Graby();
 
@@ -839,7 +838,7 @@ HTML
         $this->assertSame('http://example.org/path/to/image.jpg', $e->firstChild->attributes->getNamedItem('src')->nodeValue);
     }
 
-    public function testContentLinksRemove()
+    public function testContentLinksRemove(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(
@@ -855,15 +854,15 @@ HTML
         $this->assertCount(11, $res);
         $this->assertEmpty($res['language']);
         $this->assertSame('No title found', $res['title']);
-        $this->assertContains('<p>' . str_repeat('This is an awesome text with some links, here there are the awesome', 7) . ' links :)</p>', $res['html']);
+        $this->assertStringContainsString('<p>' . str_repeat('This is an awesome text with some links, here there are the awesome', 7) . ' links :)</p>', $res['html']);
         $this->assertSame('http://example.com', $res['url']);
         $this->assertSame('This is an awesome text with some links, here there are the awesomeThis is an awesome text with some links, here there are the awesomeThis is an awesome text with some links, here there are the awesomeThis is an awesome text with some links, here there &hellip;', $res['summary']);
-        $this->assertContains('text/html', $res['headers']['content-type']);
+        $this->assertStringContainsString('text/html', $res['headers']['content-type']);
         $this->assertEmpty($res['image']);
         $this->assertFalse($res['native_ad']);
     }
 
-    public function testMimeActionNotDefined()
+    public function testMimeActionNotDefined(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'application/pdf']));
@@ -883,7 +882,7 @@ HTML
         $this->assertFalse($res['native_ad']);
     }
 
-    public function dataForSafeCurl()
+    public function dataForSafeCurl(): array
     {
         return [
             ['http://0.0.0.0:123'],
@@ -900,7 +899,7 @@ HTML
     /**
      * @dataProvider dataForSafeCurl
      */
-    public function testBlockedUrlBySafeCurl($url)
+    public function testBlockedUrlBySafeCurl(string $url): void
     {
         $graby = new Graby();
         $res = $graby->fetchContent($url);
@@ -916,7 +915,7 @@ HTML
         $this->assertSame(500, $res['status']);
     }
 
-    public function testErrorMessages()
+    public function testErrorMessages(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, [], 'yay'));
@@ -939,7 +938,7 @@ HTML
         $this->assertFalse($res['native_ad']);
     }
 
-    public function dataWithAccent()
+    public function dataWithAccent(): array
     {
         return [
             'host with accent' => ['http://pérotin.com/post/2009/06/09/SAV-Free-un-sketch-kafkaien', 'http://xn--protin-bva.com/post/2009/06/09/SAV-Free-un-sketch-kafkaien'],
@@ -952,7 +951,7 @@ HTML
     /**
      * @dataProvider dataWithAccent
      */
-    public function testUrlWithAccent($url, $urlExpected)
+    public function testUrlWithAccent(string $url, string $urlExpected): void
     {
         $graby = new Graby();
 
@@ -965,7 +964,7 @@ HTML
         $this->assertSame($urlExpected, $res);
     }
 
-    public function dataForCleanupHtml()
+    public function dataForCleanupHtml(): array
     {
         return [
             'nothing' => [
@@ -1002,7 +1001,7 @@ HTML
     /**
      * @dataProvider dataForCleanupHtml
      */
-    public function testCleanupHtml($html, $expected, $withLog = false)
+    public function testCleanupHtml(string $html, string $expected, bool $withLog = false): void
     {
         $logger = new Logger('foo');
         $handler = new TestHandler();
@@ -1022,7 +1021,7 @@ HTML
         }
     }
 
-    public function testEncodingUtf8ForTextPlainPage()
+    public function testEncodingUtf8ForTextPlainPage(): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/malformed_UTF8_characters.txt');
         $res = $graby->fetchContent('http://www.ais.org/~jrh/acn/text/ACN8-1.txt');
@@ -1031,17 +1030,17 @@ HTML
         $this->assertTrue(false !== json_encode($res['html']), json_last_error_msg());
     }
 
-    public function testEmptyNodesRemoved()
+    public function testEmptyNodesRemoved(): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/framablog.html');
         $res = $graby->fetchContent('https://framablog.org/2017/12/02/avancer-ensemble-vers-la-contribution/');
 
         // The initial treatment was encapsulating the content into the empty node
         // So we don't want to see that again
-        $this->assertNotContains('<figure><p>Après un <em>icebreaker</em>', $res['html']);
+        $this->assertStringNotContainsString('<figure><p>Après un <em>icebreaker</em>', $res['html']);
     }
 
-    public function testMetaAuthor()
+    public function testMetaAuthor(): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/keithjgrant.html');
         $res = $graby->fetchContent('https://keithjgrant.com/posts/2018/06/resilient-declarative-contextual/');
@@ -1053,7 +1052,7 @@ HTML
         $this->assertEquals('Keith J. Grant', $authors[0]);
     }
 
-    public function testJsonLd()
+    public function testJsonLd(): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/20minutes-jsonld.html');
         $res = $graby->fetchContent('http://www.20minutes.fr/sport/football/2155935-20171022-stade-rennais-portugais-paulo-fonseca-remplacer-christian-gourcuff');
@@ -1078,7 +1077,7 @@ HTML
         $this->assertSame('Jeremy Goujon', $res['authors'][0]);
     }
 
-    public function testKeepOlStartAttribute()
+    public function testKeepOlStartAttribute(): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/timothysykes-keepol.html');
         $res = $graby->fetchContent('https://www.timothysykes.com/blog/10-things-know-short-selling/');
@@ -1098,20 +1097,20 @@ HTML
         $this->assertArrayHasKey('headers', $res);
 
         $this->assertSame(200, $res['status']);
-        $this->assertContains('<ol start="2">', $res['html']);
-        $this->assertContains('<ol start="3">', $res['html']);
-        $this->assertContains('<ol start="4">', $res['html']);
+        $this->assertStringContainsString('<ol start="2">', $res['html']);
+        $this->assertStringContainsString('<ol start="3">', $res['html']);
+        $this->assertStringContainsString('<ol start="4">', $res['html']);
     }
 
-    public function testContentWithXSS()
+    public function testContentWithXSS(): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/gist-xss.html');
         $res = $graby->fetchContent('https://gist.githubusercontent.com/nicosomb/94d1e08c42baff9184c313d638de1195/raw/d63b0bc99225604a9f4b57bfea1cd7a538c8ceeb/gistfile1.txt');
 
-        $this->assertNotContains('<script>', $res['html']);
+        $this->assertStringNotContainsString('<script>', $res['html']);
     }
 
-    public function testBadUrl()
+    public function testBadUrl(): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/bjori-404.html', 404);
         $res = $graby->fetchContent('https://bjori.blogspot.com/201');
@@ -1140,7 +1139,7 @@ HTML
         $this->assertEmpty($res['image']);
     }
 
-    public function dataDate()
+    public function dataDate(): array
     {
         return [
             [
@@ -1159,7 +1158,7 @@ HTML
     /**
      * @dataProvider dataDate
      */
-    public function testDate($url, $file, $expectedDate)
+    public function testDate(string $url, string $file, string $expectedDate): void
     {
         $graby = $this->getGrabyWithMock('/fixtures/content/' . $file);
         $res = $graby->fetchContent($url);
@@ -1181,7 +1180,7 @@ HTML
         $this->assertSame($expectedDate, $res['date']);
     }
 
-    public function dataAuthors()
+    public function dataAuthors(): array
     {
         return [
             [
@@ -1200,7 +1199,7 @@ HTML
     /**
      * @dataProvider dataAuthors
      */
-    public function testAuthors($url, $file, $expectedAuthors)
+    public function testAuthors(string $url, string $file, array $expectedAuthors): void
     {
         $graby = $this->getGrabyWithMock(
             '/fixtures/content/' . $file,
@@ -1235,7 +1234,7 @@ HTML
     /**
      * Validated using the site_config in "tests/fixtures".
      */
-    public function testIfPageContainsWithSinglePageLink()
+    public function testIfPageContainsWithSinglePageLink(): void
     {
         $graby = $this->getGrabyWithMock(
             '/fixtures/content/timothysykes-keepol.html',
@@ -1270,7 +1269,7 @@ HTML
     /**
      * Validated using the site_config in "tests/fixtures".
      */
-    public function testIfPageContainsWithNextPageLink()
+    public function testIfPageContainsWithNextPageLink(): void
     {
         $graby = $this->getGrabyWithMock(
             '/fixtures/content/rollingstone.html',
@@ -1303,7 +1302,7 @@ HTML
         $this->assertSame(200, $res['status']);
     }
 
-    public function testImgNoReferrer()
+    public function testImgNoReferrer(): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(
@@ -1346,7 +1345,7 @@ HTML
     /**
      * @see https://github.com/j0k3r/graby/issues/223
      */
-    public function testWithTooLongHtmlJitFail()
+    public function testWithTooLongHtmlJitFail(): void
     {
         $graby = $this->getGrabyWithMock(
             '/fixtures/content/blog-oracle.html',
@@ -1365,7 +1364,7 @@ HTML
     /**
      * Return an instance of graby with a mocked Guzzle client returning data from a predefined file.
      */
-    private function getGrabyWithMock($filePath, $status = 200, array $grabyConfig = [])
+    private function getGrabyWithMock(string $filePath, int $status = 200, array $grabyConfig = []): Graby
     {
         $response = new Response(
             $status,

--- a/tests/Monolog/Formatter/GrabyFormatterTest.php
+++ b/tests/Monolog/Formatter/GrabyFormatterTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class GrabyFormatterTest extends TestCase
 {
-    public function testFormat()
+    public function testFormat(): void
     {
         $formatter = new GrabyFormatter();
         $res = $formatter->formatBatch([[
@@ -26,8 +26,8 @@ class GrabyFormatterTest extends TestCase
             ],
         ]]);
 
-        $this->assertContains('<pre>This is a log message</pre>', $res);
-        $this->assertContains('<pre>(bool) true</pre>', $res);
-        $this->assertContains('"interesting": "ok"', $res);
+        $this->assertStringContainsString('<pre>This is a log message</pre>', $res);
+        $this->assertStringContainsString('<pre>(bool) true</pre>', $res);
+        $this->assertStringContainsString('"interesting": "ok"', $res);
     }
 }

--- a/tests/Monolog/Handler/GrabyHandlerTest.php
+++ b/tests/Monolog/Handler/GrabyHandlerTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class GrabyHandlerTest extends TestCase
 {
-    public function testFormat()
+    public function testFormat(): void
     {
         $handler = new GrabyHandler();
         $handler->handle([

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -10,14 +10,14 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigBuilderTest extends TestCase
 {
-    public function testConstructDefault()
+    public function testConstructDefault(): void
     {
         $builder = new ConfigBuilder(['site_config' => [__DIR__]]);
 
         $this->assertInstanceOf('Graby\SiteConfig\ConfigBuilder', $builder);
     }
 
-    public function testBuildFromArrayNoLines()
+    public function testBuildFromArrayNoLines(): void
     {
         $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
         $configActual = $configBuilder->parseLines([]);
@@ -25,7 +25,7 @@ class ConfigBuilderTest extends TestCase
         $this->assertEquals($configBuilder->create(), $configActual);
     }
 
-    public function testBuildFromArray()
+    public function testBuildFromArray(): void
     {
         $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
         $configActual = $configBuilder->parseLines([
@@ -85,7 +85,7 @@ class ConfigBuilderTest extends TestCase
         $this->assertTrue(true === $configActual->autodetect_on_failure(true));
     }
 
-    public function dataForAddToCache()
+    public function dataForAddToCache(): array
     {
         return [
             ['mykey', '', 'mykey'],
@@ -97,7 +97,7 @@ class ConfigBuilderTest extends TestCase
     /**
      * @dataProvider dataForAddToCache
      */
-    public function testAddToCache($key, $cachedKey, $expectedKey)
+    public function testAddToCache(string $key, string $cachedKey, string $expectedKey): void
     {
         $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
 
@@ -112,7 +112,7 @@ class ConfigBuilderTest extends TestCase
         $this->assertEquals($config, $configBuilder->getCachedVersion($expectedKey));
     }
 
-    public function dataForCachedVersion()
+    public function dataForCachedVersion(): array
     {
         return [
             ['mykey', false],
@@ -124,7 +124,7 @@ class ConfigBuilderTest extends TestCase
     /**
      * @dataProvider dataForCachedVersion
      */
-    public function testCachedVersion($key, $cached)
+    public function testCachedVersion(string $key, bool $cached): void
     {
         $config = false;
         $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
@@ -139,7 +139,7 @@ class ConfigBuilderTest extends TestCase
         $this->assertEquals($config, $configBuilder->getCachedVersion($key));
     }
 
-    public function testBuildOnCachedVersion()
+    public function testBuildOnCachedVersion(): void
     {
         $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
         $config1 = $configBuilder->buildForHost('www.host.io');
@@ -155,7 +155,7 @@ class ConfigBuilderTest extends TestCase
         $this->assertEquals($config1, $config2);
     }
 
-    public function dataForBuild()
+    public function dataForBuild(): array
     {
         return [
             // bar hostname
@@ -181,7 +181,7 @@ class ConfigBuilderTest extends TestCase
     /**
      * @dataProvider dataForBuild
      */
-    public function testBuildSiteConfig($host, $expectedRes, $matchedHost = null)
+    public function testBuildSiteConfig(string $host, bool $expectedRes, ?string $matchedHost = null): void
     {
         $configBuilder = new ConfigBuilder([
             'site_config' => [__DIR__ . '/../fixtures/site_config'],
@@ -197,7 +197,7 @@ class ConfigBuilderTest extends TestCase
         }
     }
 
-    public function testBuildWithCachedVersion()
+    public function testBuildWithCachedVersion(): void
     {
         $configBuilder = new ConfigBuilder([
             'site_config' => [__DIR__ . '/../fixtures/site_config'],
@@ -207,7 +207,7 @@ class ConfigBuilderTest extends TestCase
 
         $this->assertInstanceOf('Graby\SiteConfig\SiteConfig', $res);
 
-        $configBuilder->addToCache($res->cache_key, $res);
+        $configBuilder->addToCache((string) $res->cache_key, $res);
 
         $res2 = $configBuilder->loadSiteConfig('fr.wikipedia.org');
 
@@ -215,7 +215,7 @@ class ConfigBuilderTest extends TestCase
         $this->assertEquals($res, $res2, 'Config retrieve from cache');
     }
 
-    public function testLogMessage()
+    public function testLogMessage(): void
     {
         $logger = new Logger('foo');
         $handler = new TestHandler();
@@ -240,7 +240,7 @@ class ConfigBuilderTest extends TestCase
         $this->assertSame('Appending site config settings from global.txt', $records[2]['message']);
     }
 
-    public function testWithBadHost()
+    public function testWithBadHost(): void
     {
         $configBuilder = new ConfigBuilder([
             'site_config' => [__DIR__ . '/../fixtures/site_config'],
@@ -254,7 +254,7 @@ class ConfigBuilderTest extends TestCase
     /**
      * Ensure merging config multiples times doesn't generate duplicate in replace_string / find_string.
      */
-    public function testMergeConfigMultipleTimes()
+    public function testMergeConfigMultipleTimes(): void
     {
         $configBuilder = new ConfigBuilder([
             'site_config' => [__DIR__ . '/../fixtures/site_config'],


### PR DESCRIPTION
The lib is now fully tested with the lowest possible deps defined in `composer.json`.
I started that as we are now accepting Monolog 2.0. The library should still works with Monolog 1.
I found some flaws and raised some deps to make the library works again.

I've also upgraded PHPStan and convert some code to have less side effects.

Tests files are type hinted now.
The library isn't yet because it might BC. I'll have type hint on the library when jumping to the 3.0 release.