### PR TITLE
Fix CS & upgrade GitHub Actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -33,7 +33,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: "Run PHP CS Fixer"
         run: "php vendor/bin/php-cs-fixer fix --verbose --dry-run --format=checkstyle | cs2pr"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -41,7 +41,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: "Setup logs"
         run: "mkdir -p build/logs"
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -76,7 +76,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: "Setup logs"
         run: "mkdir -p build/logs"
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -122,7 +122,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           dependency-versions: "lowest"
 
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -159,7 +159,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: "Setup adapter: Guzzle 5"
         run: |
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -199,7 +199,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: "Setup adapter: cURL"
         run: |
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -239,7 +239,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: "Setup logs"
         run: "mkdir -p build/logs"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php-http/discovery": "^1.14",
         "php-http/httplug": "^2.2",
         "php-http/message": "^1.12",
-        "simplepie/simplepie": "^1.5",
+        "simplepie/simplepie": "^1.8",
         "smalot/pdfparser": "^2.0",
         "symfony/options-resolver": "^3.4|^4.4|^5.3|^6.0",
         "symfony/polyfill-intl-idn": "^1.26"
@@ -62,7 +62,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         }
     }
 }

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -220,10 +220,7 @@ class HttpClient
         }
 
         // remove utm parameters & fragment
-        $uri = new Uri(str_replace('&amp;', '&', $effectiveUrl));
-        parse_str($uri->getQuery(), $query);
-        $queryParameters = array_filter($query, fn ($k) => !(0 === stripos((string) $k, 'utm_')), \ARRAY_FILTER_USE_KEY);
-        $effectiveUrl = (string) new Uri($uri->withFragment('')->withQuery(http_build_query($queryParameters)));
+        $effectiveUrl = (string) $this->removeTrackersFromUrl(new Uri(str_replace('&amp;', '&', $effectiveUrl)));
 
         $this->logger->info('Data fetched: {data}', ['data' => [
             'effective_url' => $effectiveUrl,
@@ -531,5 +528,39 @@ class HttpClient
         }
 
         return $headers;
+    }
+
+    /**
+     * Remove trackers from url.
+     *
+     * @author Jean Baptiste Favre
+     *
+     * @see https://github.com/fossar/selfoss/blob/0d7bde56e502f7d79bfb38dcdd657c7da89cf1f1/src/spouts/rss/fulltextrss.php#L120
+     */
+    private function removeTrackersFromUrl(Uri $uri): Uri
+    {
+        // Query string
+        $query = $uri->getQuery();
+        if ('' !== $query) {
+            $q_array = explode('&', $query);
+            // Remove utm_* parameters
+            $clean_query = array_filter(
+                $q_array,
+                function (string $param): bool {
+                    return !str_starts_with($param, 'utm_');
+                }
+            );
+            $uri = $uri->withQuery(implode('&', $clean_query));
+        }
+        // Fragment
+        $fragment = $uri->getFragment();
+        if ('' !== $fragment) {
+            // Remove xtor=RSS anchor
+            if (str_contains($fragment, 'xtor=RSS')) {
+                $uri = $uri->withFragment('');
+            }
+        }
+
+        return $uri;
     }
 }

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -222,8 +222,8 @@ class HttpClient
         // remove utm parameters & fragment
         $uri = new Uri(str_replace('&amp;', '&', $effectiveUrl));
         parse_str($uri->getQuery(), $query);
