### PR TITLE
Improve regex used to remove conditional comments in HTML

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -768,8 +768,7 @@ class ContentExtractor
     /**
      * Remove elements.
      *
-     * @param \DOMNodeList<\DOMNode>|false $elems      Not force typed because it can also be false
-     * @param string                       $logMessage
+     * @param \DOMNodeList<\DOMNode>|false $elems Not force typed because it can also be false
      */
     private function removeElements($elems = false, ?string $logMessage = null): void
     {
@@ -798,7 +797,6 @@ class ContentExtractor
      * Wrap elements with provided tag.
      *
      * @param \DOMNodeList<\DOMNode>|false $elems
-     * @param string                       $logMessage
      */
     private function wrapElements($elems = false, string $tag = 'div', ?string $logMessage = null): void
     {

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -179,27 +179,9 @@ class HttpClient
 
         $body = (string) $response->getBody();
 
-        // be sure to remove conditional comments for IE around the html tag
-        // we only remove conditional comments until we found the <head> tag
-        // they usually contains the <html> tag which we try to found and replace the last occurence
-        // with the whole conditional comments
-        preg_match('/^\<!--\[if(\X+)\<!\[endif\]--\>(\X+)\<head\>$/mi', $body, $matchesConditional);
-
-        if (\count($matchesConditional) > 1) {
-            preg_match_all('/\<html([\sa-z0-9\=\"\"\-:\/\.\#]+)\>$/mi', $matchesConditional[0], $matchesHtml);
-
-            if (\count($matchesHtml) > 1) {
-                $htmlTag = end($matchesHtml[0]);
-
-                if (!empty($htmlTag)) {
-                    $body = str_replace($matchesConditional[0], $htmlTag . '<head>', $body);
-                }
-            }
-        }
-
         // be sure to remove ALL other conditional comments for IE
-        // (regex found here: https://stackoverflow.com/a/137831/569101)
-        preg_match_all('/<!--\[if\s(?:[^<]+|<(?!!\[endif\]-->))*<!\[endif\]-->/mi', $body, $matchesConditional);
+        // (regex inspired from here: https://stackoverflow.com/a/55083809/954513)
+        preg_match_all('/<!--(?:\[| ?<!).+?-->/mis', $body, $matchesConditional);
 
         if (isset($matchesConditional[0]) && (is_countable($matchesConditional[0]) ? \count($matchesConditional[0]) : 0) > 1) {
             foreach ($matchesConditional as $conditionalComment) {

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -372,13 +372,29 @@ class HttpClientTest extends TestCase
                 'html' => '<!DOCTYPE html><html class="no-js"><head><meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"><meta charset="utf-8"><meta content="text/html" http-equiv="Content-Type"><meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"><link href="/favicon.ie9.ico" rel="Shortcut Icon" type="image/x-icon"/><link href="//cdn.cnn.com/cnn/.e/img/3.0/global/misc/apple-touch-icon.png" rel="apple-touch-icon" type="image/png"/><!--[if lte IE 9]><meta http-equiv="refresh" content="1;url=/2.85.0/static/unsupp.html" /><![endif]--><!--[if gt IE 9><!--><!--<![endif]--><title>New York police tout improving crime numbers to defend frisking policy  - CNN</title><meta content="us" name="section"><meta name="referrer" content="unsafe-url"><meta content="2012-05-13T21:22:42Z" property="og:pubdate"><meta content="2012-05-13T21:22:42Z" name="pubdate"><meta content="2012-05-14T02:34:10Z" name="lastmod"><meta content="https://www.cnn.com/2012/05/13/us/new-york-police-policy/index.html" property="og:url"><meta content="By the CNN Wire Staff" name="author">',
                 'removeData' => '<meta http-equiv="refresh" content="1;url=/2.85.0/static/unsupp.html" />',
             ],
+            'non-standard downlevel-revealed comment' => [
+                'url' => 'http://wallabag.org',
+                'html' => '<!DOCTYPE html>
+<html>
+   <body>
+      <!--[if mso]>
+      <img src="http://example.wallabag.org/hidden.jpg" alt="hidden image">
+      <![endif]-->
+      <!--[if !mso]><!-- -->
+      <img src="http://example.wallabag.org/shown.jpg" alt="shown image" />
+      <!-- <![endif]-->
+   </body>
+</html>',
+                'removeData' => 'hidden image',
+                'preserveData' => 'shown image',
+            ],
         ];
     }
 
     /**
      * @dataProvider dataForConditionalComments
      */
-    public function testWithMetaRefreshInConditionalComments(string $url, string $html, string $removeData): void
+    public function testWithMetaRefreshInConditionalComments(string $url, string $html, string $removeData, ?string $preserveData = null): void
     {
         $httpMockClient = new HttpMockClient();
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/html'], $html));
@@ -392,6 +408,9 @@ class HttpClientTest extends TestCase
         $this->assertStringNotContainsString('endif', (string) $res->getResponse()->getBody());
         $this->assertSame('text/html', $res->getResponse()->getHeaderLine('content-type'));
         $this->assertSame(200, $res->getResponse()->getStatusCode());
+        if (null !== $preserveData) {
+            $this->assertStringContainsString($preserveData, (string) $res->getResponse()->getBody());
+        }
     }
 
     public function dataForUserAgent(): array


### PR DESCRIPTION
From the test added by this commit, the previous regex incorrectly removed the shown.jpg image. The new regex now keeps what would be normally shown by a browser.

It should be noted that, according to regex101.com this instruction comes at a cost three times higher that before (~1,200 iterations in place of ~400)

Fixes https://github.com/wallabag/wallabag/issues/6828

**This must be backported into release/2.x for wallabag**