### PR TITLE
composer: Declare dependency on psr/http-client-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php-http/discovery": "^1.14",
         "php-http/httplug": "^2.2",
         "php-http/message": "^1.12",
+        "psr/http-client-implementation": "^1.0",
         "simplepie/simplepie": "^1.8",
         "smalot/pdfparser": "^2.0",
         "symfony/options-resolver": "^3.4|^4.4|^5.3|^6.0",

--- a/maintenance/Rector/Helpers/RecordingHttpClient.php
+++ b/maintenance/Rector/Helpers/RecordingHttpClient.php
@@ -2,21 +2,21 @@
 
 namespace Maintenance\Graby\Rector\Helpers;
 
-use Http\Client\HttpClient;
 use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class RecordingHttpClient implements HttpClient
+class RecordingHttpClient implements ClientInterface
 {
     /**
      * @var ResponseInterface[]
      */
     private array $responses;
 
-    private HttpClient $httpClient;
+    private ClientInterface $httpClient;
 
-    public function __construct(HttpClient $httpClient)
+    public function __construct(ClientInterface $httpClient)
     {
         $this->httpClient = $httpClient;
     }

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -13,8 +13,8 @@ use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\Exception\TransferException;
-use Http\Client\HttpClient as Client;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -31,9 +31,9 @@ class HttpClient
     private ?ContentExtractor $extractor;
 
     /**
-     * @param Client $client Http client
+     * @param ClientInterface $client Http client
      */
-    public function __construct(Client $client, array $config = [], LoggerInterface $logger = null, ContentExtractor $extractor = null)
+    public function __construct(ClientInterface $client, array $config = [], LoggerInterface $logger = null, ContentExtractor $extractor = null)
     {
         $this->config = new HttpClientConfig($config);
 

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -9,11 +9,11 @@ use Graby\SiteConfig\ConfigBuilder;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriResolver;
 use Http\Client\Common\PluginClient;
-use Http\Client\HttpClient as Client;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Message\CookieJar;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Readability\Readability;
@@ -35,7 +35,7 @@ class Graby
 
     private ?string $prefetchedContent = null;
 
-    public function __construct(array $config = [], Client $client = null, ConfigBuilder $configBuilder = null)
+    public function __construct(array $config = [], ?ClientInterface $client = null, ConfigBuilder $configBuilder = null)
     {
         $this->config = new GrabyConfig($config);
 


### PR DESCRIPTION
The `psr-http/client-implementation` dependency appears to have been accidentally removed in ac5d7387c8579c5c4352f40afa2419a0ed7e5d67, while still being used.

Let’s switch to its spiritual successor `psr-http/client-implementation`, which is backed by PSR-18, and correctly declare the dependency.
