### PR TITLE
HttpClient: refactor the way we clean utm_ query params

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.3"
+          - "7.4"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,11 +19,9 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.1"
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout"
@@ -104,7 +102,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.2"
+          - "7.4"
 
     steps:
       - name: "Checkout"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ That's why I made this fork:
 
 ### Requirements
 
-- PHP >= 7.1
+- PHP >= 7.4
 - [Tidy](https://github.com/htacg/tidy-html5) & cURL extensions enabled
 
 ### Installation

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,15 @@
-# UPGRADE FROM 1.x to 2.0
+# FROM 2.x to 3.0
+
+It should be easy if you didn't override or extend Graby.
+I tried to typehint everything (method parameters, method return, variable, etc.).
+
+So you must update methods you overriden.
+
+### :warning: BC changes
+
+- Support for PHP < 7.4 has been dropped
+
+# FROM 1.x to 2.0
 
 ### :warning: BC changes
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.4",
         "ext-curl": "*",
         "ext-tidy": "*",
         "fossar/htmlawed": "^1.2.7",
@@ -29,8 +29,8 @@
         "php-http/httplug": "^2.2",
         "php-http/message": "^1.9",
         "simplepie/simplepie": "^1.5",
-        "smalot/pdfparser": "^1.0",
-        "symfony/options-resolver": "^3.4|^4.4|^5.3",
+        "smalot/pdfparser": "^2.0",
+        "symfony/options-resolver": "^3.4|^4.4|^5.3|^6.0",
         "true/punycode": "^2.1"
     },
     "require-dev": {
@@ -39,10 +39,10 @@
         "php-http/guzzle6-adapter": "^2.0",
         "php-http/mock-client": "^1.4",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-deprecation-rules": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
-        "symfony/phpunit-bridge": "^5.3"
+        "phpstan/phpstan": "^1.2",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "symfony/phpunit-bridge": "^6.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "simplepie/simplepie": "^1.5",
         "smalot/pdfparser": "^2.0",
         "symfony/options-resolver": "^3.4|^4.4|^5.3|^6.0",
-        "true/punycode": "^2.1"
+        "true/punycode": "^2.1",
+        "guzzlehttp/psr7": "^1.5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,6 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "symfony/phpunit-bridge": "^6.0"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-2.0": "2.0-dev"
-        }
-    },
     "autoload": {
         "psr-4": {
             "Graby\\": "src/"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,15 +12,27 @@ parameters:
         -
             message: '#Http\\Adapter\\Guzzle5\\Client\\|Http\\Adapter\\Guzzle6\\Client\\|Http\\Client\\Curl\\Client given#'
             path: %currentWorkingDirectory%/tests/Extractor/HttpClientTest.php
-        # we don't want to BC by defining typehint everywhere
-        # TODO: remove when jumping to 3.0
-        -
-            message: '#typehint specified.#'
-            path: %currentWorkingDirectory%/src/
         # phpstan does not seem to recognize the class override for JSLikeHTMLElement
         -
             message: '#Call to an undefined method DOMElement::setInnerHtml\(\)#'
             path: %currentWorkingDirectory%/src/Extractor/ContentExtractor.php
+        -
+            message: '#\$innerHTML#'
+            path: %currentWorkingDirectory%
+        # can't find a way to cast or properly defined some return elements
+        -
+            message: '#DOMNode, object given#'
+            path: %currentWorkingDirectory%/src/Extractor/ContentExtractor.php
+        # other stuff I might have fucked up with DOM* classes
+        -
+            message: '#DOMNode::\$tagName#'
+            path: %currentWorkingDirectory%/src/
+        -
+            message: '#DOMNode::getElementsByTagName#'
+            path: %currentWorkingDirectory%/src/
+        -
+            message: '#expects DOMElement, DOMNode given#'
+            path: %currentWorkingDirectory%/src/Graby.php
 
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,11 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <!-- until all deps are compatible with PHP 8.1 -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
+
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -109,7 +109,7 @@ class HttpClient
         );
     }
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
@@ -282,12 +282,8 @@ class HttpClient
 
     /**
      * Cleanup URL and retrieve the final url to be called.
-     *
-     * @param string $url
-     *
-     * @return string
      */
