### PR TITLE
[2.x] dependencies: allow installing guzzlehttp/psr7 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php-http/message": "^1.9",
         "simplepie/simplepie": "^1.5",
         "smalot/pdfparser": "^1.0",
-        "symfony/options-resolver": "^3.4|^4.4|^5.3",
+        "symfony/options-resolver": "^3.4|^4.4|^5.3|^6.0",
         "true/punycode": "^2.1",
         "guzzlehttp/psr7": "^1.5.0|^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "smalot/pdfparser": "^1.0",
         "symfony/options-resolver": "^3.4|^4.4|^5.3",
         "true/punycode": "^2.1",
-        "guzzlehttp/psr7": "^1.5.0"
+        "guzzlehttp/psr7": "^1.5.0|^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
This constraint was introduced in
https://github.com/j0k3r/graby/commit/d8f93d915e784fb130e9b4e520e66e66d117dbdf

This is required for selfoss to use the latest version after https://github.com/fossar/selfoss/pull/1392

Partly fixes https://github.com/j0k3r/graby/issues/298