-        $queryParameters = array_filter($query, fn ($k) => !(0 === stripos($k, 'utm_')), \ARRAY_FILTER_USE_KEY);
-        $effectiveUrl = (string) Uri::withQueryValues(new Uri($uri->withFragment('')->withQuery('')), $queryParameters);
+        $queryParameters = array_filter($query, fn ($k) => !(0 === stripos((string) $k, 'utm_')), \ARRAY_FILTER_USE_KEY);
+        $effectiveUrl = (string) new Uri($uri->withFragment('')->withQuery(http_build_query($queryParameters)));
 
         $this->logger->info('Data fetched: {data}', ['data' => [
             'effective_url' => $effectiveUrl,

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -17,6 +17,7 @@ use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Readability\Readability;
+use SimplePie\Misc;
 use Smalot\PdfParser\Parser as PdfParser;
 
 /**
@@ -925,7 +926,7 @@ class Graby
             $encoding = $encoding ?: 'iso-8859-1';
             $this->logger->info('Converting to UTF-8', ['encoding' => $encoding]);
 
-            $converted = \SimplePie_Misc::change_encoding($html, $encoding, 'utf-8');
+            $converted = Misc::change_encoding($html, $encoding, 'utf-8');
 
             return false === $converted ? $html : (string) $converted;
         }

--- a/src/SiteConfig/ConfigBuilder.php
+++ b/src/SiteConfig/ConfigBuilder.php
@@ -191,6 +191,7 @@ class ConfigBuilder
      * @return false|SiteConfig
      *
      * @deprecated Use either buildForHost() / buildFromUrl() for the merged config or loadSiteConfig() to get the config for a site
+     *
      * @codeCoverageIgnore
      */
     public function build($host, $exactHostMatch = false)

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -625,8 +625,8 @@ class HttpClientTest extends TestCase
     {
         return [
             [
-                'url' => 'https://example.com/foo?utm_content=111315005&utm_medium=social&utm_source=twitter&hss_channel=tw-hello',
-                'expectedUrl' => 'https://example.com/foo?hss_channel=tw-hello',
+                'url' => 'https://example.com/foo?utm_content=111315005&utm_medium=social&utm_source=twitter&hss_channel=tw-hello&foo[]=bar&foo[]=qux',
+                'expectedUrl' => 'https://example.com/foo?hss_channel=tw-hello&foo%5B0%5D=bar&foo%5B1%5D=qux',
             ],
             [
                 'url' => 'https://example.com/foo?hss_channel=tw-hello#fragment',

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -626,7 +626,7 @@ class HttpClientTest extends TestCase
         return [
             [
                 'url' => 'https://example.com/foo?utm_content=111315005&utm_medium=social&utm_source=twitter&hss_channel=tw-hello&foo[]=bar&foo[]=qux',
-                'expectedUrl' => 'https://example.com/foo?hss_channel=tw-hello&foo%5B0%5D=bar&foo%5B1%5D=qux',
+                'expectedUrl' => 'https://example.com/foo?hss_channel=tw-hello&foo%5B%5D=bar&foo%5B%5D=qux',
             ],
             [
                 'url' => 'https://example.com/foo?hss_channel=tw-hello#fragment',

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -231,7 +231,7 @@ class GrabyFunctionalTest extends TestCase
 
         $this->assertSame(200, $res['status']);
         $this->assertEmpty($res['language']);
-        $this->assertSame('https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v%3Dtd0P8qrS8iI&format=xml', $res['url']);
+        $this->assertSame('https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dtd0P8qrS8iI&format=xml', $res['url']);
         $this->assertSame('[Review] The Matrix Falling (Rain) Source Code C++', $res['title']);
         // $this->assertSame('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="allowfullscreen">[embedded content]</iframe>', $res['html']);
         $this->assertSame('[embedded content]', $res['summary']);

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -231,7 +231,7 @@ class GrabyFunctionalTest extends TestCase
 
         $this->assertSame(200, $res['status']);
         $this->assertEmpty($res['language']);
-        $this->assertSame('https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Dtd0P8qrS8iI&format=xml', $res['url']);
+        $this->assertSame('https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=td0P8qrS8iI&format=xml', $res['url']);
         $this->assertSame('[Review] The Matrix Falling (Rain) Source Code C++', $res['title']);
         // $this->assertSame('<iframe id="video" width="480" height="270" src="https://www.youtube.com/embed/td0P8qrS8iI?feature=oembed" frameborder="0" allowfullscreen="allowfullscreen">[embedded content]</iframe>', $res['html']);
         $this->assertSame('[embedded content]', $res['summary']);

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -91,7 +91,7 @@ class GrabyTest extends TestCase
         if ($author) {
             $this->assertSame([$author], $res['authors']);
         } else {
-            $this->assertEmpty($res['authors'], 'authors not empty; got ' . $res['language']);
+            $this->assertEmpty($res['authors'], 'authors not empty; got ' . var_export($res['authors'], true));
         }
 
         $this->assertSame($parsedContent, $res['html'], 'Same html');
@@ -379,6 +379,7 @@ class GrabyTest extends TestCase
 
     /**
      * @group dns-sensitive
+     *
      * @dataProvider dataForSinglePage
      */
     public function testSinglePage(string $url, string $expectedUrl, string $singlePageUrl): void


### PR DESCRIPTION
Long time without an update and it requires an update. Also:
- use `http_build_query` to rebuild the query instead of `Uri::withQueryValues` because the array from the filter method might contains array and it's not supported (reported by PHPStan and validated with a new test)
- fix deprecating of `\SimplePie_Misc`

Replace https://github.com/j0k3r/graby/pull/308