### PR TITLE
rector: Update for latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         }
     },
     "scripts": {
-        "rector": "vendor/bin/rector process -c maintenance/rector.config.php"
+        "rector": "vendor/bin/rector process -c maintenance/rector.php"
     },
     "config": {
         "sort-packages": true,

--- a/maintenance/rector.php
+++ b/maintenance/rector.php
@@ -3,19 +3,20 @@
 declare(strict_types=1);
 
 use Maintenance\Graby\Rector\MockGrabyResponseRector;
-use Rector\Core\Configuration\Option;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Set\ValueObject\LevelSetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_74);
+return static function (Rector\Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_74,
+    ]);
 
-    $services = $containerConfigurator->services();
-    $services->set(MockGrabyResponseRector::class);
+    // Breaks creating new files.
+    // https://github.com/rectorphp/rector/issues/7231
+    $rectorConfig->disableParallel();
 
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
+    $rectorConfig->rule(MockGrabyResponseRector::class);
+    $rectorConfig->paths([
         __DIR__ . '/../maintenance',
         __DIR__ . '/../src',
         __DIR__ . '/../tests',
@@ -24,14 +25,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $phpunitBridges = glob(__DIR__ . '/../vendor/bin/.phpunit/phpunit-*');
     $latestPhpunitBridge = end($phpunitBridges);
     assert(false !== $latestPhpunitBridge, 'There must be at least one PHPUnit version installed by Symfony PHPUnit bridge, please run `vendor/bin/simple-phpunit install`.');
-    $parameters->set(Option::BOOTSTRAP_FILES, [
+    $rectorConfig->bootstrapFiles([
         $latestPhpunitBridge . '/vendor/autoload.php',
     ]);
 
-    $parameters->set(Option::SKIP, [
+    $rectorConfig->skip([
         // nodeNameResolver requires string.
         StringClassNameToClassConstantRector::class => __DIR__ . '/Rector/**',
     ]);
 
-    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/../phpstan.neon');
+    $rectorConfig->phpstanConfig(__DIR__ . '/../phpstan.neon');
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,10 +20,6 @@ parameters:
         -
             message: '#\$innerHTML#'
             path: %currentWorkingDirectory%
-        # can't find a way to cast or properly defined some return elements
-        -
-            message: '#DOMNode, object given#'
-            path: %currentWorkingDirectory%/src/Extractor/ContentExtractor.php
         # other stuff I might have fucked up with DOM* classes
         -
             message: '#DOMNode::\$tagName#'


### PR DESCRIPTION
Currently broken for some reason:

If I revert the test fixtures, `composer rector` is no longer able to add them with Rector ≥ 0.13.1. It works with 0.13.0 and older. I do not see anything suspicious in the changes though https://github.com/rectorphp/rector-src/compare/0.13.0...0.13.1.

Opened https://github.com/rectorphp/rector/issues/7231.