### PR TITLE
Add default values for parameters after optional parameters

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -887,7 +887,7 @@ class ContentExtractor
      *
      * @return bool Telling if we have to detect title again or not
      */
-    private function extractTitle(bool $detectTitle, string $cssClass, ?\DOMNode $node = null, string $logMessage): bool
+    private function extractTitle(bool $detectTitle, string $cssClass, ?\DOMNode $node = null, ?string $logMessage=null): bool
     {
         if (null === $node) {
             return true;
@@ -911,7 +911,7 @@ class ContentExtractor
      *
      * @return bool Telling if we have to detect date again or not
      */
-    private function extractDate(bool $detectDate, string $cssClass, ?\DOMNode $node = null, string $logMessage): bool
+    private function extractDate(bool $detectDate, string $cssClass, ?\DOMNode $node = null, ?string $logMessage=null): bool
     {
         if (null === $node) {
             return true;
@@ -982,7 +982,7 @@ class ContentExtractor
      *
      * @return bool Telling if we have to detect body again or not
      */
-    private function extractBody(bool $detectBody, string $xpathExpression, ?\DOMNode $node = null, string $type): bool
+    private function extractBody(bool $detectBody, string $xpathExpression, ?\DOMNode $node = null, ?string $type=null): bool
     {
         if (false === $detectBody || !$this->xpath) {
             return false;


### PR DESCRIPTION
Fixes #344

Not sure that $type can be null, but this at least gets rid of the deprecation errors.