### PR TITLE
Backport recent fixes

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -88,6 +88,7 @@ class ContentExtractor
         $this->siteConfig = null;
         $this->title = null;
         $this->body = null;
+        $this->image = null;
         $this->nativeAd = false;
         $this->date = null;
         $this->language = null;

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -957,11 +957,11 @@ class Graby
             $html_head = substr($html, 0, 50000);
             if (preg_match('/^<\?xml\s+version=(?:"[^"]*"|\'[^\']*\')\s+encoding=("[^"]*"|\'[^\']*\')/s', $html_head, $match)) {
                 $encoding = trim($match[1], '"\'');
-            } elseif (preg_match('/<meta\s+http-equiv=["\']?Content-Type["\']? content=["\'][^;]+;\s*charset=["\']?([^;"\'>]+)/i', $html_head, $match)) {
+            } elseif (preg_match('/<meta\s+http-equiv\s*=\s*["\']?Content-Type["\']? content\s*=\s*["\'][^;]+;\s*charset=["\']?([^;"\'>]+)/i', $html_head, $match)) {
                 $encoding = trim($match[1]);
             } elseif (preg_match_all('/<meta\s+([^>]+)>/i', $html_head, $match)) {
                 foreach ($match[1] as $_test) {
-                    if (preg_match('/charset=["\']?([^"\']+)/i', $_test, $_m)) {
+                    if (preg_match('/charset\s*=\s*["\']?([^"\']+)/i', $_test, $_m)) {
                         $encoding = trim($_m[1]);
                         break;
                     }


### PR DESCRIPTION
- ContentExtractor: clear image property on reset
- Graby::convert2Utf8: Allow spaces around HTML attributes
