### PR TITLE
Add ability to process prefetched content

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ array(
 
 The `date` result is the same as displayed in the content. If `date` is not `null` in the result, we recommend you to parse it using [`date_parse`](http://php.net/date_parse) (this is what we are using to validate that the date is correct).
 
+### Retrieve content from a prefetched page
+
+If you want to extract content from a page you fetched outside of Graby, you can call `setContentAsPrefetched()` before calling `fetchContent()`, e.g.:
+
+``` php
+use Graby\Graby;
+
+$article = 'http://www.bbc.com/news/entertainment-arts-32547474';
+
+$input = '<html>[...]</html>';
+
+$graby = new Graby();
+$graby->setContentAsPrefetched($input);
+$result = $graby->fetchContent($article);
+```
+
 ### Cleanup content
 
 Since the 1.9.0 version, you can also send html content to be cleanup in the same way graby clean content retrieved from an url. The url is still needed to convert links to absolute, etc.

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -1342,6 +1342,23 @@ HTML
         $this->assertNotSame('No title found', $res['title']);
     }
 
+    public function testPrefetchedContent(): void
+    {
+        $httpMockClient = new HttpMockClient();
+        $graby = new Graby([
+            'debug' => true,
+        ], $httpMockClient);
+
+        $input = '<html><body><h1>This is my awesome article</h1><article><p>' . str_repeat('This is an awesome text with some links, here there are the awesome', 7) . '</p></article></body></html>';
+
+        $graby->setContentAsPrefetched($input);
+        $res = $graby->fetchContent('https://example.com/prefetched-content');
+
+        $this->assertSame('This is my awesome article', $res['title']);
+        $this->assertSame('https://example.com/prefetched-content', $res['url']);
+        $this->assertStringContainsString('here there are the awesome', $res['html']);
+    }
+
     /**
      * Return an instance of graby with a mocked Guzzle client returning data from a predefined file.
      */


### PR DESCRIPTION
fetchContent() now accepts an optional parameter, prefetchedContent, which
can contain the content of a page that was fetched outside of Graby.

If we take the example of Wallabag it gives the ability to send the
content of a page (_through a browser extension for example_) without
making network calls to fetch the actual page.