### PR TITLE
ContentExtractor: clear image property on reset

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -60,6 +60,7 @@ class ContentExtractor
         $this->siteConfig = null;
         $this->title = null;
         $this->body = null;
+        $this->image = null;
         $this->nativeAd = false;
         $this->date = null;
         $this->language = null;


### PR DESCRIPTION
The property was introduced in https://github.com/j0k3r/graby/commit/b5d8ad48c7d01505c53c80382ccf11f2acb90148 without reset method being made aware of it.
As a result, Graby might have returned an image from a previous item, when the Graby instance is re-used (like Wallabag does).
Ideally, we would create a fresh ContentExtractor for each URL to preempt issues like this.
