### PR TITLE
PHPStan: use predictable phpunit path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         }
     },
     "scripts": {
+        "phpstan": "phpstan analyse --memory-limit 512M",
         "rector": "vendor/bin/rector process -c maintenance/rector.php"
     },
     "config": {

--- a/maintenance/Rector/MockGrabyResponseRector.php
+++ b/maintenance/Rector/MockGrabyResponseRector.php
@@ -218,6 +218,7 @@ CODE_SAMPLE
     {
         $currentStmt = $this->betterNodeFinder->resolveCurrentStatement($new);
         $scope = $currentStmt->getAttribute(AttributeKey::SCOPE);
+        \assert(null !== $scope); // For PHPStan.
 
         return new Variable($this->variableNaming->createCountedValueName('httpMockClient', $scope));
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
         - tests
 
     bootstrapFiles:
-        - vendor/bin/.phpunit/phpunit-8.5-0/vendor/autoload.php
+        - vendor/bin/.phpunit/phpunit/vendor/autoload.php
 
     ignoreErrors:
         # because we check for some HTTP client to exist or not (Guzzle 5/6 & cURL)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,4 +33,3 @@ parameters:
 
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -748,7 +748,7 @@ class ContentExtractor
     /**
      * Check if given node list exists and has length more than 0.
      *
-     * @param \DOMNodeList|false $elems Not force typed because it can also be false
+     * @param \DOMNodeList<\DOMNode>|false $elems Not force typed because it can also be false
      */
     private function hasElements($elems = false): bool
     {
@@ -762,8 +762,8 @@ class ContentExtractor
     /**
      * Remove elements.
      *
-     * @param \DOMNodeList|false $elems      Not force typed because it can also be false
-     * @param string             $logMessage
+     * @param \DOMNodeList<\DOMNode>|false $elems      Not force typed because it can also be false
+     * @param string                       $logMessage
      *
      * @return void|null
      */
@@ -793,8 +793,8 @@ class ContentExtractor
     /**
      * Wrap elements with provided tag.
      *
-     * @param \DOMNodeList|false $elems
-     * @param string             $logMessage
+     * @param \DOMNodeList<\DOMNode>|false $elems
+     * @param string                       $logMessage
      *
      * @return void|null
      */

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -725,6 +725,8 @@ class ContentExtractor
      * If a siteConfig is already set and no prepare site config is passed, this is a noop.
      *
      * @param SiteConfig $siteConfig Will avoid to recalculate the site config
+     *
+     * @phpstan-assert SiteConfig $this->siteConfig
      */
     private function prepareSiteConfig(string $html, string $url, ?SiteConfig $siteConfig = null): void
     {
@@ -810,7 +812,7 @@ class ContentExtractor
 
         $a = iterator_to_array($elems);
         foreach ($a as $item) {
-            if (null !== $item && null !== $item->parentNode && $item instanceof \DOMElement) {
+            if ($item instanceof \DOMElement && null !== $item->parentNode) {
                 /** @var \DOMDocument */
                 $ownerDocument = $item->ownerDocument;
                 $newNode = $ownerDocument->createElement($tag);

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -751,7 +751,7 @@ class Graby
      */
     private function makeAbsoluteAttr(string $base, \DOMNode $e, $attr): void
     {
-        if (!$e->attributes->getNamedItem($attr) || !$e instanceof \DOMElement) {
+        if (!$e instanceof \DOMElement || !$e->attributes->getNamedItem($attr)) {
             return;
         }
 

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -836,6 +836,7 @@ HTML
         $method->invokeArgs($graby, ['http://example.org', $e]);
 
         $this->assertSame('http://example.org/lol', $e->getAttribute('href'));
+        \assert($e->firstChild instanceof \DOMElement); // For PHPStan
         $this->assertNotNull($e->firstChild->attributes->getNamedItem('src'));
         $this->assertSame('http://example.org/path/to/image.jpg', $e->firstChild->attributes->getNamedItem('src')->nodeValue);
     }


### PR DESCRIPTION
phpunit-bridge also creates a stable symlink:
https://github.com/symfony/phpunit-bridge/commit/7421104e7b4286463353b0fa70f9b59ba3dda9df
