### PR TITLE
Ensure empty value from `site_config` are kept

### DIFF
--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -320,6 +320,10 @@ class ConfigBuilder
             }
         }
 
+        // merge http_header array from currentConfig into newConfig
+        // because final values override former values in case of named keys
+        $currentConfig->http_header = array_merge($newConfig->http_header, $currentConfig->http_header);
+
         // Complex solution to ensure find_string & replace_string aren't duplicated when merging config multiple times
         // We can't perform an array_unique on these values mostly because replace_string can have same values, example:
         //      find_string: <amp-img
@@ -328,10 +332,7 @@ class ConfigBuilder
         //      replace_string: <img
         // To fix that issue, we combine find & replace as key & value in one array, we merge them and then rebuild find & replace string in the current config
 
-        // merge http_header array from currentConfig into newConfig
-        // because final values override former values in case of named keys
-        $currentConfig->http_header = array_merge($newConfig->http_header, $currentConfig->http_header);
-
+        // in case of bad configuration
         if (\count($currentConfig->find_string) !== \count($currentConfig->replace_string)) {
             return $currentConfig;
         }
@@ -378,7 +379,7 @@ class ConfigBuilder
 
             $val = trim($command[1]);
             $command = trim($command[0]);
-            if ('' === $command || '' === $val) {
+            if ('' === $command) {
                 continue;
             }
 

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -340,4 +340,36 @@ class GrabyFunctionalTest extends TestCase
         // if the cookie wasn't taking into account, it'll be "NPR Choice page"
         $this->assertSame('Michael Flynn\'s Contradictory Line On Russia', $res['title']);
     }
+
+    public function testSaveXmlUnknownEncoding(): void
+    {
+        $graby = new Graby([
+            'debug' => true,
+            'extractor' => [
+                'config_builder' => [
+                    'site_config' => [__DIR__ . '/fixtures/site_config'],
+                ],
+            ],
+        ]);
+        $res = $graby->fetchContent('http://motherjones.com/politics/2012/02/mac-mcclelland-free-online-shipping-warehouses-labor');
+
+        $this->assertCount(11, $res);
+        $this->assertSame(200, $res['status']);
+    }
+
+    public function testWithEmptyReplaceString(): void
+    {
+        $graby = new Graby([
+            'debug' => true,
+            'extractor' => [
+                'config_builder' => [
+                    'site_config' => [__DIR__ . '/fixtures/site_config'],
+                ],
+            ],
+        ]);
+        $res = $graby->fetchContent('https://www.presseportal.de/pm/103258/2930232');
+
+        $this->assertCount(11, $res);
+        $this->assertSame(200, $res['status']);
+    }
 }


### PR DESCRIPTION
For example, when user wants to replace a string with nothing, `replace_string:` will be used and shouldn't be skipped.
Also, adding more tests regarding [previous PR](https://github.com/j0k3r/graby/pull/279).