### PR TITLE
ContentExtractor: fix handling of data-srcset

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -607,16 +607,23 @@ class ContentExtractor
                     continue;
                 }
 
-                $src = null;
+                $attributes = [];
                 foreach ($this->config['src_lazy_load_attributes'] as $attribute) {
                     if ($e->hasAttribute($attribute)) {
-                        $src = $e->getAttribute($attribute);
+                        $key = 'src';
+                        if ('data-srcset' === $attribute) {
+                            $key = 'srcset';
+                        }
+                        $attributes[$key] = $e->getAttribute($attribute);
                         $e->removeAttribute($attribute);
                     }
                 }
 
-                if (null !== $src) {
-                    $e->setAttribute('src', $src);
+                foreach (['src', 'srcset'] as $attr) {
+                    if (\array_key_exists($attr, $attributes)
+                        && null !== $attributes[$attr]) {
+                        $e->setAttribute($attr, $attributes[$attr]);
+                    }
                 }
             }
 

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -756,6 +756,11 @@ class ContentExtractorTest extends TestCase
                 '<div>' . str_repeat('this is the best part of the show', 10) . '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-toto-src="http://0.0.0.0/big_image.jpg"/></div>',
                 '<img src="http://0.0.0.0/big_image.jpg"',
             ],
+            // test with img attribute data-srcset
+            [
+                '<div>' . str_repeat('this is the best part of the show', 10) . '<img data-src="http://0.0.0.0/src.jpg" data-srcset="http://0.0.0.0/srcset1 680w, http://0.0.0.0/srcset2 1536w"/></div>',
+                '<img src="http://0.0.0.0/src.jpg" srcset="http://0.0.0.0/srcset1 680w, http://0.0.0.0/srcset2 1536w"/>',
+            ],
         ];
     }
 


### PR DESCRIPTION
The extractor was incorrectly setting the value of data-srcset into the
src attribute, however srcset does not use the same format leading to
loading error with incorrect paths. Now data-srcset sets the value of
srcset which will let the browser to use paths of either src or srcset
attributes.

This PR may require new tests to ensure non-regression.

Here is an example with `https://www.numerama.com/sciences/661291-covid-19-le-modele-emmental-montre-aussi-pourquoi-la-desinformation-est-si-grave.html`: 

```
<img class="size-large wp-image-661339" alt="" src="https://www.numerama.com/wp-content/uploads/2020/11/sgr-1935-2154-sursauts-radio-rapides-1024x576.jpg%201024w,%20https://www.numerama.com/content/uploads/2020/10/gestes_barrieres_emmental-680x383.jpg%20680w,%20https://www.numerama.com/content/uploads/2020/10/gestes_barrieres_emmental-1536x864.jpg%201536w,%20https://www.numerama.com/content/uploads/2020/10/gestes_barrieres_emmental.jpg%201920w" referrerpolicy="no-referrer" width="1024" height="576">
```

Fixes https://github.com/wallabag/wallabag/issues/4914