-    private function cleanupUrl($url)
+    private function cleanupUrl(string $url): string
     {
         // rewrite part of urls to something more readable
         foreach ($this->config['rewrite_url'] as $find => $action) {
@@ -323,10 +319,8 @@ class HttpClient
      * by checking the extension.
      *
      * @param string $url Absolute url
-     *
-     * @return bool
      */
-    private function possibleUnsupportedType($url)
+    private function possibleUnsupportedType(string $url): bool
     {
         $ext = strtolower(trim(pathinfo($url, \PATHINFO_EXTENSION)));
 
@@ -344,10 +338,8 @@ class HttpClient
      *
      * @param string $url        Absolute url
      * @param array  $httpHeader Custom HTTP Headers from SiteConfig
-     *
-     * @return string
      */
-    private function getUserAgent($url, array $httpHeader = [])
+    private function getUserAgent(string $url, array $httpHeader = []): string
     {
         $ua = $this->config['ua_browser'];
 
@@ -392,10 +384,8 @@ class HttpClient
      *
      * @param string $url        Absolute url
      * @param array  $httpHeader Custom HTTP Headers from SiteConfig
-     *
-     * @return string
      */
-    private function getReferer($url, $httpHeader = [])
+    private function getReferer(string $url, array $httpHeader = []): string
     {
         $default_referer = $this->config['default_referer'];
 
@@ -418,10 +408,8 @@ class HttpClient
      *
      * @param string $url        Absolute url
      * @param array  $httpHeader Custom HTTP Headers from SiteConfig
-     *
-     * @return string|null
      */
-    private function getCookie($url, $httpHeader = [])
+    private function getCookie(string $url, array $httpHeader = []): ?string
     {
         if (!empty($httpHeader['cookie'])) {
             $this->logger->info('Found cookie "{cookie}" for url "{url}" from site config', ['cookie' => $httpHeader['cookie'], 'url' => $url]);
@@ -463,7 +451,7 @@ class HttpClient
      *
      * @return string|false
      */
-    private function getAccept($url, $httpHeader = [])
+    private function getAccept(string $url, array $httpHeader = [])
     {
         if (!empty($httpHeader['accept'])) {
             $this->logger->info('Found accept header "{accept}" for url "{url}" from site config', ['accept' => $httpHeader['accept'], 'url' => $url]);
@@ -481,10 +469,8 @@ class HttpClient
      * Since the request is now done we directly check the Content-Type header
      *
      * @param array $headers All headers from the request
-     *
-     * @return bool
      */
-    private function headerOnlyType(array $headers)
+    private function headerOnlyType(array $headers): bool
     {
         $contentType = isset($headers['content-type']) ? $headers['content-type'] : '';
 
@@ -512,7 +498,7 @@ class HttpClient
      *
      * @return false|string
      */
-    private function getMetaRefreshURL($url, $html)
+    private function getMetaRefreshURL(string $url, string $html)
     {
         if ('' === $html) {
             return false;
@@ -548,7 +534,7 @@ class HttpClient
      *
      * @return false|string
      */
-    private function getUglyURL($url, $html)
+    private function getUglyURL(string $url, string $html)
     {
         $found = false;
         foreach ($this->config['ajax_triggers'] as $string) {
@@ -577,10 +563,8 @@ class HttpClient
     /**
      * Format all headers to avoid unecessary array level.
      * Also lower the header name.
-     *
-     * @return array
      */
-    private function formatHeaders(ResponseInterface $response)
+    private function formatHeaders(ResponseInterface $response): array
     {
         $headers = [];
         foreach ($response->getHeaders() as $name => $value) {

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -263,7 +263,12 @@ class HttpClient
         }
 
         // remove utm parameters & fragment
-        $effectiveUrl = preg_replace('/((\?)?(&(amp;)?)?utm_(.*?)\=[^&]+)|(#(.*?)\=[^&]+)/', '', rawurldecode($effectiveUrl));
+        $uri = new Uri(str_replace('&amp;', '&', $effectiveUrl));
+        parse_str($uri->getQuery(), $query);
+        $queryParameters = array_filter($query, function ($k) {
+            return !(0 === stripos($k, 'utm_'));
+        }, \ARRAY_FILTER_USE_KEY);
+        $effectiveUrl = (string) Uri::withQueryValues(new Uri($uri->withFragment('')->withQuery('')), $queryParameters);
 
         $this->logger->info('Data fetched: {data}', ['data' => [
             'effective_url' => $effectiveUrl,

--- a/src/HttpClient/Plugin/CookiePlugin.php
+++ b/src/HttpClient/Plugin/CookiePlugin.php
@@ -95,7 +95,7 @@ class CookiePlugin implements Plugin
     {
         $parts = array_map('trim', explode(';', $setCookieHeader));
 
-        if (empty($parts) || !strpos($parts[0], '=')) {
+        if ('' === $parts[0] || false === strpos($parts[0], '=')) {
             return null;
         }
 

--- a/src/HttpClient/Plugin/History.php
+++ b/src/HttpClient/Plugin/History.php
@@ -18,29 +18,23 @@ class History implements Journal
      */
     private $lastResponse;
 
-    /**
-     * @return RequestInterface|null
-     */
-    public function getLastRequest()
+    public function getLastRequest(): ?RequestInterface
     {
         return $this->lastRequest;
     }
 
-    /**
-     * @return ResponseInterface|null
-     */
-    public function getLastResponse()
+    public function getLastResponse(): ?ResponseInterface
     {
         return $this->lastResponse;
     }
 
-    public function addSuccess(RequestInterface $request, ResponseInterface $response)
+    public function addSuccess(RequestInterface $request, ResponseInterface $response): void
     {
         $this->lastRequest = $request;
         $this->lastResponse = $response;
     }
 
-    public function addFailure(RequestInterface $request, ClientExceptionInterface $exception)
+    public function addFailure(RequestInterface $request, ClientExceptionInterface $exception): void
     {
     }
 }

--- a/src/Monolog/Handler/GrabyHandler.php
+++ b/src/Monolog/Handler/GrabyHandler.php
@@ -13,8 +13,8 @@ use Monolog\Processor\PsrLogMessageProcessor;
  */
 class GrabyHandler extends AbstractProcessingHandler
 {
-    protected $records = [];
-    protected $recordsByLevel = [];
+    protected array $records = [];
+    protected array $recordsByLevel = [];
 
     public function __construct($level = Logger::DEBUG, $bubble = true)
     {
@@ -24,18 +24,21 @@ class GrabyHandler extends AbstractProcessingHandler
         $this->pushProcessor(new PsrLogMessageProcessor());
     }
 
-    public function getRecords()
+    public function getRecords(): array
     {
         return $this->records;
     }
 
-    public function clear()
+    public function clear(): void
     {
         $this->records = [];
         $this->recordsByLevel = [];
     }
 
-    public function hasRecords($level)
+    /**
+     * @param string|int $level Logging level value or name
+     */
+    public function hasRecords($level): bool
     {
         return isset($this->recordsByLevel[$level]);
     }

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -11,12 +11,12 @@ class ConfigBuilder
 {
     /** @var LoggerInterface */
     private $logger;
-    private $config = [];
-    private $configFiles = [];
-    private $cache = [];
+    private array $config = [];
+    private array $configFiles = [];
+    private array $cache = [];
 
     // Array for accepted headers for http_header()
-    private $acceptedHeaders = [
+    private array $acceptedHeaders = [
         'user-agent',
         'referer',
         'cookie',
@@ -24,7 +24,7 @@ class ConfigBuilder
     ];
 
     // Array of accepted HTML tags for wrap_in()
-    private $acceptedWrapInTags = [
+    private array $acceptedWrapInTags = [
         'blockquote',
         'p',
         'div',
@@ -52,7 +52,7 @@ class ConfigBuilder
         $this->loadConfigFiles();
     }
 
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
@@ -64,7 +64,7 @@ class ConfigBuilder
      *     - If we add a new file after, it won't be loaded.
      *     - We'll need to manually reload config files.
      */
-    public function loadConfigFiles()
+    public function loadConfigFiles(): void
     {
         $this->configFiles = Files::getFiles($this->config['site_config']);
     }
@@ -75,7 +75,7 @@ class ConfigBuilder
      * @param string     $key    Key for the cache
      * @param SiteConfig $config Config to be cached
      */
-    public function addToCache($key, SiteConfig $config)
+    public function addToCache($key, SiteConfig $config): void
     {
         $key = strtolower($key);
         if ('www.' === substr($key, 0, 4)) {
@@ -419,20 +419,21 @@ class ConfigBuilder
      * @param SiteConfig $config    Current config
      * @param string     $condition XPath condition
      */
-    private function handleIfPageContainsCondition(SiteConfig $config, $condition)
+    private function handleIfPageContainsCondition(SiteConfig $config, string $condition): void
     {
+        $rule = false;
         if (!empty($config->single_page_link)) {
             $rule = 'single_page_link';
         } elseif (!empty($config->next_page_link)) {
             $rule = 'next_page_link';
-        } else {
-            // no link found, we can't apply "if_page_contains"
-            return;
         }
 
-        $key = end($config->$rule);
-        reset($config->$rule);
+        // no link found, we can't apply "if_page_contains"
+        if ($rule) {
+            $key = end($config->$rule);
+            reset($config->$rule);
 
-        $config->if_page_contains[$rule][$key] = (string) $condition;
+            $config->if_page_contains[$rule][$key] = (string) $condition;
+        }
     }
 }

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -163,10 +163,10 @@ class ContentExtractorTest extends TestCase
 
         $this->assertTrue($res, 'Extraction went well');
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
-        $this->assertStringContainsString('<iframe class="video"', $content_block->ownerDocument->saveXML($content_block));
-        $this->assertCount(1, $contentExtractor->getAuthors());
+        $this->assertStringContainsString('<iframe class="video"', (string) $contentBlock->ownerDocument->saveXML($contentBlock));
+        $this->assertCount(1, (array) $contentExtractor->getAuthors());
         $this->assertSame('CaTV', $contentExtractor->getAuthors()[0]);
     }
 
@@ -191,9 +191,9 @@ class ContentExtractorTest extends TestCase
 
         $this->assertTrue($res, 'Extraction went well');
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
-        $this->assertStringContainsString('<iframe src="">[embedded content]</iframe>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<iframe src="">[embedded content]</iframe>', (string) $contentBlock->ownerDocument->saveXML($contentBlock));
     }
 
     public function dataForNextPage(): array
@@ -375,7 +375,7 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->readability->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertStringNotContainsString($removedContent, $content);
+        $this->assertStringNotContainsString($removedContent, (string) $content);
     }
 
     public function dataForStripIdOrClass(): array
@@ -407,9 +407,9 @@ class ContentExtractorTest extends TestCase
         $content = $domElement->ownerDocument->saveXML($domElement);
 
         if (null === $removedContent) {
-            $this->assertStringContainsString((string) $matchContent, $content);
+            $this->assertStringContainsString((string) $matchContent, (string) $content);
         } else {
-            $this->assertStringNotContainsString($removedContent, $content);
+            $this->assertStringNotContainsString($removedContent, (string) $content);
         }
     }
 
@@ -442,7 +442,7 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->readability->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertStringNotContainsString($removedContent, $content);
+        $this->assertStringNotContainsString($removedContent, (string) $content);
     }
 
     public function dataForStripDisplayNoneAndInstapaper(): array
@@ -475,7 +475,7 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->readability->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertStringNotContainsString($removedContent, $content);
+        $this->assertStringNotContainsString($removedContent, (string) $content);
     }
 
     public function dataForStripAttr(): array
@@ -514,11 +514,11 @@ class ContentExtractorTest extends TestCase
         $content = $domElement->ownerDocument->saveXML($domElement);
 
         foreach ($assertions['removedContent'] as $removedContent) {
-            $this->assertStringNotContainsString($removedContent, $content);
+            $this->assertStringNotContainsString($removedContent, (string) $content);
         }
 
         foreach ($assertions['keptContent'] as $keptContent) {
-            $this->assertStringContainsString($keptContent, $content);
+            $this->assertStringContainsString($keptContent, (string) $content);
         }
     }
 
@@ -719,7 +719,7 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertStringNotContainsString('My Title', $content);
+        $this->assertStringNotContainsString('My Title', (string) $content);
         $this->assertSame('My Title', $contentExtractor->getTitle());
     }
 
@@ -793,7 +793,7 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertStringContainsString($htmlExpected, $content);
+        $this->assertStringContainsString($htmlExpected, (string) $content);
     }
 
     public function testIframeEmbeddedContent(): void
@@ -817,7 +817,7 @@ class ContentExtractorTest extends TestCase
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertStringContainsString('<iframe src="http://www.dailymotion.com/embed/video/x2kjh59" frameborder="0" width="534" height="320">[embedded content]</iframe>', $content);
+        $this->assertStringContainsString('<iframe src="http://www.dailymotion.com/embed/video/x2kjh59" frameborder="0" width="534" height="320">[embedded content]</iframe>', (string) $content);
     }
 
     public function testLogMessage(): void
@@ -847,7 +847,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame('Trying {pattern} for language', $records[4]['message']);
         $this->assertSame('Trying {pattern} for language', $records[5]['message']);
         $this->assertSame('Using Readability', $records[6]['message']);
-        $this->assertSame('Date is bad (strtotime failed): {date}', $records[7]['message']);
+        $this->assertSame('Date is bad (wrong year): {date}', $records[7]['message']);
         $this->assertSame('Attempting to parse HTML with {parser}', $records[9]['message']);
     }
 
@@ -916,8 +916,8 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $domElement = $contentExtractor->getContent();
         $content = $domElement->ownerDocument->saveXML($domElement);
 
-        $this->assertStringNotContainsString('<head>', $content);
-        $this->assertStringNotContainsString('<base>', $content);
+        $this->assertStringNotContainsString('<head>', (string) $content);
+        $this->assertStringNotContainsString('<base>', (string) $content);
     }
 
     public function testNativeAd(): void
@@ -931,10 +931,10 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
 
         $this->assertTrue($res, 'Extraction went well');
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
         $this->assertTrue($contentExtractor->isNativeAd());
-        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', (string) $contentBlock->ownerDocument->saveXML($contentBlock));
     }
 
     public function testJsonLd(): void
@@ -948,13 +948,13 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
 
         $this->assertTrue($res, 'Extraction went well');
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
         $this->assertSame('title !!', $contentExtractor->getTitle());
         $this->assertSame('2017-10-23T16:05:38+02:00', $contentExtractor->getDate());
-        $this->assertStringContainsString('bob', $contentExtractor->getAuthors()[0]);
+        $this->assertStringContainsString('bob', (string) $contentExtractor->getAuthors()[0]);
         $this->assertSame('https://static.jsonld.io/medias.jpg', $contentExtractor->getImage());
-        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', (string) $contentBlock->ownerDocument->saveXML($contentBlock));
     }
 
     public function testJsonLdWithMultipleAuthors(): void
@@ -966,7 +966,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
             'https://nativead.io/jsonld'
         );
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
         $this->assertSame([
             'Elisa Thevenet',
@@ -1006,13 +1006,13 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
 
         $this->assertTrue($res);
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
         $this->assertSame('title !!', $contentExtractor->getTitle());
         $this->assertSame('2017-10-23T17:04:21+00:00', $contentExtractor->getDate());
         $this->assertSame('fr_FR', $contentExtractor->getLanguage());
         $this->assertSame('https://static.opengraph.io/medias_11570.jpg', $contentExtractor->getImage());
-        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', (string) $contentBlock->ownerDocument->saveXML($contentBlock));
     }
 
     public function testAvoidDataUriImageInOpenGraph(): void
@@ -1026,10 +1026,10 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
 
         $this->assertTrue($res);
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
         $this->assertEmpty($contentExtractor->getImage());
-        $this->assertStringContainsString('<p>hihi</p>', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('<p>hihi</p>', (string) $contentBlock->ownerDocument->saveXML($contentBlock));
     }
 
     public function testJsonLdIgnoreList(): void
@@ -1044,7 +1044,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $this->assertTrue($res, 'Extraction went well');
 
         $this->assertSame('The Foobar Company is launching globally', $contentExtractor->getTitle());
-        $this->assertStringContainsString('Foobar CEO', $contentExtractor->getAuthors()[0]);
+        $this->assertStringContainsString('Foobar CEO', (string) $contentExtractor->getAuthors()[0]);
     }
 
     public function testJsonLdIgnoreListWithPeriodical(): void
@@ -1076,12 +1076,12 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
 
         $this->assertTrue($res, 'Extraction went well');
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
 
         $this->assertEmpty($contentExtractor->getTitle());
         $this->assertNull($contentExtractor->getDate());
         $this->assertEmpty($contentExtractor->getAuthors());
-        $this->assertStringContainsString('this is the best part of the show', $content_block->ownerDocument->saveXML($content_block));
+        $this->assertStringContainsString('this is the best part of the show', (string) $contentBlock->ownerDocument->saveXML($contentBlock));
     }
 
     public function testJsonLdName(): void
@@ -1133,7 +1133,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
             $url,
             $siteConfig
         );
-        $authors = $contentExtractor->getAuthors();
+        $authors = (array) $contentExtractor->getAuthors();
         $authorsUnique = array_unique($authors);
 
         $this->assertTrue(\count($authors) === \count($authorsUnique), 'There is no duplicate authors');
@@ -1209,9 +1209,9 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
 
         $this->assertTrue($res, 'Extraction went well');
 
-        $content_block = $contentExtractor->getContent();
+        $contentBlock = $contentExtractor->getContent();
         $doc = new \DOMDocument();
-        $doc->loadXML($content_block->innerHTML);
+        $doc->loadXML($contentBlock->innerHTML);
         $xpath = new \DOMXPath($doc);
 
         $el = $xpath->query($xpathQuery);

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -620,4 +620,36 @@ class HttpClientTest extends TestCase
             $this->assertArrayNotHasKey('accept', $records[3]['context']);
         }
     }
+
+    public function dataForWithUrlContainingQueryAndFragment(): array
+    {
+        return [
+            [
+                'url' => 'https://example.com/foo?utm_content=111315005&utm_medium=social&utm_source=twitter&hss_channel=tw-hello',
+                'expectedUrl' => 'https://example.com/foo?hss_channel=tw-hello',
+            ],
+            [
+                'url' => 'https://example.com/foo?hss_channel=tw-hello#fragment',
+                'expectedUrl' => 'https://example.com/foo?hss_channel=tw-hello',
+            ],
+            [
+                'url' => 'https://example.com/foo?utm_content=111315005',
+                'expectedUrl' => 'https://example.com/foo',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataForWithUrlContainingQueryAndFragment
+     */
+    public function testWithUrlContainingQueryAndFragment(string $url, string $expectedUrl): void
+    {
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new Response(200));
+
+        $http = new HttpClient($httpMockClient);
+        $res = $http->fetch($url);
+
+        $this->assertSame($expectedUrl, $res['effective_url']);
+    }
 }

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -220,7 +220,7 @@ class GrabyFunctionalTest extends TestCase
 
         $this->assertSame(200, $res['status']);
         $this->assertEmpty($res['language']);
-        $this->assertSame('https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml', $res['url']);
+        $this->assertSame('https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v%3Dtd0P8qrS8iI&format=xml', $res['url']);
         $this->assertSame('[Review] The Matrix Falling (Rain) Source Code C++', $res['title']);
         // $this->assertSame('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="allowfullscreen">[embedded content]</iframe>', $res['html']);
         $this->assertSame('[embedded content]', $res['summary']);

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -163,7 +163,7 @@ class GrabyFunctionalTest extends TestCase
         return [
             // ['http://pérotin.com/post/2015/08/31/Le-cadran-solaire-amoureux'],
             ['https://en.wikipedia.org/wiki/Café'],
-            ['http://www.atterres.org/article/budget-2016-les-10-méprises-libérales-du-gouvernement'],
+            // ['http://www.atterres.org/article/budget-2016-les-10-méprises-libérales-du-gouvernement'],
         ];
     }
 

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -403,7 +403,7 @@ class GrabyTest extends TestCase
     public function dataForSinglePage(): array
     {
         return [
-            'single_page_link will return a string (ie the text content of <a> node)' => ['singlepage1.com', 'http://singlepage1.com/printed view', 'http://moreintelligentlife.com/print/content'],
+            'single_page_link will return a string (ie the text content of <a> node)' => ['singlepage1.com', 'http://singlepage1.com/printed%20view', 'http://moreintelligentlife.com/print/content'],
             'single_page_link will return the a node' => ['singlepage2.com', 'http://singlepage2.com/print/content', 'http://singlepage2.com/print/content'],
             'single_page_link will return the href from a node' => ['singlepage3.com', 'http://singlepage3.com/print/content', 'http://singlepage3.com/print/content'],
             'single_page_link will return nothing useful' => ['singlepage4.com', 'http://singlepage4.com', 'http://singlepage4.com/print/content'],


### PR DESCRIPTION
The old `preg_replace` call incorrectly removed the `?` of the query string
section which could lead to things like this:

  `http://example.com/foo?utm_source=a&var=value` =>
`http://example.com/foo&var=value`