### PR TITLE
Graby: keep empty td and th elements

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -266,8 +266,8 @@ class Graby
         $re = '/^[ \t]*[\r\n]+/m';
         $htmlCleaned = preg_replace($re, '', $html);
 
-        // Remove empty nodes (except iframe)
-        $re = '/<(?!iframe)([^>\s]+)[^>]*>(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;|\s)*<\/\1>/m';
+        // Remove empty nodes (except iframe, td and th)
+        $re = '/<(?!iframe|td|th)([^>\s]+)[^>]*>(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;|\s)*<\/\1>/m';
         $html = preg_replace($re, '', (string) $htmlCleaned);
 
         // in case html string is too long, keep the html uncleaned to avoid empty html


### PR DESCRIPTION
Empty td and th must be kept to prevent any layout breakage, e.g.:

``` html
    <table>
      <tr>
        <td></td>
        <td>Header</td>
      </tr>
      <tr>
        <td>Foo</td>
        <td>Bar</td>
      </tr>
    </table>
```