### PR TITLE
ContentExtractor: Fix invalid argument type

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -713,12 +713,13 @@ class ContentExtractor
     /**
      * Validate and convert a date to the W3C format.
      *
-     * @param string $date
+     * @param string|null $date
      *
      * @return string|null Formatted date using the W3C format (Y-m-d\TH:i:sP) OR null if the date is badly formatted
      */
     public function validateDate($date)
     {
+        $date = (string) $date;
         $parseDate = (array) date_parse($date);
 
         // If no year has been found during date_parse, we nuke the whole value


### PR DESCRIPTION
This was tripping up selfoss:

	date_parse(): Passing null to parameter #1 ($datetime) of type string is deprecated
	[vendor/j0k3r/graby/src/Extractor/ContentExtractor.php:722]
	[vendor/j0k3r/graby/src/Extractor/ContentExtractor.php:722] date_parse()
	[vendor/j0k3r/graby/src/Extractor/ContentExtractor.php:541] Graby\Extractor\ContentExtractor->validateDate()
	[vendor/j0k3r/graby/src/Graby.php:374] Graby\Extractor\ContentExtractor->process()
	[vendor/j0k3r/graby/src/Graby.php:181] Graby\Graby->doFetchContent()
	[src/spouts/rss/fulltextrss.php:97] Graby\Graby->fetchContent()
	[src/spouts/rss/fulltextrss.php:74] spouts\rss\fulltextrss->getFullContent()
	[src/spouts/Item.php:117] spouts\rss\fulltextrss->spouts\rss\{closure}()
	[workbench.php:112] spouts\Item->getContent()
