### PR TITLE
Rebuild siteconfig if host for singlepage is not the same than the so…

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -745,7 +745,19 @@ class Graby
         // check it's not what we have already!
         if (false !== $singlePageUrl && $singlePageUrl !== $url) {
             // it's not, so let's try to fetch it...
-            $response = $this->httpClient->fetch($singlePageUrl, false, $siteConfig->http_header);
+            $headers = $siteConfig->http_header;
+
+            $sourceUrl = parse_url($url);
+            $targetUrl = parse_url($singlePageUrl);
+            if (\is_array($sourceUrl)
+                && \is_array($targetUrl)
+                && \array_key_exists('host', $sourceUrl)
+                && \array_key_exists('host', $targetUrl)
+                && $sourceUrl['host'] !== $targetUrl['host']) {
+                $targetSiteConfig = $this->configBuilder->buildForHost($targetUrl['host']);
+                $headers = $targetSiteConfig->http_header;
+            }
+            $response = $this->httpClient->fetch($singlePageUrl, false, $headers);
 
             if ($response['status'] < 300) {
                 $this->logger->info('Single page content found with url', ['url' => $singlePageUrl]);

--- a/tests/fixtures/site_config/singlepage5.com.txt
+++ b/tests/fixtures/site_config/singlepage5.com.txt
@@ -1,0 +1,3 @@
+title: //h1[@class='print-title']
+body: //div[@class='main-article']
+prune: no


### PR DESCRIPTION
Consider a `single_page_link` directive on twitter.com that follows any
link found in a tweet. Here is an example with the following tweet:

  https://twitter.com/Cloudflare/status/1341353044504694787

This eventually leads to the following page:

  https://blog.cloudflare.com/beat-an-acoustics-inspired-ddos-attack/

Until now, Graby was incorrectly sending to cloudflare.com
http headers defined for twitter.com.
