### PR TITLE
Fix cookies on multiple page

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
     level: 7
     paths:
-        - maintenance/Rector
+        #- maintenance/Rector
         - src
         - tests
 
@@ -20,10 +20,6 @@ parameters:
         -
             message: '#\$innerHTML#'
             path: %currentWorkingDirectory%
-        # can't find a way to cast or properly defined some return elements
-        -
-            message: '#DOMNode, object given#'
-            path: %currentWorkingDirectory%/src/Extractor/ContentExtractor.php
         # other stuff I might have fucked up with DOM* classes
         -
             message: '#DOMNode::\$tagName#'

--- a/src/HttpClient/Plugin/CookiePlugin.php
+++ b/src/HttpClient/Plugin/CookiePlugin.php
@@ -34,7 +34,8 @@ class CookiePlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
-        $cookies = [];
+        // inject cookies previously defined (like when it's defined in site config)
+        $cookies = $request->getHeader('Cookie');
         foreach ($this->cookieJar->getCookies() as $cookie) {
             if ($cookie->isExpired()) {
                 continue;

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -358,6 +358,37 @@ class GrabyFunctionalTest extends TestCase
         $this->assertSame('Michael Flynn\'s Contradictory Line On Russia', $res['title']);
     }
 
+    public function testCookieOnMultiplePages(): void
+    {
+        // Rector: do not add mock client – we are testing if the cookie is set.
+        $graby = new Graby([
+            'debug' => true,
+            'extractor' => [
+                'config_builder' => [
+                    'site_config' => [__DIR__ . '/fixtures/site_config'],
+                ],
+            ],
+        ]);
+        $res = $graby->fetchContent('https://www.golem.de/news/app-entwicklung-cross-platform-oder-nativ-programmieren-2202-162600.html');
+
+        $this->assertCount(11, $res);
+
+        $this->assertArrayHasKey('status', $res);
+        $this->assertArrayHasKey('html', $res);
+        $this->assertArrayHasKey('title', $res);
+        $this->assertArrayHasKey('language', $res);
+        $this->assertArrayHasKey('date', $res);
+        $this->assertArrayHasKey('authors', $res);
+        $this->assertArrayHasKey('url', $res);
+        $this->assertArrayHasKey('summary', $res);
+        $this->assertArrayHasKey('image', $res);
+        $this->assertArrayHasKey('native_ad', $res);
+        $this->assertArrayHasKey('headers', $res);
+
+        $this->assertSame(200, $res['status']);
+        $this->assertStringNotContainsString('Golem.de mit Cookies', $res['html']);
+    }
+
     public function testSaveXmlUnknownEncoding(): void
     {
         $httpMockClient = new HttpMockClient();


### PR DESCRIPTION
It was the case for golem.de, the cookie wasn't properly send to the next page (might be a bug in the cookie jar not properly retrieving previous defined cookies).

Fix https://github.com/j0k3r/graby-site-config/issues/48