### PR TITLE
Ensure `find_string` & `replace_string` size are equal

### DIFF
--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -332,11 +332,6 @@ class ConfigBuilder
         //      replace_string: <img
         // To fix that issue, we combine find & replace as key & value in one array, we merge them and then rebuild find & replace string in the current config
 
-        // in case of bad configuration
-        if (\count($currentConfig->find_string) !== \count($currentConfig->replace_string)) {
-            return $currentConfig;
-        }
-
         $findReplaceCurrentConfig = array_combine($currentConfig->find_string, $currentConfig->replace_string);
         $findReplaceNewConfig = array_combine($newConfig->find_string, $newConfig->replace_string);
         $findReplaceMerged = array_merge((array) $findReplaceCurrentConfig, (array) $findReplaceNewConfig);
@@ -410,6 +405,14 @@ class ConfigBuilder
             } elseif ((')' === substr($command, -1)) && preg_match('!([a-z0-9_]+)\(([a-z]+)\)$!i', $command, $match) && 'wrap_in' === $match[1] && \in_array(strtolower($match[2]), $this->acceptedWrapInTags, true)) {
                 $config->wrap_in[strtolower(trim($match[2]))] = $val;
             }
+        }
+
+        // in case of bad configuration
+        if (\count($config->find_string) !== \count($config->replace_string)) {
+            $this->logger->warning('find_string & replace_string size mismatch, check the site config to fix it', ['find_string' => $config->find_string, 'replace_string' => $config->replace_string]);
+
+            $config->find_string = [];
+            $config->replace_string = [];
         }
 
         return $config;

--- a/tests/SiteConfig/ConfigBuilderTest.php
+++ b/tests/SiteConfig/ConfigBuilderTest.php
@@ -274,4 +274,26 @@ class ConfigBuilderTest extends TestCase
         $this->assertCount(2, $config4->find_string);
         $this->assertCount(2, $config4->replace_string);
     }
+
+    public function testCleanupFindReplaceString(): void
+    {
+        $logger = new Logger('foo');
+        $handler = new TestHandler();
+        $logger->pushHandler($handler);
+
+        $configBuilder = new ConfigBuilder(['site_config' => [__DIR__]]);
+        $configBuilder->setLogger($logger);
+
+        $configActual = $configBuilder->parseLines([
+            'find_string: src="/assets/img/highlight_ph.png"',
+        ]);
+
+        $this->assertCount(0, $configActual->find_string);
+        $this->assertCount(0, $configActual->replace_string);
+
+        $records = $handler->getRecords();
+
+        $this->assertSame('find_string & replace_string size mismatch, check the site config to fix it', $records[0]['message']);
+        $this->assertCount(2, $records[0]['context']);
+    }
 }


### PR DESCRIPTION
That validation is performed in `parseLines` so the size of them can't mismatch when merging configuration for example.
A warning log is raised in case of mismatch.

Following https://github.com/j0k3r/graby/pull/279#discussion_r780230930
Poke @jtojnar 