### PR TITLE
Fix PHP Error/Warnning

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -201,8 +201,8 @@ class ContentExtractor
         $this->readability = $this->getReadability($html, $url, $parser, $this->siteConfig->tidy() && $smartTidy);
         $tidied = $this->readability->tidied;
 
-        $this->logger->info('Body size after Readability: {length}', ['length' => \strlen((string) $this->readability->dom->saveXML())]);
-        $this->logger->debug('Body after Readability', ['dom_saveXML' => $this->readability->dom->saveXML()]);
+        $this->logger->info('Body size after Readability: {length}', ['length' => \strlen((string) $this->readability->dom->saveXML($this->readability->dom->documentElement))]);
+        $this->logger->debug('Body after Readability', ['dom_saveXML' => $this->readability->dom->saveXML($this->readability->dom->documentElement)]);
 
         // we use xpath to find elements in the given HTML document
         $this->xpath = new \DOMXPath($this->readability->dom);
@@ -373,11 +373,11 @@ class ContentExtractor
 
         $this->removeElements($elems, 'Stripping {length} empty a elements');
 
-        $this->logger->debug('DOM after site config stripping', ['dom_saveXML' => $this->readability->dom->saveXML()]);
+        $this->logger->debug('DOM after site config stripping', ['dom_saveXML' => $this->readability->dom->saveXML($this->readability->dom->documentElement)]);
 
         // try to get body
         foreach ($this->siteConfig->body as $pattern) {
-            $this->logger->info('Trying {pattern} for body (content length: {content_length})', ['pattern' => $pattern, 'content_length' => \strlen((string) $this->readability->dom->saveXML())]);
+            $this->logger->info('Trying {pattern} for body (content length: {content_length})', ['pattern' => $pattern, 'content_length' => \strlen((string) $this->readability->dom->saveXML($this->readability->dom->documentElement))]);
 
             $res = $this->extractBody(
                 true,

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -327,6 +327,15 @@ class ConfigBuilder
         //      find_string: <other-img
         //      replace_string: <img
         // To fix that issue, we combine find & replace as key & value in one array, we merge them and then rebuild find & replace string in the current config
+
+        // merge http_header array from currentConfig into newConfig
+        // because final values override former values in case of named keys
+        $currentConfig->http_header = array_merge($newConfig->http_header, $currentConfig->http_header);
+
+        if (\count($currentConfig->find_string) !== \count($currentConfig->replace_string)) {
+            return $currentConfig;
+        }
+
         $findReplaceCurrentConfig = array_combine($currentConfig->find_string, $currentConfig->replace_string);
         $findReplaceNewConfig = array_combine($newConfig->find_string, $newConfig->replace_string);
         $findReplaceMerged = array_merge((array) $findReplaceCurrentConfig, (array) $findReplaceNewConfig);
@@ -339,10 +348,6 @@ class ConfigBuilder
             $currentConfig->find_string[] = $findString;
             $currentConfig->replace_string[] = $replaceString;
         }
-
-        // merge http_header array from currentConfig into newConfig
-        // because final values override former values in case of named keys
-        $currentConfig->http_header = array_merge($newConfig->http_header, $currentConfig->http_header);
 
         return $currentConfig;
     }


### PR DESCRIPTION
- PHP Warning:  array_combine(): Both parameters should have an equal number

- PHP Warning:  DOMDocument::saveXML(): unknown encoding

- PHP Fatal error:  Uncaught TypeError: Typed property Graby\\Extractor\\ContentExtractor::$title must be string or null

issue - #278