### PR TITLE
tests: Fix pdf test after pdfparser 2.8.0 bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php-http/message": "^1.14",
         "psr/http-client-implementation": "^1.0",
         "simplepie/simplepie": "^1.8",
-        "smalot/pdfparser": "^2.0",
+        "smalot/pdfparser": "^2.8",
         "symfony/options-resolver": "^3.4|^4.4|^5.3|^6.4|^7.0",
         "symfony/polyfill-intl-idn": "^1.26",
         "symfony/polyfill-php80": "^1.27"

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -282,7 +282,7 @@ class GrabyTest extends TestCase
         $this->assertEmpty($res->getLanguage());
         $this->assertSame('Document1', $res->getTitle());
         $this->assertStringContainsString('Document title', $res->getHtml());
-        $this->assertStringContainsString('Morbi vulputate tincidunt ve nenatis.', $res->getHtml());
+        $this->assertStringContainsString('Morbi vulputate tincidunt venenatis.', $res->getHtml());
         $this->assertStringContainsString('http://example.com/test.pdf', (string) $res->getEffectiveResponse()->getEffectiveUri());
         $this->assertNotNull($res->getSummary());
         $this->assertStringContainsString('Document title Calibri : Lorem ipsum dolor sit amet', $res->getSummary());


### PR DESCRIPTION
Before 2.8.0 release, pdfparser added a space at roughly the 51th character,
incorrectly breaking some words:

    Verdana : Nullam hendrerit ante sed risus luctus el ementum. Morbi consectetur <br />\n
    et diam sed dignissim. Sed a erat metus. Mauris a u ltrices velit. Aenean laoreet <br />\n
    lectus nisi, tincidunt auctor nunc dictum at. Pelle ntesque at enim ac arcu mattis <br />\n
    pellentesque et et lectus. Pellentesque in augue ip sum. Vivamus sapien lorem, <br />\n
    semper auctor ligula sit amet, aliquam imperdiet mi . Maecenas in neque in tellus <br />\n
    sagittis feugiat ac non dolor. Ut adipiscing erat a c tortor fringilla, in lobortis orci <br />\n
    gravida. Praesent vulputate neque ac nibh elementum  tempor. Etiam tincidunt <br />\n
    aliquam libero, ut faucibus justo sodales sed. Aene an aliquam sodales nulla, vel <br />\n
    mollis leo blandit at. Morbi vulputate tincidunt ve nenatis.

Updating pdfparser fixed this so let’s update the test.
I have bisected it to https://github.com/smalot/pdfparser/commit/feaf39e73744953a0eabd9026ebe436d22e5f6ac

**Bumping smalot to ≥ 2.2.0 adds ext-iconv requirement.**