### PR TITLE
Update version j0k3r/php-readability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/psr7": "^2.0",
         "j0k3r/graby-site-config": "^1.0.181",
         "j0k3r/httplug-ssrf-plugin": "^2.0",
-        "j0k3r/php-readability": "^1.2.9",
+        "j0k3r/php-readability": "^2.0.4",
         "monolog/monolog": "^1.18.0|^2.3",
         "php-http/client-common": "^2.7",
         "php-http/discovery": "^1.19",


### PR DESCRIPTION
Upgrade j0k3r/php-readability version

It avoids the following error on project creation : 
`Fatal error: Declaration of Readability\Readability::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void`

Why ? In php-readability version 1.2.9 (or even 1.2.10) the function setLogger wasn't typed void, unlike Psr\Log\LoggerAwareInterface::setLogger, and that's the cause of the error