### PR TITLE
ContentExtractor: simplify validateDate

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -685,31 +685,21 @@ class ContentExtractor
     /**
      * Validate and convert a date to the W3C format.
      *
-     * @param string $date
-     *
      * @return string|null Formatted date using the W3C format (Y-m-d\TH:i:sP) OR null if the date is badly formatted
      */
     public function validateDate(?string $date): ?string
     {
-        $date = (string) $date;
-        $parseDate = (array) date_parse($date);
-
-        // If no year has been found during date_parse, we nuke the whole value
-        // because the date is invalid
-        if (null !== $date && false === $parseDate['year']) {
-            $this->logger->info('Date is bad (wrong year): {date}', ['date' => $date]);
-
+        if (null === $date) {
             return null;
         }
 
-        // in case the date can't be converted we assume it's a wrong date
-        if (null !== $date && 0 > strtotime($date) || false === strtotime($date)) {
-            $this->logger->info('Date is bad (strtotime failed): {date}', ['date' => $date]);
+        try {
+            return (new \DateTime($date))->format(\DateTime::W3C);
+        } catch (\Exception $exception) {
+            $this->logger->info('Cannot parse date: {date}', ['date' => $date]);
 
             return null;
         }
-
-        return (new \DateTime($date))->format(\DateTime::W3C);
     }
 
     protected function addAuthor(string $authorDirty): void

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -809,8 +809,7 @@ class ContentExtractorTest extends TestCase
         $this->assertSame('Trying {pattern} for language', $records[4]['message']);
         $this->assertSame('Trying {pattern} for language', $records[5]['message']);
         $this->assertSame('Using Readability', $records[6]['message']);
-        $this->assertSame('Date is bad (wrong year): {date}', $records[7]['message']);
-        $this->assertSame('Attempting to parse HTML with {parser}', $records[9]['message']);
+        $this->assertSame('Attempting to parse HTML with {parser}', $records[8]['message']);
     }
 
     public function testWithCustomFiltersForReadability(): void
@@ -1105,7 +1104,7 @@ secteurid=6;articleid=907;article_jour=19;article_mois=12;article_annee=2016;
         $contentExtractor = new ContentExtractor(self::$contentExtractorConfig);
 
         $res = $contentExtractor->process(
-            '   <meta property="article:published_time" content="-0001-11-30T00:00:00+00:00" /> <p>' . str_repeat('this is the best part of the show', 10) . '</p> ',
+            '   <meta property="article:published_time" content="-0001-11-304T00:00:00+00:00" /> <p>' . str_repeat('this is the best part of the show', 10) . '</p> ',
             'https://domattr.io/woops!'
         );
 


### PR DESCRIPTION
- Drop incorrect and redundant phpdoc param hint.
- Terminate early on null so that we can drop later casts and null checks.
- Drop extra date verification, we can just catch an Exception when DateTime constructor cannot parse the date.
  As a bonus, negative dates like `-0001-11-30T00:00:00+00:00` will be accepted.
