### PR TITLE
Allow installing `smalot/pdfparser` newer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-http/httplug": "^2.0",
         "php-http/message": "^1.7",
         "simplepie/simplepie": "^1.5",
-        "smalot/pdfparser": "^0.15.1",
+        "smalot/pdfparser": "^0.16",
         "symfony/options-resolver": "^3.4|^4.0|^5.0",
         "true/punycode": "^2.1"
     },


### PR DESCRIPTION
Which drop TCPDF deps