### PR TITLE
ContentExtractor: remove logic for wp img lazy loading

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -593,20 +593,6 @@ class ContentExtractor
                     continue;
                 }
 
-                // Custom case for WordPress plugin http://wordpress.org/extend/plugins/lazy-load/
-                // the plugin replaces the src attribute to point to a 1x1 gif and puts the original src
-                // inside the data-lazy-src attribute. It also places the original image inside a noscript element
-                // next to the amended one.
-                // @see https://plugins.trac.wordpress.org/browser/lazy-load/trunk/lazy-load.php
-                if (null !== $e->nextSibling && 'noscript' === $e->nextSibling->nodeName) {
-                    $newElem = $e->ownerDocument->createDocumentFragment();
-                    $newElem->appendXML($e->nextSibling->innerHTML);
-                    $e->nextSibling->parentNode->replaceChild($newElem, $e->nextSibling);
-                    $e->parentNode->removeChild($e);
-
-                    continue;
-                }
-
                 $attributes = [];
                 foreach ($this->config['src_lazy_load_attributes'] as $attribute) {
                     if ($e->hasAttribute($attribute)) {


### PR DESCRIPTION
I triggered a bug on a page with a wordpress image lazy loading system
based on noscript tags. In the case of this page, two noscript tags were
nested for the same image. The page fetch returned two different results
depending on the libxml version installed on the Debian and Alpine
systems I used for the test.

As far as we already have a logic to move data-lazy-* values in src and
srcset, I consider that the whole logic around the noscript tag is not
needed anymore.

The page used to trigger the bug: https://petapixel.com/2021/01/20/a-face-mask-can-double-as-a-flash-diffuser-for-better-portraits/

A HTML snippet of this page:

``` html
<p>
   <img loading="lazy" src="https://petapixel.com/assets/uploads/2021/01/maskback-800x701.jpg" alt width="800" height="701" class="aligncenter size-large wp-image-505005 jetpack-lazy-image" data-lazy-srcset="https://petapixel.com/assets/uploads/2021/01/maskback-800x701.jpg 800w, https://petapixel.com/assets/uploads/2021/01/maskback-320x281.jpg 320w, https://petapixel.com/assets/uploads/2021/01/maskback.jpg 1080w" data-lazy-sizes="(max-width: 800px) 100vw, 800px" data-lazy-src="http://petapixel.com/assets/uploads/2021/01/maskback-800x701.jpg?is-pending-load=1" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
   <noscript>
      <img loading="lazy"  alt="" width="800" height="701"  data-srcset="https://petapixel.com/assets/uploads/2021/01/maskback-800x701.jpg 800w, https://petapixel.com/assets/uploads/2021/01/maskback-320x281.jpg 320w, https://petapixel.com/assets/uploads/2021/01/maskback.jpg 1080w"  data-src="http://petapixel.com/assets/uploads/2021/01/maskback-800x701.jpg" data-sizes="(max-width: 800px) 100vw, 800px" class="aligncenter size-large wp-image-505005 lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
      <noscript>
         <img loading="lazy" src="http://petapixel.com/assets/uploads/2021/01/maskback-800x701.jpg" alt="" width="800" height="701" class="aligncenter size-large wp-image-505005" srcset="https://petapixel.com/assets/uploads/2021/01/maskback-800x701.jpg 800w, https://petapixel.com/assets/uploads/2021/01/maskback-320x281.jpg 320w, https://petapixel.com/assets/uploads/2021/01/maskback.jpg 1080w" sizes="(max-width: 800px) 100vw, 800px" />
      </noscript>
   </noscript>
</p>
```

This change was enough to fix the issue for this page.
However I'm not fully aware of all use cases for this lazy loading/noscript mechanism so maybe more discussion is needed to ensure that we don't break anything else.