### PR TITLE
ContentExtractor: Fix encoding in JSON-LD

### DIFF
--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -1208,7 +1208,7 @@ class ContentExtractor
      *     - OpenGraph
      *     - JSON-LD.
      *
-     * @param string $html Html from the page
+     * @param string $html UTF-8-encoded HTML fragment of the page
      */
     private function extractDefinedInformation(string $html): void
     {
@@ -1219,7 +1219,7 @@ class ContentExtractor
         libxml_use_internal_errors(true);
 
         $doc = new \DOMDocument();
-        $doc->loadHTML($html);
+        $doc->loadHTML('<meta charset="utf-8">' . $html);
 
         libxml_use_internal_errors(false);
 

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -189,7 +189,7 @@ class Graby
     /**
      * Cleanup HTML from a DOMElement or a string.
      *
-     * @param string|\DOMElement $contentBlock
+     * @param string|\DOMElement $contentBlock a DOM element or UTF-8-encoded HTML fragment
      */
     public function cleanupHtml($contentBlock, UriInterface $url): string
     {

--- a/tests/GrabyFunctionalTest.php
+++ b/tests/GrabyFunctionalTest.php
@@ -267,4 +267,27 @@ class GrabyFunctionalTest extends TestCase
         $this->assertNotNull($res->getSummary());
         $this->assertSame(200, $res->getEffectiveResponse()->getResponse()->getStatusCode());
     }
+
+    // https://github.com/j0k3r/graby/issues/359
+    public function testExtractDefinedInformation(): void
+    {
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new Response(200, ['Content-Type' => ['text/html; charset=UTF-8'], 'Transfer-Encoding' => ['chunked'], 'Connection' => ['keep-alive'], 'Date' => ['Sun, 23 Feb 2025 23:19:48 GMT'], 'countrycode' => ['CZ'], 'Accept-Ranges' => ['bytes'], 'X-Frame-Options' => ['SAMEORIGIN'], 'Cache-Control' => ['no-cache, private'], 'Surrogate-Control' => ['content="ESI/1.0"'], 'Vary' => ['Accept-Encoding'], 'Strict-Transport-Security' => ['max-age=31536000; includeSubDomains; preload'], 'x-clientip' => ['89.177.205.85'], 'X-Cache' => ['Miss from cloudfront'], 'Via' => ['1.1 4614c36172b2854b1e1e94af37435c8e.cloudfront.net (CloudFront)'], 'X-Amz-Cf-Pop' => ['PRG50-C1'], 'X-Amz-Cf-Id' => ['SX6OzC1Nese_say0csdmfmPKp4ez2utzI3ePYATt_MZuJri_HJ1mEA==']], (string) file_get_contents(__DIR__ . '/fixtures/content/https___www.xataka.com_movilidad_coches-vendidos-2023-2024-espana.html')));
+        $graby = new Graby([
+            'debug' => true,
+            'extractor' => [
+                'config_builder' => [
+                    'site_config' => [__DIR__ . '/fixtures/site_config'],
+                ],
+            ],
+        ], $httpMockClient);
+        $res = $graby->fetchContent('https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana');
+
+        $this->assertNotNull($res->getSummary());
+        $this->assertStringContainsString(
+            'automóvil',
+            $res->getHtml(),
+            'JSON-LD processing must use UTF-8'
+        );
+    }
 }

--- a/tests/fixtures/content/https___www.xataka.com_movilidad_coches-vendidos-2023-2024-espana.html
+++ b/tests/fixtures/content/https___www.xataka.com_movilidad_coches-vendidos-2023-2024-espana.html
@@ -1,0 +1,1976 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <script>
+ var country = 'ES';
+ var isSpainOrLatamUser = true;
+</script>
+  <title>Los coches más vendidos en 2023 y 2024 en España</title>
+<script>
+ WSL2 = window.WSL2 || {};
+ WSL2.config = WSL2.config || {};
+ WSL2.config.title = "Los coches más vendidos en 2023 y 2024 en España";
+</script>
+ <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+ <meta name="description" content="El mercado del automóvil español quiere volver a tomar color y recuperar algo del pulso perdido desde la pandemia de coronavirus en lo que a ventas de...">
+ <script>WSL2.config.metaDescription = "El mercado del automóvil español quiere volver a tomar color y recuperar algo del pulso perdido desde la pandemia de coronavirus en lo que a ventas de..."</script>
+  <meta name="news_keywords" content="España, Coche eléctrico, Coche híbrido, Coches híbridos enchufables, Xataka Movilidad">
+ <meta property="fb:admins" content="100000716994885">
+<meta property="fb:pages" content="41267802635">
+<meta property="fb:app_id" content="355823546895">
+<meta name="application-name" content="Xataka">
+<meta name="msapplication-tooltip" content="Gadgets y tecnología: últimas tecnologías en electrónica de consumo - XATAKA">
+<meta name="msapplication-starturl" content="https://www.xataka.com">
+<meta name="mobile-web-app-capable" content="yes">
+                 <meta property="og:image" content="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/840_560.jpeg">
+      <meta property="og:title" content="Los coches más vendidos en 2023 y 2024 en España">
+  <meta property="og:description" content="El mercado del automóvil español quiere volver a tomar color y recuperar algo del pulso perdido desde la pandemia de coronavirus en lo que a ventas de...">
+  <meta property="og:url" content="https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana">
+  <meta property="og:type" content="article">
+  <meta property="og:updated_time" content="2025-01-08T16:15:39Z">
+    <meta name="DC.Creator" content="Alberto de la Torre">
+  <meta name="DC.Date" content="2024-03-18">
+  <meta name="DC.date.issued" content="2025-01-08T16:15:39Z">
+  <meta name="DC.Source" content="Xataka">
+  <meta property="article:modified_time" content="2025-01-08T16:15:39Z">
+  <meta property="article:published_time" content="2025-01-08T16:15:39Z">
+  <meta property="article:section" content="movilidad">
+  <meta name="robots" content="max-image-preview:large">
+     <meta property="article:tag" content="España">
+     <meta property="article:tag" content="Coche eléctrico">
+     <meta property="article:tag" content="Coche híbrido">
+     <meta property="article:tag" content="Coches híbridos enchufables">
+          <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/1366_521.jpeg"><meta name="twitter:site" content="@xataka"><meta name="twitter:title" content="Los coches más vendidos en 2023 y 2024 en España"><meta name="twitter:description" content="El mercado del automóvil español quiere volver a tomar color y recuperar algo del pulso perdido desde la pandemia de coronavirus en lo que a ventas de...">         <script>
+  window.dataLayer = [{"site":"XTK","siteSection":"postpage","vertical":"Technology","amp":"no","postId":298745,"postUrl":"https:\/\/www.xataka.com\/movilidad\/coches-vendidos-2023-2024-espana","publishedDate":"2024-03-18","modifiedDate":"2025-01-08T16:15","categories":"movilidad","tags":"espana,coche-electrico,coche-hibrido,coches-hibridos-enchufables","videoContent":false,"partner":false,"blockLength":13,"author":"alberto de la torre","postType":"normal","linksToEcommerce":"none","ecomPostExpiration":"everlasting","mainCategory":"movilidad","postExpiration":null,"wordCount":1084}];
+ window.dataLayer[0].visitor_country = country;
+ </script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-L3X96ZX03D"></script>
+<script>
+ window.dataLayer = window.dataLayer || [];
+ window.WSL2 = window.WSL2 || {};
+ window.WSL2.pageViewParams = {"site":"XTK","site_section":"postpage","vertical":"Technology","amp":"no","visitor_country":"CZ","content_id":298745,"post_url":"https:\/\/www.xataka.com\/movilidad\/coches-vendidos-2023-2024-espana","content_publication_date":"2024-03-18","modified_date":"2025-01-08T16:15","page_category":"movilidad","content_tags":"espana,coche-electrico,coche-hibrido,coches-hibridos-enchufables","has_video_content":false,"global_branded":false,"block_length":13,"content_author_id":"alberto de la torre","post_type":"normal","links_to_ecommerce":"none","ecompost_expiration":"everlasting","mainCategory":"movilidad","post_expiration":null,"word_count":1084};
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+ gtag('config', 'G-L3X96ZX03D', {
+  send_page_view: false
+ });
+ gtag('event', 'page_view', {"site":"XTK","site_section":"postpage","vertical":"Technology","amp":"no","visitor_country":"CZ","content_id":298745,"post_url":"https:\/\/www.xataka.com\/movilidad\/coches-vendidos-2023-2024-espana","content_publication_date":"2024-03-18","modified_date":"2025-01-08T16:15","page_category":"movilidad","content_tags":"espana,coche-electrico,coche-hibrido,coches-hibridos-enchufables","has_video_content":false,"global_branded":false,"block_length":13,"content_author_id":"alberto de la torre","post_type":"normal","links_to_ecommerce":"none","ecompost_expiration":"everlasting","mainCategory":"movilidad","post_expiration":null,"word_count":1084});
+ window.WSL2.gtag = gtag;
+</script>  <script>
+
+ var gdprAppliesGlobally = true;
+
+ (function() {
+  function n() {
+   if (!window.frames.__cmpLocator) {
+    if (document.body && document.body.firstChild) {
+     var e = document.body;
+     var t = document.createElement("iframe");
+     t.style.display = "none";
+     t.name = "__cmpLocator";
+     t.title = "cmpLocator";
+     e.insertBefore(t, e.firstChild)
+    } else {
+     setTimeout(n, 5)
+    }
+   }
+  }
+
+  function e(e, t, n) {
+   if (typeof n !== "function") {
+    return
+   }
+   if (!window.__cmpBuffer) {
+    window.__cmpBuffer = []
+   }
+   if (e === "ping") {
+    n({
+     gdprAppliesGlobally: window.gdprAppliesGlobally,
+     cmpLoaded: false
+    }, true)
+   } else {
+    window.__cmpBuffer.push({
+     command: e,
+     parameter: t,
+     callback: n
+    })
+   }
+  }
+  e.stub = true;
+
+  function t(r) {
+   if (!window.__cmp || window.__cmp.stub !== true) {
+    return
+   }
+   if (!r.data) {
+    return
+   }
+   var a = typeof r.data === "string";
+   var e;
+   try {
+    e = a ? JSON.parse(r.data) : r.data
+   } catch (t) {
+    return
+   }
+   if (e.__cmpCall) {
+    var o = e.__cmpCall;
+    window.__cmp(o.command, o.parameter, function(e, t) {
+     var n = {
+      __cmpReturn: {
+       returnValue: e,
+       success: t,
+       callId: o.callId
+      }
+     };
+     r.source.postMessage(a ? JSON.stringify(n) : n, "*")
+    })
+   }
+  }
+  if (typeof window.__cmp !== "function") {
+   window.__cmp = e;
+   if (window.addEventListener) {
+    window.addEventListener("message", t, false)
+   } else {
+    window.attachEvent("onmessage", t)
+   }
+  }
+  n()
+ })();
+
+
+ (function(e) {
+  var t = document.createElement("script");
+  t.id = "spcloader";
+  t.async = true;
+  t.src = "https://sdk.privacy-center.org/" + e + "/loader.js?target=" + document.location.hostname;
+  t.charset = "utf-8";
+  var n = document.getElementsByTagName("script")[0];
+  n.parentNode.insertBefore(t, n)
+ })("7bd10a97-724f-47b3-8e9f-867f0dea61c8");
+
+ function scrollListener(e) {
+  var o = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight || 0,
+   n = Math.max(document.body.scrollHeight || 0, document.documentElement.scrollHeight || 0, document.body.offsetHeight || 0, document.documentElement.offsetHeight || 0, document.body.clientHeight || 0, document.documentElement.clientHeight || 0);
+  30 <= (window.pageYOffset || document.body.scrollTop || document.documentElement.scrollTop || 0) / (n - o) * 100 && (Didomi.setUserAgreeToAll(), window.removeEventListener("scroll", scrollListener))
+ }
+
+ window.didomiOnReady = window.didomiOnReady || [], window.didomiOnReady.push(function(e) {
+  e.notice.isVisible() && window.addEventListener("scroll", scrollListener)
+ });
+
+</script>
+<script type="didomi/javascript">
+ if (!window.frames['__tcfapiLocator']) {
+  if (document.head) {
+   var head = document.head,
+   iframe = document.createElement('iframe');
+   iframe.style.cssText = 'display:none';
+   iframe.name = '__tcfapiLocator';
+   head.appendChild(iframe);
+  }
+ }
+</script><script>
+ window.WSL2 = window.WSL2 || {};
+ WSL2.config = WSL2.config || {};
+ WSL2.config.enableDidomiOverlay = 1;
+</script>
+
+                         
+
+  
+
+
+
+
+
+
+
+
+<script type="application/ld+json">
+ {"@context":"https:\/\/schema.org","@type":"Article","mainEntityOfPage":"https:\/\/www.xataka.com\/movilidad\/coches-vendidos-2023-2024-espana","name":"Los coches más vendidos en 2023 y 2024 en España","headline":"Los coches más vendidos en 2023 y 2024 en España","articlebody":"El mercado del automóvil español quiere volver a tomar color y recuperar algo del pulso perdido desde la pandemia de coronavirus en lo que a ventas de vehículos se refiere. En 2023, las matriculaciones en nuestro país sumaron un total de 949.359 vehículos, un 16,7% más que en 2022, según datos de Anfac, quienes aportan todos los datos que vienen a continuación. Si hablamos de 2024, el volumen de ventas creció hasta superar el año anterior. En España se vendieron 1.016.885 automóviles, un 7,11% más que en 2023, cuando se sumaron 949.359 vehículos. Pero, ¿cómo han sido estas ventas y cuáles fueron los vehículos más vendidos? ¿Cuáles lo fueron en 2023? Vamos a repasarlos. Los coches más vendidos en 2024 Si buscamos la fotografía general del mercado del automóvil en nuestro país, podemos comprobar que, en lo que va de año, el mercado está creciendo aunque en agosto el ritmo se ralentizó. En el último mes, el de diciembre, se mantiene el crecimiento ya adelantado en el resto del año. Se han matriculado 105.346 unidades por las 81.772 matrículas de 2023. Esto supone un crecimiento del 28,83% en las ventas El pasado mes de diciembre, los coches más vendidos (sumando todo tipo de tecnologías) fueron los siguientes: Toyota C-HR: 2.818 unidades Dacia Sandero: 2.780 unidades Tesla Model 3: 2.445 unidades Hyundai Tucson: 2.424 unidades Seat Ibiza: 2.192 unidades Si ampliamos el foco y miramos al acumulado del año, los coches más vendidos entre enero y diciembre de 2024 son los siguientes: Dacia Sandero: 32.994 unidades Toyota Corolla: 22.129 unidades Seat Ibiza: 22.021 unidades Hyundai Tucson: 21.595 unidades MG ZS: 20.386 unidades Los coches eléctricos más vendidos en 2024 En cuanto a diseccionar los vehículos por tecnologías, si miramos a los coches eléctricos nos encontramos que, durante el pasado mes de diciembre, se matricularon 8.818 unidades en España. Es un 49,56% más que en 2023.&amp;nbsp; En 2024, en España se han matriculado 57.374 coches eléctricos, lo que supone un aumento del 11,17% en comparación al mismo periodo de 2023. La cuota de mercado ha quedado en un 5,64% del peso total de las matriculaciones españolas. Los coches eléctricos más vendidos del mes de diciembre de 2024 fueron: Tesla Model 3: 2.445 unidades Tesla Model Y: 761 unidades Kia EV3: 518 unidades MINI Mini: 334 unidades BYD Dolphin: 306 unidades En 2024, en el acumulado, los coches eléctricos más vendidos son: Tesla Model 3: 11.043 unidades Tesla Model Y: 5.495 unidades MG4 Electric: 2.668 unidades Volvo EX30: 2.358 unidades BMW iX1: 1.807 unidades Los coches híbridos enchufables más vendidos en 2024 En lo que a híbridos enchufables, en diciembre de 2024 se han vendido 6.306 unidades de este tipo de automóviles, un descenso del 3,67% respecto al mismo mes de 2023. En el total del año, la caída ha sido de un 5,80%, con 58.558 unidades. La cuota de mercado queda en un 5,75% del total de las ventas. Los coches híbridos enchufables más vendidos del mes de diciembre de 2024 fueron: BMW X1: 528 unidades BYD Seal U: 524 unidades Mercedes GLC: 423 unidades MG EHS: 414 unidades Toyota C-HR: 352 unidades En el acumulado de 2024, los coches híbridos enchufables más vendidos son: Mercedes GLC: 4.988 unidades Ford Kuga: 3.457 unidades Cupra Formentor: 3.194 unidades Mercedes GLA: 2.734 unidades Hyundai Tucson: 2.248 unidades En Xataka Los coches híbridos enchufables más baratos que se pueden comprar (2024) Los coches híbridos más vendidos en 2024 Dejando atrás a los coches enchufables, los híbridos también están experimentando un importante crecimiento entre los vehículos más vendidos en nuestro país. Hay que tener en cuenta que en los vehículos híbridos también se cuentan los microhíbridos de 48 voltios. En lo que se refiere al mes de diciembre de 2024, los coches híbridos vendieron 45.180 unidades, muy por encima del mismo mes de 2023. Las matriculaciones han experimentado un crecimiento del 61,78%. Si miramos al global del año, en España se matricularon en 2024 un total de 392.365 automóviles híbridos. Es una cuota de mercado del 38,58%, superano las cifras de la gasolina (37,24%). El crecimiento fue del 29,50% respecto a 2023, cuando se matricularon 302.988 automóviles. Los coches híbridos más vendidos del mes de septiembre de 2024 fueron: Toyota C-HR: 2.466 unidades Toyota Yaris Cross: 1.764 unidades Nissan Qashqai: 1.728 unidades Dacia Duster: 1.686 unidades Hyundai Tucson: 1.544 unidades En el acumulado, los coches híbridos más vendidos son: Toyota Corolla: 22.129 unidades Toyota Yaris Cross: 18.335 unidades Nissan Qashqai: 18.067 unidades Toyota C-HR: 16.426 unidades Kia Sportage: 13.112 unidades Los coches más vendidos en 2023 Si echamos la vista atrás para ver qué sucedió en 2023, encontramos que en España se vendieron 949.359 automóviles. Esta cifra, aunque lejos de los mejores datos de nuestro país, fueron un 16,7% superiores a los de 2022, cuando se vendieron 813.376 automóviles. Por tecnologías, el coche eléctrico vendió un 69,10% más que en 2022, sumando un total de &amp;nbsp;51.612 matriculaciones que representaron el 5,44% de cuota de mercado. Los híbridos enchufables vendieron 60.446 unidades, con una cuota de mercado del 6,37%. Su crecimiento fue del 32,38%. En cuanto a los híbridos, en total se creció un 26,36%, representado en 302.845 unidades matriculadas y una cuota de mercado del 31,90%. Los coches más vendidos de 2023 (todas las tecnologías): Dacia Sandero: 27.951 unidades Seat Arona: 21.639 unidades Toyota Corolla: 19.845 unidades MG ZS: 19.818 unidades Peugeot 2008: 19.433 unidades Los coches eléctricos más vendidos de 2023: Tesla Model Y: 6.833 unidades Tesla Model 3: 6.116 unidades MG4 Electric: 3.094 unidades Fiat 500: 2.022 unidades Dacia Spring: 2.013 unidades Los coches híbridos enchufables más vendidos de 2023: Ford Kuga: 4.088 unidades LYNK &amp;amp; CO 01: 3.930 unidades Kia Sportage: 2.526 unidades Peugeot 3008: 2.480 unidades Mercedes GLC: 2.193 unidades Los coches híbridos más vendidos de 2023: Toyota Corolla: 19.845 unidades Toyota C-HR: 18.478 unidades Nissan Qashqai: 15.908 unidades Toyota Yaris Cross: 15.514 unidades Fiat 500: 13.855 unidades Imagen | Dacia, Tesla y Mercedes En Xataka | Qué son los coches de kilómetro 0 y en qué casos pueden ser una buena opción","datePublished":"2025-01-08T16:15:39Z","dateModified":"2025-01-08T16:15:39Z","description":"El mercado del automóvil español quiere volver a tomar color y recuperar algo del pulso perdido desde la pandemia de coronavirus en lo que a ventas de...","publisher":{"@type":"Organization","name":"Xataka Movilidad","url":"https:\/\/www.xataka.com","sameAs":["https:\/\/x.com\/xataka","https:\/\/www.facebook.com\/Xataka","https:\/\/www.youtube.com\/user\/xatakatv","https:\/\/instagram.com\/xataka","https:\/\/www.linkedin.com\/company\/11275845\/"],"logo":{"@type":"ImageObject","url":"https:\/\/i.blogs.es\/683919\/logo-horizontal.png","width":600,"height":60},"Parentorganization":"Webedia"},"image":{"@type":"ImageObject","url":"https:\/\/i.blogs.es\/651d87\/dacia-sandero-2021-1600-06\/1366_2000.jpeg","width":"1200","height":"900"},"author":{"@type":"Person","Jobtitle":"Editor - Xataka Movilidad","name":"Alberto de la Torre","url":"https:\/\/www.xataka.com\/autor\/alberto-de-la-torre"},"url":"https:\/\/www.xataka.com\/movilidad\/coches-vendidos-2023-2024-espana","thumbnailUrl":"https:\/\/i.blogs.es\/651d87\/dacia-sandero-2021-1600-06\/1366_2000.jpeg","articleSection":"Xataka Movilidad","creator":"Alberto de la Torre","keywords":"España, Coche eléctrico, Coche híbrido, Coches híbridos enchufables, Xataka Movilidad"}
+</script>
+   <link rel="preconnect" href="https://i.blogs.es">
+<link rel="shortcut icon" href="https://img.weblogssl.com/css/xataka/p/common/favicon.ico" type="image/ico">
+<link rel="apple-touch-icon" href="https://img.weblogssl.com/css/xataka/p/common/apple-touch-icon.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://img.weblogssl.com/css/xataka/p/common/apple-touch-icon-144-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://img.weblogssl.com/css/xataka/p/common/apple-touch-icon-114-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://img.weblogssl.com/css/xataka/p/common/apple-touch-icon-72-precomposed.png">
+<link rel="apple-touch-icon-precomposed" href="https://img.weblogssl.com/css/xataka/p/common/apple-touch-icon-57-precomposed.png">
+ <link rel="preconnect" href="https://static.criteo.net/" crossorigin>
+ <link rel="dns-prefetch" href="https://static.criteo.net/">
+ <link rel="preconnect" href="https://ib.adnxs.com/" crossorigin>
+ <link rel="dns-prefetch" href="https://ib.adnxs.com/">
+ <link rel="preconnect" href="https://bidder.criteo.com/" crossorigin>
+ <link rel="dns-prefetch" href="https://bidder.criteo.com/">
+   <link rel="preload" as="image" fetchpriority="high" type="image/jpeg" href="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/500_333.jpeg" media="(max-width: 500px)">
+  <link rel="preload" as="image" fetchpriority="high" type="image/jpeg" href="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/840_560.jpeg" media="(min-width: 501px) and (max-width: 1199px)">
+  <link rel="preload" as="image" fetchpriority="high" type="image/jpeg" href="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/1200_800.jpeg" media="(min-width: 1200px)">
+ <link rel="preload" as="style" href="https://img.weblogssl.com/css/xataka/p/xataka-d/main.css?v=1739964634">
+   <link rel="alternate" type="application/rss+xml" title="Xataka - todas las noticias" href="/index.xml">
+   <link rel="image_src" href="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/75_75.jpeg">
+      <link rel="canonical" href="https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana">
+   
+    <link rel="preload" href="https://img.weblogssl.com/g/r/fonts/tofino_regular-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+  <link rel="preload stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,400;0,700;1,400;1,700&amp;display=swap" as="style" type="text/css" crossorigin="anonymous">
+   <link rel="amphtml" href="https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana/amp" >
+  <link rel="stylesheet" type="text/css" href="https://img.weblogssl.com/css/xataka/p/xataka-d/main.css?v=1739964634">
+   <style>
+   .masthead-nano-logo a {
+   color: #ebfffe; /* Color del logo , RRSS y VIPlinks */
+  }
+
+  .masthead-nano-nav-container .masthead-nav-topics-anchor,
+  .masthead-nano-nav-container .masthead-nav-social-anchor {
+   color: #ebfffe; /* Color del logo , RRSS y VIPlinks */
+  }
+
+  .masthead-nano-container {
+   background: #080f07; /* Color del fondo de la cabecera */
+  }
+
+  .masthead-nano-nav-container {
+   background: #080f07; /* Color del fondo de la cabecera */
+  }
+  .masthead-nano-nav-container:after {
+   background: linear-gradient(to right, #080f0700, #080f07); /* Color del fondo de la cabecera */
+  }
+  .masthead-nano-nav {
+    border-top-color: #263624;
+  }
+   .masthead-nano-container .masthead-nano-logo a {
+  background-image: url("https\3A \2F \2F i\2E blogs\2E es\2F 683919/headboard-edge.svg");  /* nanomedios logo image */
+ }
+  
+ .masthead-nano-container .masthead-nano-logo {
+    width: 220px; /* Tamaño mínimo del logo Anchura  */
+    height: 48px; /* Tamaño mínimo del logo Altura  */
+}
+@media only screen and (min-width: 768px) {
+     .masthead-nano-container .masthead-nano-logo {
+        width: 257px; /* Tamaño máximo del logo Anchura  */
+        height: 56px; /* Tamaño máximo del logo Altura  */
+    }
+}
+  
+</style>     </head>
+<body class="js-desktop  prod js-body m-category-nanomedia ">
+       <script type="didomi/javascript">
+     function sendcomscore() {
+
+ var s = document.createElement("script"),
+ el = document.getElementsByTagName("script")[0];
+ s.setAttribute("data-vendor", "iab:77");
+ s.text = 'var cs_ucfr = ""; \
+ if (Didomi.getUserStatusForVendor(77)) { \
+  var cs_ucfr = "1"; \
+ } else if (Didomi.getUserStatusForVendor(77) == false) { \
+  var cs_ucfr = "0"; \
+ } \
+ \
+ var _comscore = _comscore || []; \
+ var configs = { \
+  c1: "2", \
+  c2: "6035191", \
+  cs_ucfr: cs_ucfr \
+ }; \
+ var keyword = keyword || ""; \
+ if (keyword) { \
+  configs.options = { \
+   url_append: "comscorekw=" + keyword \
+  }; \
+ } \
+ _comscore.push(configs); \
+ var s = document.createElement("script"), \
+ el = document.getElementsByTagName("script")[0]; \
+ \
+ s.src = "https://sb.scorecardresearch.com/cs/6035191/beacon.js"; \
+ \
+ window.didomiEventListeners = []; \
+ \
+ el.parentNode.insertBefore(s, el);';
+ el.parentNode.insertBefore(s, el);
+}
+
+if(Didomi.getUserStatusForVendor(77) == undefined){
+
+ window.didomiEventListeners = window.didomiEventListeners || [];
+ window.didomiEventListeners.push({
+  event: 'consent.changed',
+  listener: function(context) {
+
+  sendcomscore()
+  }
+ });
+} else {
+ sendcomscore()
+}   </script>
+
+<script>
+ dataLayer.push({
+  contentGroup1: "post",
+  contentGroup2: "alberto de la torre",
+  contentGroup3: "movilidad",
+  contentGroup4: "normal",
+  contentGroup5: "240318",
+ });
+</script>
+ <div id="publicidad"></div>
+<script>
+ function hash(string) {
+  const utf8 = new TextEncoder().encode(string);
+  return crypto.subtle.digest('SHA-256', utf8).then((hashBuffer) => {
+   const hashArray = Array.from(new Uint8Array(hashBuffer));
+   const hashHex = hashArray
+    .map((bytes) => bytes.toString(16).padStart(2, '0'))
+    .join('');
+   return hashHex;
+  });
+ }
+ const populateHashedEmail = () => {
+  const loggedin = WSL2.User.isUserLoggedIn();
+  if (loggedin) {
+   const userEmail = WSL2.User.getUserEmail();
+   hash(userEmail).
+    then((hashedEmail) => {
+     jad.config.publisher.hashedId = {
+      sha256email: hashedEmail,
+     };
+    });
+  }   
+ }
+ WSL2.config.enablePerformanceImprovements = "0";
+ window.hasAdblocker = getComputedStyle(document.querySelector('#publicidad')).display === 'none';
+                        WSL2.config.dynamicIU = "/1018282/xataka/postpage";
+  window.jad = window.jad || {};
+ jad.cmd = jad.cmd || [];
+ let swrap = document.createElement("script");
+ if ('1' === WSL2.config.enablePerformanceImprovements) {
+  swrap.defer = true;
+ }
+ else {
+  swrap.async = true;
+ }
+
+ const jadTargetingData = {"site":"XTK","siteSection":"postpage","vertical":"Technology","amp":"no","visitor_country":"CZ","postId":298745,"postUrl":"https:\/\/www.xataka.com\/movilidad\/coches-vendidos-2023-2024-espana","publishedDate":"2024-03-18","modifiedDate":"2025-01-08T16:15","categories":"movilidad","tags":"espana,coche-electrico,coche-hibrido,coches-hibridos-enchufables","videoContent":false,"partner":false,"blockLength":13,"author":"alberto de la torre","postType":"normal","linksToEcommerce":"none","ecomPostExpiration":"everlasting","mainCategory":"movilidad","postExpiration":null,"wordCount":1084};
+   {
+   const postCreationDate = 1710781620
+   const currentDate = new Date();
+   const currentTimestamp = currentDate.getTime();
+   const postTimeStamp = new Date(postCreationDate*1000).getTime();
+   const sixDaysMilliseconds = 6 * 60 * 24 * 60 * 1000;
+   jadTargetingData["recency"] = currentTimestamp - postTimeStamp > sixDaysMilliseconds ? 'old' : 'new';
+   const currentHour = (currentDate.getUTCHours() + 2) % 24;
+   jadTargetingData["hour"] = String(currentHour).length == 1 ? '0' + currentHour : currentHour;
+  }
+ 
+ let upv = +sessionStorage.getItem("upv");
+ if (upv) {
+  upv += 1;
+ } else {
+  upv = 1;
+ }
+ sessionStorage.setItem("upv", upv);
+ jadTargetingData["upv"] = upv;
+
+ swrap.src = "https://cdn.lib.getjad.io/library/1018282/xataka";
+ swrap.setAttribute("importance", "high");
+ let g = document.getElementsByTagName("head")[0];
+ const europeanCountriesCode = [
+  'AD', 'AL', 'AT', 'AX', 'BA', 'BE', 'BG', 'BY', 'CH', 'CY', 'CZ', 'DE', 'DK',
+  'EE', 'ES', 'FI', 'FO', 'FR', 'GB', 'GG', 'GI', 'GR', 'HR', 'HU', 'IE', 'IM',
+  'IS', 'IT', 'JE', 'LI', 'LT', 'LU', 'LV', 'MC', 'MD', 'ME', 'MK', 'MT', 'NL',
+  'NO', 'PL', 'PT', 'RO', 'RS', 'RU', 'SE', 'SI', 'SJ', 'SK', 'SM', 'UA', 'VA'
+ ];
+ window.WSL2 = window.WSL2 || {};
+ window.WSL2.isEuropeanVisitor = europeanCountriesCode.includes(window.country);
+ const enableCmpChanges = "1";
+ let cmpObject = {
+   includeCmp: window.WSL2.isEuropeanVisitor ? false : true,
+   name: window.WSL2.isEuropeanVisitor ? 'didomi' : 'none'
+  }
+  if (window.WSL2.isEuropeanVisitor && "1" == enableCmpChanges) {
+   cmpObject = {
+    ...cmpObject,
+    "siteId": "7bd10a97-724f-47b3-8e9f-867f0dea61c8",
+     "noticeId": "n7j2DGhK",
+    "paywall": {
+     "clientId": "AeAcL5krxDiL6T0cdEbtuhszhm0bBH9S0aQeZwvgDyr0roxQA6EJoZBra8LsS0RstogsYj54y_SWXQim",
+     "planId": "P-8MN24328CY367915SMWG2EII",
+     "tosUrl": "https://weblogs.webedia.es/condiciones-uso.html",
+     "touUrl": "https://weblogs.webedia.es/condiciones-uso.html",
+     "privacyUrl": "https://weblogs.webedia.es/cookies.html" ,
+     "language":  "es"
+    }
+   }
+  }
+ g.parentNode.insertBefore(swrap, g);
+ jad.cmd.push(function() {
+
+  jad.public.setConfig({
+   page: "/1018282/xataka/postpage", 
+         
+    pagePositions: [
+        'top',
+   'cen1',
+   'cen2',
+   'footer',
+   'oop',
+   'cintillo',
+   '1',
+   'inread1',
+   '2',
+   '3',
+ 
+    ],
+    elementsMapping: {
+        "top": "div-gpt-top",
+   "cen1": "div-gpt-cen",
+   "cen2": "div-gpt-cen2",
+   "footer": "div-gpt-bot2",
+   "oop": "div-gpt-int",
+   "cintillo": "div-gpt-int2",
+   "1": "div-gpt-lat",
+   "inread1": "div-gpt-out",
+   "2": "div-gpt-lat2",
+   "3": "div-gpt-lat3",
+ 
+    },
+    targetingOnPosition: {
+               "top": {
+     'fold': ['atf']
+    },
+               "cen1": {
+     'fold': ['btf']
+    },
+               "cen2": {
+     'fold': ['btf']
+    },
+               "footer": {
+     'fold': ['btf']
+    },
+               "oop": {
+     'fold': ['mtf']
+    },
+               "cintillo": {
+     'fold': ['mtf']
+    },
+               "1": {
+     'fold': ['atf']
+    },
+               "inread1": {
+     'fold': ['mtf']
+    },
+               "2": {
+     'fold': ['mtf']
+    },
+               "3": {
+     'fold': ['mtf']
+    },
+               "4": {
+     'fold': ['mtf']
+    },
+               "5": {
+     'fold': ['mtf']
+    },
+               "6": {
+     'fold': ['mtf']
+    },
+               "7": {
+     'fold': ['mtf']
+    },
+               "8": {
+     'fold': ['mtf']
+    },
+      
+    },
+      targeting: jadTargetingData,
+   interstitialOnFirstPageEnabled: false,
+   cmp: cmpObject,
+   wemass: {
+    targeting: {
+     page: {
+      type: jadTargetingData.siteSection ?? "",
+      content: {
+       categories: jadTargetingData.categories ? jadTargetingData.categories.split(',') : [""],
+      },
+      article: {
+       id: jadTargetingData.postId ?? "",
+       title: WSL2.config.title ?? "",
+       description: WSL2.config.metaDescription ?? "",
+       topics: Array.isArray(jadTargetingData.tags)
+          ? jadTargetingData.tags
+          : jadTargetingData.tags
+          ? jadTargetingData.tags.split(',')
+          : [""],
+       authors: jadTargetingData.author ? jadTargetingData.author.split(',') : [""],
+       modifiedAt: jadTargetingData.modifiedDate ? new Date(jadTargetingData.modifiedDate).toISOString() : "",
+       publishedAt: jadTargetingData.publishedDate ? new Date(jadTargetingData.modifiedDate).toISOString() : "",
+       premium: false,
+       wordCount: jadTargetingData.wordCount ?? "",
+       paragraphCount: jadTargetingData.blockLength ?? "",
+       section: jadTargetingData.mainCategory ?? "",
+       subsection: "",
+      },
+      user: {
+       type: "",
+       age: null,
+       gender: "",
+      },
+     },
+    },
+   },
+  });
+
+  jad.public.loadPositions();
+
+  jad.public.displayPositions();
+ });
+ if(!window.hasAdblocker) {
+  window.addEventListener('load', () => {
+   populateHashedEmail();
+   WSL2.Events.on('loginSuccess', populateHashedEmail);
+   WSL2.Events.on('onLogOut', () => {
+    jad.config.publisher.hashedId = {};
+   });
+  });
+ }
+</script> 
+<div class="customize-me">
+ <div class="head-content-favs">
+     <div class="head-container head-container-with-ad head-container-with-corner m-favicons-compact m-head-masthead">
+ <div class="head head-with-ad is-init">
+     <div class="head-favicons-container">
+ <nav class="head-favicons">
+  <div class="head-favicons-index head-webedia-logo">
+   <a id="favicons-toggle" href="https://www.webedia.es/" data-target="#head-favicons"><abbr title="Webedia">Webedia</abbr></a>
+  </div>
+ </nav>
+</div>    <div class="masthead-site-lead m-is-compact">
+ <div class="masthead-container">
+  <div class="masthead-logo">
+   <div class="masthead-logo-brand">
+    <a href="/" class="masthead-brand">Xataka</a>
+   </div>
+     </div>
+       <nav class="masthead-actions">
+    <ul class="masthead-actions-list">
+     <li class="masthead-actions-list-item"><a href="#sections" class="masthead-actions-menu m-v1 js-toggle" data-searchbox="#search-field-1">Menú</a></li>
+     <li class="masthead-actions-list-item"><a href="#headlines" class="masthead-actions-nuevo m-v1 js-toggle">Nuevo</a></li>
+    </ul>
+   </nav>
+   </div>
+</div>
+  <div class="masthead-nano-container js-nano-container  m-nanomaker-custom m-nanomaker-logo">
+ <div class="masthead-nano-lead">
+  <div class="masthead-nano-logo">
+       <a href="/categoria/movilidad">Xataka Movilidad</a>
+     </div >
+   </div>
+</div>
+     <div class="masthead-nano-nav-container js-nano-container m-nanomaker-custom m-nanomaker-logo" id="showSwipecard">
+ <nav class="masthead-nano-nav">
+  <ul class="masthead-nav-topics">
+       <li class="masthead-nav-topics-item"><a class="masthead-nav-topics-anchor" href="https://www.xataka.com/tag/pruebas-de-coches">pruebas de coches</a></li>
+       <li class="masthead-nav-topics-item"><a class="masthead-nav-topics-anchor" href="https://www.xataka.com/tag/circulacion">circulacion</a></li>
+       <li class="masthead-nav-topics-item"><a class="masthead-nav-topics-anchor" href="https://www.xataka.com/tag/trucos-motor">trucos motor</a></li>
+     </ul>
+   <ul class="masthead-nav-social">
+                    <li class="masthead-nav-social-item"><a href="https://twitter.com/xatakamovilidad" class="masthead-nav-social-anchor masthead-social-x" rel="nofollow">Twitter</a></li>
+             <li class="masthead-nav-social-item"><a href="https://www.facebook.com/xatakamovilidad/" class="masthead-nav-social-anchor masthead-social-facebook" rel="nofollow">Facebook</a></li>
+                     </ul>
+ </nav>
+</div>
+   </div>
+</div>
+
+    <div class="ad ad-top">
+  <div class="ad-box" id="div-gpt-top">
+     </div>
+   </div>
+   
+    <div class="page-container ">
+         <div class="section-deeplinking-container m-deeplinking-news m-deeplinking-post o-deeplinking-section">
+  <div class="section-deeplinking o-deeplinking-section_wrapper">
+       <div class="section-deeplinking-wrap">
+     <span class="section-deeplinking-header">HOY SE HABLA DE</span>
+     <ul id="js-deeplinking-news-nav-links" class="section-deeplinking-list">
+             <li class="section-deeplinking-item"><a href="https://www.xataka.com/ingenieria-y-megaconstrucciones/china-recurrio-a-material-peculiar-para-construir-puente-maritimo-largo-mundo-bambu" class="section-deeplinking-anchor">China</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.genbeta.com/inteligencia-artificial/mayores-ventajas-deepseek-para-aprender-a-programar-esta-chatgpt-maravilla-verlo-directo" class="section-deeplinking-anchor">DeepSeek</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.genbeta.com/a-fondo/bill-gates-tiene-fortuna-100-000-millones-euros-coleccion-relojes-casio-valorada-120-euros" class="section-deeplinking-anchor">Bill Gates</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.3djuegos.com/pc/noticias/potencial-increible-elon-musk-sigue-decepcionado-videojuegos-actuales-quiere-crear-juegos-revolucionarios-ia" class="section-deeplinking-anchor">Elon Musk</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.espinof.com/actores-y-actrices/que-fue-miko-hughes-nino-prodigio-que-empezo-a-actuar-3-anos-acabo-convirtiendose-meme" class="section-deeplinking-anchor">El Niño</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.3djuegos.com/3djuegos-trivia/noticias/generacion-z-se-ve-obligada-a-rechazar-trabajos-culpa-su-propia-economia-1-cada-10-no-puede-costearse-uniformes-traslados" class="section-deeplinking-anchor">Generación Z</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.xataka.com/magnet/mundial-cafe-existe-espana-ha-puesto-sus-esperanzas-barista-vigo-marcos-gonzalez" class="section-deeplinking-anchor">Café</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.xatakandroid.com/aplicaciones-android/hay-vida-alla-tienda-oficial-apps-para-android-auto-mejor-plataformas-apps-que-merecen-pena" class="section-deeplinking-anchor">Android Auto</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.xataka.com/robotica-e-ia/opinion-director-general-microsoft-acerca-ia-inusual-sospecha-cuanto-crecera-economia-global-gracias-a-ella" class="section-deeplinking-anchor">IA</a></li>
+             <li class="section-deeplinking-item"><a href="https://www.xataka.com/vehiculos/ante-la-falta-de-tripulacion-corea-del-sur-esta-desarrollando-barcos-con-ia-y-eeuu-ya-les-ha-echado-el-ojo" class="section-deeplinking-anchor">Barcos</a></li>
+           </ul>
+     <div id="js-deeplinking-news-nav-btn" class="section-deeplinking-btn" style="display:none"></div>
+    </div>
+     </div>
+ </div>
+
+         <div class="content-container">
+    <main>
+     <article class="article article-normal">
+       <header class="post-normal-header">
+                 <div class="post-title-container">
+  <h1 class="post-title">
+     Los coches más vendidos en 2023 y 2024 en España   </h1>
+</div>
+          <section class="post-entradilla">
+  <div class="post-entradilla-inner">
+   <ul>
+  <li><h2>En 2023 se vendieron 949.359 autom&#243;viles en Espa&#241;a, un 16,7% m&#225;s que en 2022</h2></li>
+  <li><h2>El Dacia Sandero fue el coche m&#225;s vendido de 2023, sumando 27.951 unidades</h2></li>
+</ul>
+  </div>
+ </section>
+                            <div class="post-asset-main">
+            <div class="article-asset-big article-asset-image js-post-images-container">
+               
+<div class="asset-content">
+ <picture>
+  <source media="(min-width: 1200px)" srcset="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/1200_800.jpeg" width="1200" height="800">
+  <source media="(min-width: 501px)" srcset="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/840_560.jpeg" width="840" height="560">
+  <img alt="Dacia Sandero 2021 1600 06" src="https://i.blogs.es/651d87/dacia-sandero-2021-1600-06/500_333.jpeg" width="500" height="333" decoding="sync" loading="eager" fetchpriority="high">
+ </picture>
+</div>
+             </div>
+            </div>
+                <div class="post-comments-shortcut">
+                            <a title="Sin comentarios" href="#comments" class="post-comments js-smooth-scroll">Sin comentarios</a>
+              
+               <a href="#" onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana%3Futm_source%3Dfacebook%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneraweb', '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600'); return false;" class="btn-facebook js-btn-facebook" data-postname="coches-vendidos-2023-2024-espana">Facebook</a>
+ <a href="https://twitter.com/intent/tweet?url=https://www.xataka.com/p/298745%3Futm_source%3Dtwitter%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneraweb&text=Los%20coches%20m%C3%A1s%20vendidos%20en%202023%20y%202024%20en%20Espa%C3%B1a&via=xataka" class="btn-x js-btn-twitter" data-postname="coches-vendidos-2023-2024-espana">Twitter</a>
+<a href="https://share.flipboard.com/bookmarklet/popout?v=2&title=Los%20coches%20m%C3%A1s%20vendidos%20en%202023%20y%202024%20en%20Espa%C3%B1a&url=https%3A%2F%2Fwww.xataka.com%2Fmovilidad%2Fcoches-vendidos-2023-2024-espana%3Futm_source%3Dflipboard%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneraweb" class="btn-flipboard js-flipboard-share-button js-flipboard-share-event" data-postname="coches-vendidos-2023-2024-espana">Flipboard</a>
+<a href="mailto:?subject=Los%20coches%20m%C3%A1s%20vendidos%20en%202023%20y%202024%20en%20Espa%C3%B1a&body=https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana%3Futm_source%3Demailsharing%26utm_medium%3Demail%26utm_content%3DPOST%26utm_campaign%3Dbotoneraweb%26utm_term%3DCLICK%2BON%2BTITLE" class="btn-email js-btn-email" data-postname="coches-vendidos-2023-2024-espana">E-mail</a>
+ <span class="js-whatsapp"></span>
+ <script>
+   document.addEventListener('DOMContentLoaded', () => {
+     const userAgent = navigator.userAgent.toLowerCase();
+     if (userAgent.indexOf('ipod') < 0) {
+       if (userAgent.indexOf('android') >= 0 || userAgent.indexOf('iphone') >= 0) {
+         const length = document.getElementsByClassName('js-whatsapp').length;
+         for (let i = 0; i < length; i++) {
+           document.getElementsByClassName('js-whatsapp')[i].innerHTML = `<a class='btn-whatsapp js-btn-whatsapp' data-postname="coches-vendidos-2023-2024-espana" href="whatsapp://send?text=Los coches más vendidos en 2023 y 2024 en España  https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana%3Futm_source%3Dwhatsapp%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneramobile">Whatsapp</a>`;
+         }
+       }
+     }
+   }, {once:true});
+ </script>
+        </div>
+       </header>
+      <div class="article-content-wrapper">
+       <div class="article-content-inner">
+                  <div class="article-metadata-container">
+ <div class="article-meta-row">
+ <div class="article-time">
+   <time
+   class="article-date"
+   datetime="2025-01-08T16:15:39Z"
+   data-format="D MMMM YYYY"
+   data-post-modified-time="2025-01-08T16:15:39Z"
+   data-post-modified-format="D MMMM YYYY, HH:mm"
+   data-post-reindexed-original-time=""
+  >
+   2025-01-08T16:15:39Z  </time>
+  <span id="is-editor"></span>
+</div>
+   </div>
+</div>
+ <div class="author-signature">
+ <img src="https://www.gravatar.com/avatar/aea5623585569da2b2b24cdabdd7bc53?s=80&amp;d=mm&amp;r=g" alt="alberto-de-la-torre" class="author-avatar">
+ <div class="author-signature-wrap">
+   <p class="author-name">Alberto de la Torre</p>
+      <div class="author-social-wrap" id="authorSocialWrap">
+  <a class="author-page_link" href="/autor/alberto-de-la-torre">2106 publicaciones de Alberto de la Torre</a>
+</div>    </div>
+ </div>
+                        <div class="article-content">
+          <div class="blob js-post-images-container">
+<p>El mercado del automóvil español quiere volver a tomar color y recuperar algo del pulso perdido desde la pandemia de coronavirus en lo que a ventas de vehículos se refiere. En 2023, las matriculaciones en nuestro país sumaron un total de 949.359 vehículos, un 16,7% más que en 2022, según datos de <a rel="noopener, noreferrer" href="https://anfac.com/">Anfac</a>, quienes aportan todos los datos que vienen a continuación.</p>
+<!-- BREAK 1 --> <div class="ad ad-lat">
+  <div class="ad-box" id="div-gpt-lat">
+     </div>
+   </div>
+
+<p>Si hablamos de <strong>2024</strong>, el volumen de ventas creció hasta superar el año anterior. En España se vendieron 1.016.885 automóviles, un 7,11% más que en 2023, cuando se sumaron 949.359 vehículos.</p>
+<!-- BREAK 2 -->
+<p>Pero, ¿cómo han sido estas ventas y cuáles fueron los vehículos más vendidos? ¿Cuáles lo fueron en 2023? Vamos a repasarlos.</p>
+
+<h2>Los coches más vendidos en 2024</h2>
+
+<p>Si buscamos la fotografía general del mercado del automóvil en nuestro país, podemos comprobar que, en lo que va de año, el mercado está creciendo aunque en agosto el ritmo se ralentizó.</p>
+<!-- BREAK 3 --> <div class="ad ad-out">
+  <div class="ad-box" id="div-gpt-out">
+     </div>
+   </div>
+
+<p>En el último mes, el de diciembre, se mantiene el crecimiento ya adelantado en el resto del año. Se han matriculado 105.346 unidades por las 81.772 matrículas de 2023. Esto supone un crecimiento del 28,83% en las ventas</p>
+<!-- BREAK 4 -->
+<p>El pasado mes de diciembre, los <strong>coches más vendidos</strong> (sumando todo tipo de tecnologías) fueron los siguientes:</p>
+
+<ol>
+  <li>Toyota C-HR: 2.818 unidades</li>
+  <li>Dacia Sandero: 2.780 unidades</li>
+  <li>Tesla Model 3: 2.445 unidades</li>
+  <li>Hyundai Tucson: 2.424 unidades</li>
+  <li>Seat Ibiza: 2.192 unidades</li>
+</ol>
+
+<p>Si ampliamos el foco y miramos al acumulado del año, los coches más vendidos entre enero y diciembre de 2024 son los siguientes:</p>
+
+<ol>
+  <li>Dacia Sandero: 32.994 unidades</li>
+  <li>Toyota Corolla: 22.129 unidades</li>
+  <li>Seat Ibiza: 22.021 unidades</li>
+  <li>Hyundai Tucson: 21.595 unidades</li>
+  <li>MG ZS: 20.386 unidades</li>
+</ol>
+<div class="article-asset-image article-asset-normal article-asset-center">
+ <div class="asset-content">
+                   <img class="centro_sinmarco" height=1127 width=1594 loading="lazy" decoding="async" sizes="100vw" fetchpriority="high" srcset="https://i.blogs.es/1c291a/tesla-model_y-2021-1600-04/450_1000.jpeg 450w, https://i.blogs.es/1c291a/tesla-model_y-2021-1600-04/650_1200.jpeg 681w,https://i.blogs.es/1c291a/tesla-model_y-2021-1600-04/1024_2000.jpeg 1024w, https://i.blogs.es/1c291a/tesla-model_y-2021-1600-04/1366_2000.jpeg 1366w" src="https://i.blogs.es/1c291a/tesla-model_y-2021-1600-04/450_1000.jpeg" alt="Tesla Model Y 2021 1600 04">
+   <noscript><img alt="Tesla Model Y 2021 1600 04" class="centro_sinmarco" src="https://i.blogs.es/1c291a/tesla-model_y-2021-1600-04/450_1000.jpeg"></noscript>
+   
+      </div>
+</div>
+<h3>Los coches eléctricos más vendidos en 2024</h3>
+
+<p>En cuanto a diseccionar los vehículos por tecnologías, si miramos a los coches eléctricos nos encontramos que, durante el pasado mes de diciembre, se matricularon 8.818 unidades en España. Es un 49,56% más que en 2023.&nbsp;</p>
+<!-- BREAK 5 -->
+<p>En 2024, en España se han matriculado 57.374 coches eléctricos, lo que supone un aumento del 11,17% en comparación al mismo periodo de 2023. La cuota de mercado ha quedado en un 5,64% del peso total de las matriculaciones españolas.</p>
+<!-- BREAK 6 --> <div class="ad ad-lat2">
+  <div class="ad-box" id="div-gpt-lat2">
+     </div>
+   </div>
+
+<p>Los coches <strong>eléctricos más vendidos</strong> del mes de diciembre de 2024 fueron:</p>
+
+<ol>
+  <li>Tesla Model 3: 2.445 unidades</li>
+  <li>Tesla Model Y: 761 unidades</li>
+  <li>Kia EV3: 518 unidades</li>
+  <li>MINI Mini: 334 unidades</li>
+  <li>BYD Dolphin: 306 unidades</li>
+</ol>
+
+<p>En 2024, en el acumulado, los coches eléctricos más vendidos son:</p>
+
+<ol>
+  <li>Tesla Model 3: 11.043 unidades</li>
+  <li>Tesla Model Y: 5.495 unidades</li>
+  <li>MG4 Electric: 2.668 unidades</li>
+  <li>Volvo EX30: 2.358 unidades</li>
+  <li>BMW iX1: 1.807 unidades</li>
+</ol>
+<div class="article-asset-image article-asset-normal article-asset-center">
+ <div class="asset-content">
+                   <img class="centro_sinmarco" height=1121 width=1592 loading="lazy" decoding="async" sizes="100vw" fetchpriority="high" srcset="https://i.blogs.es/6206e2/mercedes-benz-glc-2023-1600-07/450_1000.jpeg 450w, https://i.blogs.es/6206e2/mercedes-benz-glc-2023-1600-07/650_1200.jpeg 681w,https://i.blogs.es/6206e2/mercedes-benz-glc-2023-1600-07/1024_2000.jpeg 1024w, https://i.blogs.es/6206e2/mercedes-benz-glc-2023-1600-07/1366_2000.jpeg 1366w" src="https://i.blogs.es/6206e2/mercedes-benz-glc-2023-1600-07/450_1000.jpeg" alt="Mercedes Benz Glc 2023 1600 07">
+   <noscript><img alt="Mercedes Benz Glc 2023 1600 07" class="centro_sinmarco" src="https://i.blogs.es/6206e2/mercedes-benz-glc-2023-1600-07/450_1000.jpeg"></noscript>
+   
+      </div>
+</div>
+<h3>Los coches híbridos enchufables más vendidos en 2024</h3>
+
+<p>En lo que a <a class="text-outboundlink" href="https://www.xataka.com/movilidad/tipos-coches-hibridos-hibridos-normales-a-micro-hibridos" data-vars-post-title="Tipos de coches híbridos: de los híbridos normales a los micro híbridos" data-vars-post-url="https://www.xataka.com/movilidad/tipos-coches-hibridos-hibridos-normales-a-micro-hibridos">híbridos enchufables</a>, en diciembre de 2024 se han vendido 6.306 unidades de este tipo de automóviles, un descenso del 3,67% respecto al mismo mes de 2023.</p>
+<!-- BREAK 7 -->
+<p>En el total del año, la caída ha sido de un 5,80%, con 58.558 unidades. La cuota de mercado queda en un 5,75% del total de las ventas.</p>
+
+<p>Los coches <strong>híbridos enchufables más vendidos</strong> del mes de diciembre de 2024 fueron:</p>
+
+<ol>
+  <li>BMW X1: 528 unidades</li>
+  <li>BYD Seal U: 524 unidades</li>
+  <li>Mercedes GLC: 423 unidades</li>
+  <li>MG EHS: 414 unidades</li>
+  <li>Toyota C-HR: 352 unidades</li>
+</ol>
+
+<p>En el acumulado de 2024, los coches híbridos enchufables más vendidos son:</p>
+
+<ol>
+  <li>Mercedes GLC: 4.988 unidades</li>
+  <li>Ford Kuga: 3.457 unidades</li>
+  <li>Cupra Formentor: 3.194 unidades</li>
+  <li>Mercedes GLA: 2.734 unidades</li>
+  <li>Hyundai Tucson: 2.248 unidades</li>
+</ol>
+<div class="article-asset article-asset-normal article-asset-center">
+ <div class="desvio-container">
+  <div class="desvio">
+   <div class="desvio-figure js-desvio-figure">
+    <a href="https://www.xataka.com/movilidad/coche-hibrido-enchufable-barato" class="pivot-outboundlink" data-vars-post-title="Los coches híbridos enchufables más baratos que se pueden comprar (2024)">
+     <img alt="Los&#x20;coches&#x20;h&#x00ED;bridos&#x20;enchufables&#x20;m&#x00E1;s&#x20;baratos&#x20;que&#x20;se&#x20;pueden&#x20;comprar&#x20;&#x28;2024&#x29;" width="375" height="142" src="https://i.blogs.es/b3af75/mg-hs_plug-in-2021-1600-02/375_142.jpeg">
+    </a>
+   </div>
+   <div class="desvio-summary">
+    <div class="desvio-taxonomy js-desvio-taxonomy">
+     <a href="https://www.xataka.com/movilidad/coche-hibrido-enchufable-barato" class="desvio-taxonomy-anchor pivot-outboundlink" data-vars-post-title="Los coches híbridos enchufables más baratos que se pueden comprar (2024)">En Xataka</a>
+    </div>
+    <a href="https://www.xataka.com/movilidad/coche-hibrido-enchufable-barato" class="desvio-title js-desvio-title pivot-outboundlink" data-vars-post-title="Los coches híbridos enchufables más baratos que se pueden comprar (2024)">Los coches híbridos enchufables más baratos que se pueden comprar (2024)</a>
+   </div>
+  </div>
+ </div>
+</div>
+<h3>Los coches híbridos más vendidos en 2024</h3>
+
+<p>Dejando atrás a los coches enchufables, los híbridos también están experimentando un importante crecimiento entre los vehículos más vendidos en nuestro país. Hay que tener en cuenta que en los vehículos híbridos también se cuentan los <a class="text-outboundlink" href="https://www.xataka.com/movilidad/coche-hibrido-hibrido-enchufable-electrico-cual-comprar-funcion-uso-ventajas-cada-uno" data-vars-post-title="Coche híbrido, híbrido enchufable o eléctrico: cuál comprar en función del uso y ventajas de cada uno" data-vars-post-url="https://www.xataka.com/movilidad/coche-hibrido-hibrido-enchufable-electrico-cual-comprar-funcion-uso-ventajas-cada-uno">microhíbridos de 48 voltios</a>.</p>
+<!-- BREAK 8 -->
+<p>En lo que se refiere al mes de diciembre de 2024, los coches híbridos vendieron 45.180 unidades, muy por encima del mismo mes de 2023. Las matriculaciones han experimentado un crecimiento del 61,78%.</p>
+<!-- BREAK 9 -->
+<p>Si miramos al global del año, en España se matricularon en 2024 un total de 392.365 automóviles híbridos. Es una cuota de mercado del 38,58%, superano las cifras de la gasolina (37,24%). El crecimiento fue del 29,50% respecto a 2023, cuando se matricularon 302.988 automóviles.</p>
+<!-- BREAK 10 --> <div class="ad ad-lat">
+  <div class="ad-box" id="div-gpt-lat3">
+     </div>
+   </div>
+
+<p>Los coches <strong>híbridos más vendidos</strong> del mes de septiembre de 2024 fueron:</p>
+
+<ol>
+  <li>Toyota C-HR: 2.466 unidades</li>
+  <li>Toyota Yaris Cross: 1.764 unidades</li>
+  <li>Nissan Qashqai: 1.728 unidades</li>
+  <li>Dacia Duster: 1.686 unidades</li>
+  <li>Hyundai Tucson: 1.544 unidades</li>
+</ol>
+
+<p>En el acumulado, los coches híbridos más vendidos son:</p>
+
+<ol>
+  <li>Toyota Corolla: 22.129 unidades</li>
+  <li>Toyota Yaris Cross: 18.335 unidades</li>
+  <li>Nissan Qashqai: 18.067 unidades</li>
+  <li>Toyota C-HR: 16.426 unidades</li>
+  <li>Kia Sportage: 13.112 unidades</li>
+</ol>
+<div class="article-asset-video article-asset-normal">
+ <div class="asset-content">
+  <div class="base-asset-video">
+   <div class="js-dailymotion">
+    <script type="application/json">
+                          {"videoId":"x8rlmx8","autoplay":false,"title":"Top 14 COCHES ELÉCTRICOS QUE LLEGAN EN 2024", "tag":""}
+                  </script>
+   </div>
+  </div>
+ </div>
+</div>
+<h2>Los coches más vendidos en 2023</h2>
+
+<p>Si echamos la vista atrás para ver <a class="text-outboundlink" href="https://www.xataka.com/movilidad/espana-sigue-prefiriendo-coche-barato-no-electrico-datos-matriculaciones-dejan-sabor-agridulce-para-industria" data-vars-post-title="España sigue prefiriendo el coche barato, no el eléctrico: los datos de matriculaciones dejan un sabor agridulce para la industria" data-vars-post-url="https://www.xataka.com/movilidad/espana-sigue-prefiriendo-coche-barato-no-electrico-datos-matriculaciones-dejan-sabor-agridulce-para-industria">qué sucedió en 2023</a>, encontramos que en España se vendieron 949.359 automóviles. Esta cifra, aunque lejos de los mejores datos de nuestro país, fueron un 16,7% superiores a los de 2022, cuando se vendieron 813.376 automóviles.</p>
+<!-- BREAK 11 -->
+<p>Por tecnologías, el coche eléctrico vendió un 69,10% más que en 2022, sumando un total de &nbsp;51.612 matriculaciones que representaron el 5,44% de cuota de mercado. Los híbridos enchufables vendieron 60.446 unidades, con una cuota de mercado del 6,37%. Su crecimiento fue del 32,38%.</p>
+<!-- BREAK 12 -->
+<p>En cuanto a los híbridos, en total se creció un 26,36%, representado en 302.845 unidades matriculadas y una cuota de mercado del 31,90%.</p>
+
+<h3>Los coches más vendidos de 2023 (todas las tecnologías):</h3>
+
+<ol>
+  <li>Dacia Sandero: 27.951 unidades</li>
+  <li>Seat Arona: 21.639 unidades</li>
+  <li>Toyota Corolla: 19.845 unidades</li>
+  <li>MG ZS: 19.818 unidades</li>
+  <li>Peugeot 2008: 19.433 unidades</li>
+</ol>
+
+<h3>Los coches eléctricos más vendidos de 2023:</h3>
+
+<ol>
+  <li>Tesla Model Y: 6.833 unidades</li>
+  <li>Tesla Model 3: 6.116 unidades</li>
+  <li>MG4 Electric: 3.094 unidades</li>
+  <li>Fiat 500: 2.022 unidades</li>
+  <li>Dacia Spring: 2.013 unidades</li>
+</ol>
+
+<h3>Los coches híbridos enchufables más vendidos de 2023:</h3>
+
+<ol>
+  <li>Ford Kuga: 4.088 unidades</li>
+  <li>LYNK &amp; CO 01: 3.930 unidades</li>
+  <li>Kia Sportage: 2.526 unidades</li>
+  <li>Peugeot 3008: 2.480 unidades</li>
+  <li>Mercedes GLC: 2.193 unidades</li>
+</ol>
+
+<h3>Los coches híbridos más vendidos de 2023:</h3>
+
+<ol>
+  <li>Toyota Corolla: 19.845 unidades</li>
+  <li>Toyota C-HR: 18.478 unidades</li>
+  <li>Nissan Qashqai: 15.908 unidades</li>
+  <li>Toyota Yaris Cross: 15.514 unidades</li>
+  <li>Fiat 500: 13.855 unidades</li>
+</ol>
+
+<p>Imagen | Dacia, Tesla y Mercedes</p>
+
+<p>En Xataka | <a class="text-outboundlink" href="https://www.xataka.com/movilidad/que-coches-kilometro-0-que-casos-pueden-ser-buena-opcion" data-vars-post-title="Qué son los coches de kilómetro 0 y en qué casos pueden ser una buena opción" data-vars-post-url="https://www.xataka.com/movilidad/que-coches-kilometro-0-que-casos-pueden-ser-buena-opcion">Qué son los coches de kilómetro 0 y en qué casos pueden ser una buena opción</a></p>
+<script>
+ (function() {
+  window._JS_MODULES = window._JS_MODULES || {};
+  var headElement = document.getElementsByTagName('head')[0];
+  if (_JS_MODULES.instagram) {
+   var instagramScript = document.createElement('script');
+   instagramScript.src = 'https://platform.instagram.com/en_US/embeds.js';
+   instagramScript.async = true;
+   instagramScript.defer = true;
+   headElement.appendChild(instagramScript);
+  }
+ })();
+</script>
+ 
+ </div>
+        </div>
+       </div>
+      </div>
+     </article>
+     <div class="section-post-closure">
+ <div class="section-content">
+  <div class="social-share-group">
+      <a href="#" onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana%3Futm_source%3Dfacebook%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneraweb', '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600'); return false;" class="btn-facebook js-btn-facebook" data-postname="coches-vendidos-2023-2024-espana">Facebook</a>
+ <a href="https://twitter.com/intent/tweet?url=https://www.xataka.com/p/298745%3Futm_source%3Dtwitter%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneraweb&text=Los%20coches%20m%C3%A1s%20vendidos%20en%202023%20y%202024%20en%20Espa%C3%B1a&via=xataka" class="btn-x js-btn-twitter" data-postname="coches-vendidos-2023-2024-espana">Twitter</a>
+<a href="https://share.flipboard.com/bookmarklet/popout?v=2&title=Los%20coches%20m%C3%A1s%20vendidos%20en%202023%20y%202024%20en%20Espa%C3%B1a&url=https%3A%2F%2Fwww.xataka.com%2Fmovilidad%2Fcoches-vendidos-2023-2024-espana%3Futm_source%3Dflipboard%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneraweb" class="btn-flipboard js-flipboard-share-button js-flipboard-share-event" data-postname="coches-vendidos-2023-2024-espana">Flipboard</a>
+<a href="mailto:?subject=Los%20coches%20m%C3%A1s%20vendidos%20en%202023%20y%202024%20en%20Espa%C3%B1a&body=https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana%3Futm_source%3Demailsharing%26utm_medium%3Demail%26utm_content%3DPOST%26utm_campaign%3Dbotoneraweb%26utm_term%3DCLICK%2BON%2BTITLE" class="btn-email js-btn-email" data-postname="coches-vendidos-2023-2024-espana">E-mail</a>
+ <span class="js-whatsapp"></span>
+ <script>
+   document.addEventListener('DOMContentLoaded', () => {
+     const userAgent = navigator.userAgent.toLowerCase();
+     if (userAgent.indexOf('ipod') < 0) {
+       if (userAgent.indexOf('android') >= 0 || userAgent.indexOf('iphone') >= 0) {
+         const length = document.getElementsByClassName('js-whatsapp').length;
+         for (let i = 0; i < length; i++) {
+           document.getElementsByClassName('js-whatsapp')[i].innerHTML = `<a class='btn-whatsapp js-btn-whatsapp' data-postname="coches-vendidos-2023-2024-espana" href="whatsapp://send?text=Los coches más vendidos en 2023 y 2024 en España  https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana%3Futm_source%3Dwhatsapp%26utm_medium%3Dsocial%26utm_campaign%3Dbotoneramobile">Whatsapp</a>`;
+         }
+       }
+     }
+   }, {once:true});
+ </script>
+  </div>
+     <div class="post-tags-container">
+ <span class="post-link-title">Temas</span>
+   <ul class="post-link-list" id="js-post-link-list-container">
+       <li class="post-category-name">
+           <a href="/categoria/movilidad">Xataka Movilidad</a>
+         </li>
+          <li class="post-link-item"><a href="/tag/espana">España</a></li>
+       <li class="post-link-item"><a href="/tag/coche-electrico">Coche eléctrico</a></li>
+       <li class="post-link-item"><a href="/tag/coche-hibrido">Coche híbrido</a></li>
+       <li class="post-link-item"><a href="/tag/coches-hibridos-enchufables">Coches híbridos enchufables</a></li>
+     </ul>
+  <span class="btn-expand" id="js-btn-post-tags"></span>
+</div>
+   </div>
+</div>
+  <div class ="limit-container">
+  <div class="OUTBRAIN" data-src="https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana" data-widget-id="AR_1"></div> 
+ </div>
+ <script type="didomi/javascript" async="async" src="//widgets.outbrain.com/outbrain.js" data-vendor="iab:164"></script>
+                      <div class="ad ad-cen">
+  <div class="ad-box" id="div-gpt-cen">
+     </div>
+   </div>
+                <script>
+ window.WSLModules || (window.WSLModules = {});
+ WSLModules.Comments || (WSLModules.Comments = {
+  'moduleConf' : "c1"
+ });
+</script>
+<a id="to-comments"></a>
+<div id="comments">
+ <div class="comment-section">
+     <div class="comment-wrapper">
+    <div class="alert-message">Comentarios cerrados</div>
+   </div>
+    <script>
+  window.AML || (window.AML = {});
+  AML.Comments || (AML.Comments = {});
+  AML.Comments.config || (AML.Comments.config = {});
+  AML.Comments.config.data = {"comments":[],"meta":{"more_records":"false","start":0,"total":0,"order":"valued","totalCount":0,"commentStatus":"closed"}};
+  AML.Comments.config.postId = 298745;
+  AML.Comments.config.enableSocialShare = "0";
+  AML.Comments.config.status = "closed";
+  AML.Comments.config.campaignDate = "23_Feb_2025";
+</script>
+
+ </div>
+</div>
+           <div class="ad ad-cen2">
+  <div class="ad-box" id="div-gpt-cen2">
+     </div>
+   </div>
+      <div class="ad ad-bot">
+  <div class="ad-box" id="div-gpt-bot2">
+     </div>
+   </div>
+                 <div class="section-deeplinking-container m-evergreen-links">
+  <div class="section-deeplinking">
+       <div class="section-deeplinking-wrap">
+     <span class="section-deeplinking-header">Temas de interés</span>
+     <ul class="section-deeplinking-list" id="js-evergreen-nav-links">
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/analisis/mejores-moviles-2022-analisis-videos" class="section-deeplinking-anchor">
+         Mejores moviles 2025
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/analisis/mejores-moviles-calidad-precio-2022-analisis-videos" class="section-deeplinking-anchor">
+         Mejores móviles calidad precio 2025
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/basics/chatgpt-que-como-usarlo-que-puedes-hacer-este-chat-inteligencia-artificial" class="section-deeplinking-anchor">
+         ChatGPT
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/moviles/samsung-galaxy-s24-s24-caracteristicas-precio-ficha-tecnica" class="section-deeplinking-anchor">
+         Samsung Galaxy S24
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/moviles/iphone-16-pro-iphone-16-pro-max-caracteristicas-precio-ficha-tecnica" class="section-deeplinking-anchor">
+         iPhone 16 Pro
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/analisis/poco-x6-pro-opiniones-toma-contacto-video-fotos" class="section-deeplinking-anchor">
+         POCO X6 Pro
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/analisis/xiaomi-redmi-note-13-pro-5g-analisis-caracteristicas-precio-especificaciones" class="section-deeplinking-anchor">
+         Redmi Note 13 Pro
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/analisis/iphone-15-iphone-15-plus-analisis-caracteristicas-precio" class="section-deeplinking-anchor">
+         Iphone 15
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/analisis/xiaomi-13-analisis-caracteristicas-precio-especificaciones" class="section-deeplinking-anchor">
+         Xiaomi 13
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/moviles/oneplus-12-opiniones-toma-contacto-fotos" class="section-deeplinking-anchor">
+         One Plus 12
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/nuevo/nuevo-android-15-informacion" class="section-deeplinking-anchor">
+         Android 14
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/seleccion/buscando-mejor-portatil-relacion-calidad-precio-recomendaciones-compra-funcion-uso-nueve-modelos-destacados" class="section-deeplinking-anchor">
+         Mejores ordenadores portátiles
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/analisis/mejores-smartwatch-2022-analisis-videos" class="section-deeplinking-anchor">
+         Mejores smartwatch
+        </a>
+       </li>
+             <li class="section-deeplinking-item">
+        <a href="https://www.xataka.com/seleccion/guia-compras-auriculares-inalambricos-para-todos-bolsillos-36-modelos-15-euros-350-euros" class="section-deeplinking-anchor">
+         Auriculares inalámbricos
+        </a>
+       </li>
+           </ul>
+     <div class="section-deeplinking-btn" id="js-evergreen-nav-btn"></div>
+    </div>
+     </div>
+ </div>
+
+    </main>
+    <script>
+  window.WSLModules = window.WSLModules || {};
+  WSLModules.Footer = {'moduleConf' : 'c1'};
+</script>
+  <script>
+  document.addEventListener("DOMContentLoaded", function() {
+    runDailyMotion()
+  });
+
+  function runDailyMotion () {
+    const AUTOPLAY_LIMIT = WSL2.config.dailymotionAutoplayLimit;
+    let isPostsubtypeUseLimit = true;
+    let autoplayLimit = Infinity;
+    if (AUTOPLAY_LIMIT) {
+      isPostsubtypeUseLimit = 0 > ['landing'].indexOf(WSL2.config.postSubType);
+      autoplayLimit = isPostsubtypeUseLimit ? AUTOPLAY_LIMIT : autoplayLimit;
+    }
+
+    const isPostPage = Boolean(WSL2.config.postId);
+    const isDesktop = document.body.classList.contains('js-desktop');
+
+    const getTargetingKeyValues = (videoContainer) => {
+      let scriptTagInVideo = '';
+      Array.from(videoContainer.children).forEach((child) => {
+        if ('SCRIPT' === child.tagName) {
+          scriptTagInVideo = child;
+        }
+      });
+
+      const autoplayVideos = [];
+      const data = JSON.parse(scriptTagInVideo.text);
+      let inhouse = 'webedia-prod' === data.tag;
+      const videoData = data;
+      const isAutoplayable = isPostPage && autoplayVideos.length <= autoplayLimit ? Boolean(data.autoplay) : false;
+      let autoplayValue = isAutoplayable ? 'on' : 'off';
+      let isAutoplayTargetingTrue = data.autoplay;
+      let videoFooter = false;
+      if ('videoFooter' === data.type) {
+        autoplayValue = 'on';
+        isAutoplayTargetingTrue = true;
+        videoFooter = true;
+      }
+      
+      if (autoplayValue) {
+        autoplayVideos.push(videoContainer);
+      }
+      videoData.autoplayValue = autoplayValue;
+
+      let positionName = '';
+      if (isAutoplayTargetingTrue) {
+        positionName = isDesktop ? 'preroll_sticky_autoplay' : 'preroll_notsticky_autoplay';
+      } else {
+        positionName = isDesktop ? 'preroll_sticky_starttoplay' : 'preroll_notsticky_starttoplay';
+      }
+
+      return { positionName, videoData, inhouse, videoFooter };
+    };
+
+    const initDailymotionV3 = () => {
+      document.querySelectorAll('div.js-dailymotion').forEach((videoContainer, index) => {
+        const { positionName, videoData, inhouse, videoFooter } = getTargetingKeyValues(videoContainer); 
+        let updatedPlayerId = playerId;
+        if ('off' === videoData.autoplayValue) {
+          updatedPlayerId = WSL2.config.dailymotionPlayerIdAutoplayOff;
+        }
+        const divId = `${updatedPlayerId}-${index}`;
+        const element = document.createElement('div');
+        element.setAttribute('id', divId);
+        videoContainer.appendChild(element);
+
+        dailymotion.createPlayer(divId, {
+          referrerPolicy: 'no-referrer-when-downgrade',
+          player: updatedPlayerId,
+          params: {
+            mute: true,
+          },
+        }).then((player) => window.WSL2.handlePlayer(player, videoData, updatedPlayerId));
+        if (window.hasAdblocker) {
+          dailymotion
+            .getPlayer(divId)
+            .then((player) => {
+              player.loadContent({
+                video: videoData.videoId,
+              });
+            });
+        } else {
+          jad.cmd.push(() => {
+            jad.public.setTargetingOnPosition(
+              `${positionName}/${divId}`,
+              { related: ['yes'] }
+            );
+
+            jad.public.getDailymotionAdsParamsForScript(
+              [`${positionName}/${divId}`],
+              (res) => {
+                dailymotion
+                  .getPlayer(divId)
+                  .then((player) => {
+                    let customParameters = res[`${positionName}/${divId}`].split("/")[1];
+                    if (typeof customParameters === 'string') {
+                        customParameters = customParameters.split('&vpos');
+                    } else {
+                        customParameters = [];
+                    }
+                    let updatedCustomParameters = '%26videofooter%3D' + videoFooter + '%26inhouse%3D' + inhouse + '&vpos' ;
+                    updatedCustomParameters = customParameters.join(updatedCustomParameters);
+                    updatedCustomParameters = decodeURIComponent(updatedCustomParameters);
+                    if ('1' === WSL2.config.enableDynamicIU) {
+                      player.setCustomConfig({ dynamiciu: WSL2.config.dynamicIU, keyvalues: updatedCustomParameters, plcmt: "2" });
+                    }
+                    else {
+                      player.setCustomConfig({ customParams: updatedCustomParameters, plcmt: "2" });
+                    }
+                    player.loadContent({
+                      video: videoData.videoId,
+                    });
+                  })
+                  .then(() => {
+                    const videoElement = document.getElementById(divId);
+                    const videoParent = videoElement.parentElement.parentElement;
+                    videoParent.classList.remove('base-asset-video');
+                  });
+              }
+            );
+          });
+        }
+      });
+    };
+
+    const playerId =  WSL2.config[`${WSL2.config.device}DailymotionPlayerId`];
+    const newScript = document.createElement('script');
+
+    newScript.src = `https://geo.dailymotion.com/libs/player/${playerId}.js`;
+    newScript.onload = initDailymotionV3;
+    document.body.appendChild(newScript);
+  }
+</script> <footer class="foot js-foot">
+ <div class="wrapper foot-wrapper foot-wrapper-show">
+  <div id="newsletter" class="newsletter-box">
+     </div>
+     <div class="menu-follow foot-menu-follow">
+    <span class="item-meta foot-item-meta">Síguenos</span>
+    <ul>
+ <li>
+  <a class="icon-whatsapp link-whatsapp" href="https://whatsapp.com/channel/0029VaAOhno4tRrjQkLKjI2u" rel="nofollow">WhatsApp</a>
+ </li>
+ <li>
+  <a href="https://twitter.com/xataka" class="icon-x link-x" rel="nofollow">Twitter</a>
+ </li>
+ <li>
+  <a href="https://www.facebook.com/Xataka" class="icon-facebook link-facebook" rel="nofollow">Facebook</a>
+ </li>
+   <li>
+   <a href="https://www.youtube.com/user/xatakatv?sub_confirmation=1" class="icon-youtube link-youtube" rel="nofollow">Youtube</a>
+  </li>
+     <li>
+   <a class="icon-instagram link-instagram" href="https://instagram.com/xataka" rel="nofollow">Instagram</a>
+  </li>
+    <li>
+   <a href="https://telegram.me/xataka" class="icon-telegram link-telegram" rel="nofollow">Telegram</a>
+  </li>
+  <li>
+  <a class="icon-rss link-rss" href="/index.xml" rel="nofollow">RSS</a>
+ </li>
+     <li>
+   <a href="https://flipboard.com/@xataka" class="icon-flipboard link-flipboard" rel="nofollow">Flipboard</a>
+  </li>
+     <li>
+   <a href="https://www.linkedin.com/company/11275845/" class="icon-linkedin link-linkedin" rel="nofollow">LinkedIn</a>
+  </li>
+    <li>
+   <a class="icon-tiktok link-tiktok" href="https://www.tiktok.com/@xataka" rel="nofollow">Tiktok</a>
+  </li>
+ </ul>
+   </div>
+    <nav class="menu-categories foot-menu-categories">
+   <p class="nav-heading">En Xataka hablamos de...</p>
+   <ul>
+   <li><a class="list-item foot-list-item" href="/categoria/streaming">Streaming</a></li>   <li><a class="list-item foot-list-item" href="/categoria/analisis">Análisis</a></li>   <li><a class="list-item foot-list-item" href="/categoria/espacio">Espacio</a></li>   <li><a class="list-item foot-list-item" href="/categoria/moviles">Móviles</a></li>   <li><a class="list-item foot-list-item" href="/categoria/energia">Energía</a></li>   <li><a class="list-item foot-list-item" href="/categoria/movilidad">Xataka Movilidad</a></li>    <li><a class="list-item foot-list-item" href="/tag/apple">Apple</a></li>   <li><a class="list-item foot-list-item" href="/tag/samsung">Samsung</a></li>   <li><a class="list-item foot-list-item" href="/tag/inteligencia-artificial">Inteligencia artificial</a></li>   <li><a class="list-item foot-list-item" href="/tag/china">China</a></li>   <li><a class="list-item foot-list-item" href="/tag/empleo">Empleo</a></li>   <li><a class="list-item foot-list-item" href="/tag/windows-11">Windows 11</a></li> </ul>     </nav>
+  <p class="view-even-more"><a href="/archivos" class="btn">Ver más temas</a></p>      <div class="search-box foot-search">
+  <div class="search-form js-search-form">
+   <input id="search-field-3" type="text" 
+    placeholder="Buscar en Xataka" 
+    class="search-container-3" 
+    data-container="#search-container-3">
+   <button class="search-button js-search-button" data-field="#search-field-3">
+     Buscar
+   </button>
+  </div>
+ </div>
+   <div id="search-container-3" class="js-search-results foot-search-results"></div>
+   </div>
+</footer>
+ <script>
+  (function() {
+   var form = document.createElement('form');
+   form.method = 'POST';
+   form.classList.add('js-subscription', 'newsletter-form', 'foot-newsletter-form');
+   form.setAttribute('data-url', "https://www.xataka.com/modules/subscription/form");
+   form.innerHTML = '<p class="nav-heading">Recibe &quot;Xatakaletter&quot;, nuestra newsletter semanal </p>\
+    <p><input class="js-email newsletter-input" type="email" placeholder="Tu correo electrónico" required>\
+    <button class="btn-primary newsletter-button js-subscribe-btn" type="submit">Suscribir</button></p>\
+    <small class="newsletter-legal-disclaimer js-disclaimer">Suscribiéndote aceptas nuestra <a href="https://weblogs.webedia.es/aviso-legal.html">política de privacidad</a></small>\
+    <div class="alert-success js-subscribe-success" style="display: none;"></div>\
+    <div class="alert-error js-subscribe-error" style="display: none;">Error: el correo electrónico no tiene el formato correcto</div>';
+   var newsletterContainer = document.getElementById('newsletter');
+   newsletterContainer.insertBefore(form, newsletterContainer.firstChild);
+  })();
+ </script>
+<div class="foot-external js-foot-external ">
+ <div class="wrapper foot-wrapper">
+  <header class="foot-head">
+   <a class="backlink foot-backlink" href="#">Subir</a>
+   <p class="webedia-brand foot-webedia-brand">
+ <a href="https://www.webedia.es/" class="webedia-logo foot-webedia-logo"><span>Webedia</span></a>
+</p>
+  </header>
+    <div class="menu-external foot-menu-external">
+   <div class="spain-blogs">
+          <div class="links-category">
+    <p class="channel-title"> Tecnología </p><ul><li><a class="list-item foot-list-item"  rel="nofollow"  href="//www.xataka.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka
+         </a></li><li><a class="list-item foot-list-item"  href="//www.xatakamovil.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka Móvil
+         </a></li><li><a class="list-item foot-list-item"  href="//www.xatakandroid.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka Android
+         </a></li><li><a class="list-item foot-list-item"  href="//www.xatakahome.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka Smart Home
+         </a></li><li><a class="list-item foot-list-item"  href="//www.applesfera.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Applesfera
+         </a></li><li><a class="list-item foot-list-item"  href="//www.genbeta.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Genbeta
+         </a></li><li><a class="list-item foot-list-item"  href="//www.mundoxiaomi.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Mundo Xiaomi
+         </a></li><li><a class="list-item foot-list-item"  href="//www.territorioese.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Territorio S
+         </a></li></ul>
+  </div>
+   <div class="links-category">
+    <p class="channel-title"> Videojuegos </p><ul><li><a class="list-item foot-list-item"  href="//www.3djuegos.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           3DJuegos
+         </a></li><li><a class="list-item foot-list-item"  href="//www.vidaextra.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Vida Extra
+         </a></li><li><a class="list-item foot-list-item"  href="//www.millenium.gg?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           MGG
+         </a></li><li><a class="list-item foot-list-item"  href="//www.3djuegospc.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           3DJuegos PC
+         </a></li><li><a class="list-item foot-list-item"  href="//www.3djuegosguias.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           3DJuegos Guías
+         </a></li></ul>
+  </div>
+   <div class="links-category">
+    <p class="channel-title"> Entretenimiento </p><ul><li><a class="list-item foot-list-item"  href="https://www.sensacine.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Sensacine
+         </a></li><li><a class="list-item foot-list-item"  href="//www.espinof.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Espinof
+         </a></li></ul>
+  </div>
+   <div class="links-category">
+    <p class="channel-title"> Gastronomía </p><ul><li><a class="list-item foot-list-item"  href="//www.directoalpaladar.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Directo al Paladar
+         </a></li></ul>
+  </div>
+   <div class="links-category">
+    <p class="channel-title"> Estilo de vida </p><ul><li><a class="list-item foot-list-item"  rel="nofollow"  href="//www.vitonica.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Vitónica
+         </a></li><li><a class="list-item foot-list-item"  href="//www.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Trendencias
+         </a></li><li><a class="list-item foot-list-item"  rel="nofollow"  href="//decoracion.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Decoesfera
+         </a></li><li><a class="list-item foot-list-item"  href="//www.compradiccion.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Compradiccion
+         </a></li><li><a class="list-item foot-list-item"  href="//www.poprosa.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Poprosa
+         </a></li></ul>
+  </div>
+ 
+   </div>
+       <div class="latam-blogs">
+     <p class="channel-title">
+      Ediciones Internacionales
+     </p>
+           <div class="links-category">
+    <ul><li><a class="list-item foot-list-item"  href="//www.xataka.com.mx?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka México
+         </a></li><li><a class="list-item foot-list-item"  href="https://www.xatakaon.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka On
+         </a></li><li><a class="list-item foot-list-item"  href="//www.xataka.com.co?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka Colombia
+         </a></li><li><a class="list-item foot-list-item"  href="//www.xataka.com.ar?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka Argentina
+         </a></li><li><a class="list-item foot-list-item"  href="//www.xataka.com.br?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Xataka Brasil
+         </a></li></ul>
+  </div>
+   <div class="links-category">
+    <ul><li><a class="list-item foot-list-item"  href="//www.3djuegos.lat#utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           3DJuegos LATAM
+         </a></li></ul>
+  </div>
+   <div class="links-category">
+    <ul><li><a class="list-item foot-list-item"  href="https://www.sensacine.com.mx#utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Sensacine México
+         </a></li><li><a class="list-item foot-list-item"  href="https://www.sensacine.com.co#utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Sensacine Colombia
+         </a></li></ul>
+  </div>
+   <div class="links-category">
+    <ul><li><a class="list-item foot-list-item"  href="//www.directoalpaladar.com.mx?utm_source=xataka&utm_medium=network&utm_campaign=footer">
+           Directo al Paladar México
+         </a></li></ul>
+  </div>
+ 
+    </div>
+             <div class="foot-cookie-link">
+     <a href="javascript:Didomi.preferences.show()" class="list-item">Preferencias de Privacidad</a>
+           <a href="https://weblogs.webedia.es/aviso-legal.html" class="list-item">Política de privacidad</a>
+         </div>
+     </div>
+ </div>
+</div>
+ <aside id="head-favicons" class="head-favicons-container m-is-later js-head-favicons m-favicons-compact">
+ <div class="head-favicons">
+  <div class="head-favicons-index head-webedia-logo">
+   <a class="js-group-toggle" href="#" data-target="#head-network"><abbr title="Webedia">Webedia</abbr></a>
+  </div>
+  <ul class="head-favicons-list">
+                                 <li>
+      <a class="favicon tec-xataka
+              favicon-current
+       " rel="nofollow" href="//www.xataka.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Xataka</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-vidaextra
+       "  href="//www.vidaextra.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Vida Extra</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon oci-espinof
+       "  href="//www.espinof.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Espinof</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-genbeta
+       "  href="//www.genbeta.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Genbeta</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon est-directoalpaladar
+       "  href="//www.directoalpaladar.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Directo al Paladar</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon est-trendencias
+       "  href="//www.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Trendencias</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-applesfera
+       "  href="//www.applesfera.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Applesfera</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-xatakamovil
+       "  href="//www.xatakamovil.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Xataka Móvil</span>
+      </a>
+     </li>
+                                     <li>
+      <a class="favicon est-decoesfera
+       " rel="nofollow" href="//decoracion.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Decoesfera</span>
+      </a>
+     </li>
+                                     <li>
+      <a class="favicon est-vitonica
+       " rel="nofollow" href="//www.vitonica.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Vitónica</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-xatakandroid
+       "  href="//www.xatakandroid.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Xataka Android</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-xatakahome
+       "  href="//www.xatakahome.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Xataka Smart Home</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-compradiccion
+       "  href="//www.compradiccion.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Compradiccion</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tech-3djuegos
+       "  href="//www.3djuegos.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>3DJuegos</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon oci-sensacine
+       "  href="https://www.sensacine.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Sensacine</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tech-millenium
+       "  href="//www.millenium.gg?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>MGG</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon est-poprosa
+       "  href="//www.poprosa.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Poprosa</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-mundoxiaomi
+       "  href="//www.mundoxiaomi.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Mundo Xiaomi</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-3djuegospc
+       "  href="//www.3djuegospc.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>3DJuegos PC</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-3djuegosguias
+       "  href="//www.3djuegosguias.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>3DJuegos Guías</span>
+      </a>
+     </li>
+                          <li>
+      <a class="favicon tec-territorioese
+       "  href="//www.territorioese.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons">
+       <span>Territorio S</span>
+      </a>
+     </li>
+         </ul>
+ </div>
+</aside>
+<aside class="favicons-expanded-container js-favicons-expand" id="head-network">
+ <div class="favicons-expanded">
+           <div class="favicons-expanded-inner">
+    <ul><li><h4>Tecnología</h4></li><li><a class="favicon tec-xataka"  rel="nofollow"  href="//www.xataka.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Xataka
+     </a></li><li><a class="favicon tec-xatakamovil"  href="//www.xatakamovil.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Xataka Móvil
+     </a></li><li><a class="favicon tec-xatakandroid"  href="//www.xatakandroid.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Xataka Android
+     </a></li><li><a class="favicon tec-xatakahome"  href="//www.xatakahome.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Xataka Smart Home
+     </a></li><li><a class="favicon tec-applesfera"  href="//www.applesfera.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Applesfera
+     </a></li><li><a class="favicon tec-genbeta"  href="//www.genbeta.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Genbeta
+     </a></li><li><a class="favicon tec-mundoxiaomi"  href="//www.mundoxiaomi.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Mundo Xiaomi
+     </a></li><li><a class="favicon tec-territorioese"  href="//www.territorioese.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Territorio S
+     </a></li></ul>
+  </div>
+   <div class="favicons-expanded-inner">
+    <ul><li><h4>Videojuegos</h4></li><li><a class="favicon tech-3djuegos"  href="//www.3djuegos.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>3DJuegos
+     </a></li><li><a class="favicon tec-vidaextra"  href="//www.vidaextra.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Vida Extra
+     </a></li><li><a class="favicon tech-millenium"  href="//www.millenium.gg?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>MGG
+     </a></li><li><a class="favicon tec-3djuegospc"  href="//www.3djuegospc.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>3DJuegos PC
+     </a></li><li><a class="favicon tec-3djuegosguias"  href="//www.3djuegosguias.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>3DJuegos Guías
+     </a></li></ul>
+  </div>
+   <div class="favicons-expanded-inner">
+    <ul><li><h4>Entretenimiento</h4></li><li><a class="favicon oci-sensacine"  href="https://www.sensacine.com#utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Sensacine
+     </a></li><li><a class="favicon oci-espinof"  href="//www.espinof.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Espinof
+     </a></li></ul>
+  </div>
+   <div class="favicons-expanded-inner">
+    <ul><li><h4>Gastronomía</h4></li><li><a class="favicon est-directoalpaladar"  href="//www.directoalpaladar.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Directo al Paladar
+     </a></li></ul>
+  </div>
+   <div class="favicons-expanded-inner">
+    <ul><li><h4>Estilo de vida</h4></li><li><a class="favicon est-vitonica"  rel="nofollow"  href="//www.vitonica.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Vitónica
+     </a></li><li><a class="favicon est-trendencias"  href="//www.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Trendencias
+     </a></li><li><a class="favicon est-decoesfera"  rel="nofollow"  href="//decoracion.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Decoesfera
+     </a></li><li><a class="favicon tec-compradiccion"  href="//www.compradiccion.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Compradiccion
+     </a></li><li><a class="favicon est-poprosa"  href="//www.poprosa.com?utm_source=xataka&utm_medium=network&utm_campaign=favicons"><span></span>Poprosa
+     </a></li></ul>
+  </div>
+ 
+ </div>
+</aside>
+
+ <div id="fb-root"></div>
+   <section id="sections" class="head-menu-container head-menu-sections">
+ <a href="#sections" class="head-menu-toggler js-toggle"></a>
+ <div class="head-menu">
+  <a href="#sections" class="close close-corner js-toggle js-menu-close">Inicio</a>
+  <div id="opt-in"></div>
+     <div class="head-menu-partners">
+    <p class="nav-heading">Partners</p>
+    <ul>
+           <li><a class="head-list-item head-brand-link head-brand-tecnologialg js-track-header-event" href="/tecnologialg">
+          Life´s Good by LG
+         </a></li>           <li><a class="head-list-item head-brand-link head-brand-fullelectric js-track-header-event" href="/fullelectric">
+          Hyundai Full Electric
+         </a></li>           <li><a class="head-list-item head-brand-link head-brand-madridemprende js-track-header-event" href="/madridemprende">
+          Madrid Emprende
+         </a></li>           <li><a class="head-list-item head-brand-link head-brand-mueveteconrenault js-track-header-event" href="/mueveteconrenault">
+          muévete con Renault
+         </a></li>           <li><a class="head-list-item head-brand-link head-brand-hpimpulsatupyme js-track-header-event" href="/hpimpulsatupyme">
+          HP impulsa tu pyme
+         </a></li>         </ul>
+   </div>
+       <div class="head-menu-extras">
+    <p class="nav-heading">Destacamos</p>
+    <ul>
+                     <li><a class="head-list-item head-brand-link head-brand-tecnologiazen js-track-header-event" href="https://premios.xataka.com/">
+      Premios Xataka
+      </a></li>
+                          <li><a class="head-list-item head-brand-link head-brand-tecnologiazen js-track-header-event" href="/black-friday">
+      Black Friday
+      </a></li>
+         </ul>
+   </div>
+       <div id="sections-search"></div>
+   <script>
+    document.getElementById("sections-search").innerHTML = '\
+     <div class="head-menu-search">\
+      <div class="head-search-form js-search-form">\
+       <input id="search-field-1" type="text" placeholder="Buscar en Xataka" class="search-container-1" data-container="#search-container-1">\
+       <button class="head-search-button js-search-button" data-field="#search-field-1">Buscar</button>\
+      </div>\
+     </div>';
+   </script>
+   <div id="search-container-1" class="js-search-results"></div>
+    <div id="sections-login-wrapper" class="sections-login">
+   <div id="js-login" class="user-card"></div>
+  </div>
+  <nav class="head-menu-categories">
+    <ul>
+           <li><a class="head-list-item js-track-header-event" href="/categoria/streaming">Streaming</a></li>           <li><a class="head-list-item js-track-header-event" href="/categoria/analisis">Análisis</a></li>           <li><a class="head-list-item js-track-header-event" href="/categoria/espacio">Espacio</a></li>           <li><a class="head-list-item js-track-header-event" href="/categoria/moviles">Móviles</a></li>           <li><a class="head-list-item js-track-header-event" href="/categoria/energia">Energía</a></li>           <li><a class="head-list-item js-track-header-event" href="/categoria/movilidad">Xataka Movilidad</a></li>                <li><a class="head-list-item js-track-header-event" href="/tag/apple">Apple</a></li>           <li><a class="head-list-item js-track-header-event" href="/tag/samsung">Samsung</a></li>           <li><a class="head-list-item js-track-header-event" href="/tag/inteligencia-artificial">Inteligencia artificial</a></li>           <li><a class="head-list-item js-track-header-event" href="/tag/china">China</a></li>           <li><a class="head-list-item js-track-header-event" href="/tag/empleo">Empleo</a></li>           <li><a class="head-list-item js-track-header-event" href="/tag/windows-11">Windows 11</a></li>         </ul>
+    <p class="head-more-item">
+     <a href="/archivos" class="btn js-track-header-event">Ver más temas</a>
+    </p>
+  </nav>
+  <aside class="head-menu-follow">
+   <span class="head-item-meta">Síguenos</span>
+    <ul>
+ <li>
+  <a class="icon-whatsapp link-whatsapp" href="https://whatsapp.com/channel/0029VaAOhno4tRrjQkLKjI2u" rel="nofollow">WhatsApp</a>
+ </li>
+ <li>
+  <a href="https://twitter.com/xataka" class="icon-x link-x" rel="nofollow">Twitter</a>
+ </li>
+ <li>
+  <a href="https://www.facebook.com/Xataka" class="icon-facebook link-facebook" rel="nofollow">Facebook</a>
+ </li>
+   <li>
+   <a href="https://www.youtube.com/user/xatakatv?sub_confirmation=1" class="icon-youtube link-youtube" rel="nofollow">Youtube</a>
+  </li>
+     <li>
+   <a class="icon-instagram link-instagram" href="https://instagram.com/xataka" rel="nofollow">Instagram</a>
+  </li>
+    <li>
+   <a href="https://telegram.me/xataka" class="icon-telegram link-telegram" rel="nofollow">Telegram</a>
+  </li>
+  <li>
+  <a class="icon-rss link-rss" href="/index.xml" rel="nofollow">RSS</a>
+ </li>
+     <li>
+   <a href="https://flipboard.com/@xataka" class="icon-flipboard link-flipboard" rel="nofollow">Flipboard</a>
+  </li>
+     <li>
+   <a href="https://www.linkedin.com/company/11275845/" class="icon-linkedin link-linkedin" rel="nofollow">LinkedIn</a>
+  </li>
+    <li>
+   <a class="icon-tiktok link-tiktok" href="https://www.tiktok.com/@xataka" rel="nofollow">Tiktok</a>
+  </li>
+  <li id="sections-newsletter">
+  <a href="#head-menu-newsletter" class="icon-email link-email js-toggle-subscribe">E-mail</a>
+ </li>
+</ul>
+  </aside>
+  <section id="head-menu-newsletter" class="head-menu-newsletter">
+   <a href="#head-menu-newsletter" class="close close-corner js-close-corner"></a>
+   <form class="newsletter-form head-newsletter-form js-subscription" method="post" data-url="https://www.xataka.com/modules/subscription/form" data-id="#head-menu-newsletter">
+    <h3 class="newsletter-heading">Recibe &quot;Xatakaletter&quot;, nuestra newsletter semanal </h3>
+    <p><input class="newsletter-input js-email" type="email" placeholder='Tu correo electrónico' required>
+    <button class="btn-primary newsletter-button js-subscribe-btn" type="submit">Suscribir</button></p>
+    <small class="newsletter-legal-disclaimer js-disclaimer">Suscribiéndote aceptas nuestra <a href="https://weblogs.webedia.es/aviso-legal.html">política de privacidad</a></small>
+    <div class="alert-success js-subscribe-success" style="display: none;"></div>
+    <div class="alert-error js-subscribe-error" style="display: none;">Error: el correo electrónico no tiene el formato correcto</div>
+   </form>
+  </section>
+  <nav class="head-menu-extras">
+   <ul class="head-list">
+         <li><a class="head-list-item section-tv js-track-header-event" href="https://www.youtube.com/user/xatakatv?sub_confirmation=1">Xataka
+      <span>TV</span>
+    </a></li>
+        <li><a class="head-list-item section-staff js-track-header-event" href="/quienes-somos">Equipo editorial</a></li>
+    <li><a class="head-list-item section-contact js-track-header-event" href="/contacto">Contacta con nosotros</a></li>
+    <li id="sections-login">
+     <span id="login"></span>
+    </li>
+   </ul>
+  </nav>
+         <aside class="head-menu-external">
+     <p class="nav-heading">Más sitios que te gustarán</p>
+     <ul>
+                           <li><a class="head-list-item js-track-header-event"  href="https://www.vidaextra.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Vidaextra</a></li>                           <li><a class="head-list-item js-track-header-event"  href="https://www.xatakandroid.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Android</a></li>                           <li><a class="head-list-item js-track-header-event"  href="https://www.xatakamovil.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Móvil</a></li>                           <li><a class="head-list-item js-track-header-event"  href="https://www.applesfera.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Applesfera</a></li>                           <li><a class="head-list-item js-track-header-event"  href="https://www.genbeta.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Genbeta</a></li>           </ul>
+    </aside>
+      <div class="head-menu-channels">
+    <h3>Explora en nuestros medios</h3>
+    <ul>
+           <li><a href="#head-channel-tecnologia" class="head-list-item head-channel-caption explore-weblogs-sl-toggle">
+         Tecnología
+         <span class="head-item-meta m-desc">Móviles, tablets, aplicaciones, videojuegos, fotografía, domótica...</span></a><ul id="head-channel-tecnologia" class="head-channel-list"><li><a class="head-list-item tec-xataka js-track-header-event" rel="nofollow"  href="//www.xataka.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka</a></li><li><a class="head-list-item tec-xatakamovil js-track-header-event"   href="//www.xatakamovil.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Móvil</a></li><li><a class="head-list-item tec-xatakandroid js-track-header-event"   href="//www.xatakandroid.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Android</a></li><li><a class="head-list-item tec-xatakahome js-track-header-event"   href="//www.xatakahome.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Smart Home</a></li><li><a class="head-list-item tec-applesfera js-track-header-event"   href="//www.applesfera.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Applesfera</a></li><li><a class="head-list-item tec-genbeta js-track-header-event"   href="//www.genbeta.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Genbeta</a></li><li><a class="head-list-item tec-mundoxiaomi js-track-header-event"   href="//www.mundoxiaomi.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Mundo Xiaomi</a></li><li><a class="head-list-item tec-territorioese js-track-header-event"   href="//www.territorioese.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Territorio S</a></li></ul></li>           <li><a href="#head-channel-videojuegos" class="head-list-item head-channel-caption explore-weblogs-sl-toggle">
+         Videojuegos
+         <span class="head-item-meta m-desc">Consolas, juegos, PC, PS4, Switch, Nintendo 3DS y Xbox...</span></a><ul id="head-channel-videojuegos" class="head-channel-list"><li><a class="head-list-item tech-3djuegos js-track-header-event"   href="//www.3djuegos.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">3DJuegos</a></li><li><a class="head-list-item tec-vidaextra js-track-header-event"   href="//www.vidaextra.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Vida Extra</a></li><li><a class="head-list-item tech-millenium js-track-header-event"   href="//www.millenium.gg?utm_source=xataka&utm_medium=network&utm_campaign=footer">MGG</a></li><li><a class="head-list-item tec-3djuegospc js-track-header-event"   href="//www.3djuegospc.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">3DJuegos PC</a></li><li><a class="head-list-item tec-3djuegosguias js-track-header-event"   href="//www.3djuegosguias.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">3DJuegos Guías</a></li></ul></li>           <li><a href="#head-channel-entretenimiento" class="head-list-item head-channel-caption explore-weblogs-sl-toggle">
+         Entretenimiento
+         <span class="head-item-meta m-desc">Series, cine, estrenos en cartelera, premios, rodajes, nuevas películas, televisión...</span></a><ul id="head-channel-entretenimiento" class="head-channel-list"><li><a class="head-list-item oci-sensacine js-track-header-event"   href="https://www.sensacine.com#utm_source=xataka&utm_medium=network&utm_campaign=footer">Sensacine</a></li><li><a class="head-list-item oci-espinof js-track-header-event"   href="//www.espinof.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Espinof</a></li></ul></li>           <li><a href="#head-channel-gastronomia" class="head-list-item head-channel-caption explore-weblogs-sl-toggle">
+         Gastronomía
+         <span class="head-item-meta m-desc">Recetas, recetas de cocina fácil, pinchos, tapas, postres...</span></a><ul id="head-channel-gastronomia" class="head-channel-list"><li><a class="head-list-item est-directoalpaladar js-track-header-event"   href="//www.directoalpaladar.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Directo al Paladar</a></li></ul></li>           <li><a href="#head-channel-Estilodevida" class="head-list-item head-channel-caption explore-weblogs-sl-toggle">
+         Estilo de vida
+         <span class="head-item-meta m-desc">Moda, belleza, estilo, salud, fitness, familia, gastronomía, decoración, famosos...</span></a><ul id="head-channel-Estilodevida" class="head-channel-list"><li><a class="head-list-item est-vitonica js-track-header-event" rel="nofollow"  href="//www.vitonica.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Vitónica</a></li><li><a class="head-list-item est-trendencias js-track-header-event"   href="//www.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Trendencias</a></li><li><a class="head-list-item est-decoesfera js-track-header-event" rel="nofollow"  href="//decoracion.trendencias.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Decoesfera</a></li><li><a class="head-list-item tec-compradiccion js-track-header-event"   href="//www.compradiccion.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Compradiccion</a></li><li><a class="head-list-item est-poprosa js-track-header-event"   href="//www.poprosa.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Poprosa</a></li></ul></li>           <li><a href="#head-channel-EdicionesInternacionales" class="head-list-item head-channel-caption explore-weblogs-sl-toggle">
+         Ediciones Internacionales
+         <span class="head-item-meta m-desc">México, USA, Colombia...</span></a><ul id="head-channel-EdicionesInternacionales" class="head-channel-list"><li><a class="head-list-item tec-xataka js-track-header-event"   href="//www.xataka.com.mx?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka México</a></li><li><a class="head-list-item est-directoalpaladar js-track-header-event"   href="//www.directoalpaladar.com.mx?utm_source=xataka&utm_medium=network&utm_campaign=footer">Directo al Paladar México</a></li><li><a class="head-list-item oci-sensacine js-track-header-event"   href="https://www.sensacine.com.mx#utm_source=xataka&utm_medium=network&utm_campaign=footer">Sensacine México</a></li><li><a class="head-list-item tec-3djuegoslat js-track-header-event"   href="//www.3djuegos.lat#utm_source=xataka&utm_medium=network&utm_campaign=footer">3DJuegos LATAM</a></li><li><a class="head-list-item tec-xatakaon js-track-header-event"   href="https://www.xatakaon.com?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka On</a></li><li><a class="head-list-item tec-xataka js-track-header-event"   href="//www.xataka.com.co?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Colombia</a></li><li><a class="head-list-item tec-xataka js-track-header-event"   href="//www.xataka.com.ar?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Argentina</a></li><li><a class="head-list-item tec-xataka js-track-header-event"   href="//www.xataka.com.br?utm_source=xataka&utm_medium=network&utm_campaign=footer">Xataka Brasil</a></li><li><a class="head-list-item oci-sensacine js-track-header-event"   href="https://www.sensacine.com.co#utm_source=xataka&utm_medium=network&utm_campaign=footer">Sensacine Colombia</a></li></ul></li>         </ul>
+   </div>
+    <nav class="head-menu-links">
+   <ul class="head-list">
+    <li><a class="head-list-item js-track-header-event" href="https://www.weblogssl.com/contenidos">Condiciones de uso</a></li>
+    <li><a class="head-list-item js-track-header-event" href="https://www.weblogssl.com/cookies">Condiciones de uso de cookies</a></li>
+    <li><a class="head-list-item js-track-header-event" href="mailto:publicidad@webedia-group.com">Publicidad</a></li>
+   </ul>
+  </nav>
+ </div>
+</section>
+<div id="headlines" class="head-menu-container head-menu-new m-menu-right">
+ <a href="#headlines" class="head-menu-toggler js-toggle"></a>
+ <div class="head-menu">
+  <a href="#headlines" class="close close-corner js-toggle">Inicio</a>
+     <p class="nav-heading">Reciente</p>
+    <ul id="recent-posts">
+    <li><a href="/ingenieria-y-megaconstrucciones/secretos-puerto-shanghai-coloso-comercio-internacional-donde-reina-automatizacion" class="head-new-item">
+  Los secretos del Puerto de Shanghái, el coloso del comercio internacional donde reina la automatización
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T20:01:55Z"></time></span></a></li> <li><a href="/magnet/hubo-tiempo-que-caca-movio-economia-medio-mundo-se-llamaba-guano-enseno-valiosa-leccion-a-peru" class="head-new-item">
+  Hubo un tiempo en que la caca movió la economía de medio mundo. Se llamaba guano y enseñó una valiosa lección a Perú 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T19:01:56Z"></time></span></a></li> <li><a href="https://www.espinof.com/estrenos/capitan-america-4-acaba-hundirse-taquilla-mayores-caidas-marvel-solamente-dos-peliculas-bajaron-durante-su-segundo-fin-semana-cines?utm_source=xataka&utm_medium=network&utm_campaign=headlines_reciente" class="head-new-item m-crosspost">
+  'Capitán América 4' acaba de hundirse en taquilla con una de las mayores caídas de Marvel. Solamente dos películas bajaron más durante su segundo fin de semana en cines 
+  <span class="head-item-meta">
+   en Espinof <time class="js-header-post" datetime="2025-02-23T19:33:57Z"></time></span></a></li> <li><a href="/investigacion/atlantico-tiene-ciudad-perdida-clave-vida-otros-planetas-ahora-esta-peligro" class="head-new-item">
+  El Atlántico tiene una 'Ciudad Perdida' con la clave de la vida en otros planetas. Ahora está en peligro 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T18:31:56Z"></time></span></a></li> <li><a href="/magnet/caballo-troya-que-expats-estadounidenses-estan-introduciendo-espana-cultura-propina" class="head-new-item">
+  El caballo de Troya que los "expats" estadounidenses están introduciendo en España: la cultura de la propina 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T18:01:55Z"></time></span></a></li> <li><a href="/espacio/existe-red-cosmica-carreteras-formada-filamentos-gas-materia-oscura-acabamos-captarla-chile" class="head-new-item">
+  Existe una red cósmica de "carreteras" formada por filamentos de gas y materia oscura. Acabamos de captarla desde Chile
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T17:31:55Z"></time></span></a></li> <li><a href="/investigacion/para-transportarnos-al-antiguo-egipto-unos-investigadores-llevan-meses-haciendo-sola-cosa-oler-momias-hace-5-000-anos" class="head-new-item">
+  Para transportarnos al Antiguo Egipto, unos investigadores llevan meses haciendo una sola cosa: oler momias de hace 5.000 años 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T17:01:56Z"></time></span></a></li> <li><a href="/magnet/espana-no-solo-se-encarece-compra-viviendas-garajes-viven-su-propio-boom-subidas-37" class="head-new-item">
+  España no vive únicamente una escalada vertiginosa en el precio de la vivienda: también una crisis de garajes
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T16:31:56Z"></time></span></a></li> <li><a href="/literatura-comics-y-juegos/he-probado-boox-palma-2-combinar-kindle-movil-android-sale-bien-casi-siempre" class="head-new-item">
+  He probado el BOOX Palma 2: combinar un Kindle con un móvil Android sale bien... casi siempre 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T16:15:56Z"></time></span></a></li> <li><a href="/ecologia-y-naturaleza/dentro-de-200-anos-los-arqueologos-buscaran-en-nuestra-basura-y-encontraran-una-imagen-terrible-de-nosotros-mismos-la-sucia-realidad-de-lo-que-tiramos" class="head-new-item">
+  "Dentro de 200 años, los arqueólogos buscarán en nuestra basura y encontrarán una imagen terrible de nosotros mismos": la sucia realidad de lo que tiramos
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T16:01:56Z"></time></span></a></li> <li><a href="/ingenieria-y-megaconstrucciones/china-recurrio-a-material-peculiar-para-construir-puente-maritimo-largo-mundo-bambu" class="head-new-item">
+  Para construir el puente marítimo más largo mundo, China recurrió a un material peculiar: el bambú
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T15:31:55Z"></time></span></a></li> <li><a href="/cine-y-tv/directora-sustancia-debuto-hace-30-anos-homenaje-casero-a-star-wars-que-ahora-puedes-ver-gratis" class="head-new-item">
+  La directora de 'La sustancia' debutó hace 30 años con un homenaje casero a Star Wars que ahora puedes ver gratis
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T15:01:56Z"></time></span></a></li> <li><a href="/energia/renacer-sistema-antiguo-que-esta-iluminando-aldeas-remotas-india-rueda-hidraulica" class="head-new-item">
+  El renacer de un sistema antiguo que está iluminando aldeas remotas en India: la rueda hidráulica 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T14:31:56Z"></time></span></a></li> <li><a href="/literatura-comics-y-juegos/gran-triunfo-economico-lego-como-consiguio-escapar-quiebra-convertirse-maquina-hacer-dinero" class="head-new-item">
+  El gran triunfo económico de LEGO: cómo consiguió escapar de la quiebra y convertirse en una máquina de hacer dinero 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T14:01:56Z"></time></span></a></li> <li><a href="/aplicaciones/tu-tambien-ves-minijuegos-todas-partes-linkedin-no-estas-solo-estrategia-le-esta-funcionando" class="head-new-item">
+  Si tú también ves minijuegos por todas partes de LinkedIn, no estás solo: es una estrategia y le está funcionando 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T13:31:56Z"></time></span></a></li> <li><a href="/otros-dispositivos/jaen-hay-algo-que-olivos-como-empresa-local-esta-triunfando-fabricando-filamentos-para-impresion-3d" class="head-new-item">
+  En Jaén hay algo más que olivos: cómo una empresa local está triunfando fabricando filamentos para la impresión 3D
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T12:31:55Z"></time></span></a></li> <li><a href="https://www.genbeta.com/a-fondo/despues-15-anos-programando-esto-que-desearia-haber-sabido-primer-dia-hablan-siete-profesionales-programacion-1?utm_source=xataka&utm_medium=network&utm_campaign=headlines_reciente" class="head-new-item m-crosspost">
+  Después de 15 años programando, esto es lo que desearía haber sabido el primer día: hablan siete profesionales de la programación 
+  <span class="head-item-meta">
+   en Genbeta <time class="js-header-post" datetime="2025-02-23T13:22:34Z"></time></span></a></li> <li><a href="/magnet/cada-dia-miles-personas-se-burlan-imperio-saberlo-sus-desayunos-responsable-cruasan" class="head-new-item">
+  Cada día miles de personas se burlan sin saberlo de un imperio cuando desayunan. El responsable: el cruasán
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T12:01:55Z"></time></span></a></li> <li><a href="/materiales/nuevo-supercondensador-plastico-promete-que-baterias-no-energia-inmediata-carga-instantanea" class="head-new-item">
+  Un nuevo supercondensador de plástico promete lo que las baterías no: energía inmediata y carga instantánea 
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T11:31:55Z"></time></span></a></li> <li><a href="/robotica-e-ia/opinion-director-general-microsoft-acerca-ia-inusual-sospecha-cuanto-crecera-economia-global-gracias-a-ella" class="head-new-item">
+  La opinión del director general de Microsoft acerca de la IA es inusual. Y sospecha cuánto crecerá la economía global gracias a ella
+  <span class="head-item-meta"><time class="js-header-post" datetime="2025-02-23T11:01:56Z"></time></span></a></li>  </ul>
+  <p class="head-more-item"><a href="#" class="btn" id="view-more" data-blog="xataka">Ver más artículos</a></p>
+     <div class="head-menu-video">
+    <p class="nav-heading"> Xataka
+     <span>TV</span>
+    </p>
+    <ul id="recent-videos">
+          <li><a href="https://www.xataka.com/analisis/xiaomi-smart-band-9-pro-analisis-caracteristicas-precio-especificaciones" class="head-new-item"><span class="head-new-video-thumb"><img alt="XIAOMI&#x20;SMART&#x20;BAND&#x20;9&#x20;PRO&#x3A;&#x20;Mi&#x20;experiencia&#x20;UN&#x20;MES&#x20;DESPU&#x00C9;S&#x20;&#x7C;&#x20;Tiro&#x20;mi&#x20;SMARTWATCH&#x20;a&#x20;la&#x20;basura" src="https://img.youtube.com/vi/BiQfL2V8_Xw/mqdefault.jpg" width="320" height="180"></span><span class="head-new-video-desc">XIAOMI SMART BAND 9 PRO: Mi experiencia UN MES DESPUÉS | Tiro mi SMARTWATCH a la basura</span></a></li>     <li><a href="https://www.xataka.com/" class="head-new-item"><span class="head-new-video-thumb"><img alt="POWER&#x20;BALANCE&#x3A;&#x20;C&#x00F3;mo&#x20;unas&#x20;pulseras&#x20;&#x201C;deportivas&#x201D;&#x20;ESTAFARON&#x20;a&#x20;todo&#x20;el&#x20;mundo" src="https://img.youtube.com/vi/Lk37LsYkbdk/mqdefault.jpg" width="320" height="180"></span><span class="head-new-video-desc">POWER BALANCE: Cómo unas pulseras “deportivas” ESTAFARON a todo el mundo</span></a></li>     <li><a href="https://www.xataka.com/analisis/xiaomi-redmi-note-14-pro-movil-que-podia-haber-sido-mejor-gama-media-2025" class="head-new-item"><span class="head-new-video-thumb"><img alt="XIAOMI&#x20;REDMI&#x20;NOTE&#x20;14&#x20;PRO&#x2B;&#x20;UN&#x20;MES&#x20;DESPU&#x00C9;S&#x20;&#x7C;&#x20;Por&#x20;esto&#x20;no&#x20;es&#x20;el&#x20;MEJOR&#x20;GAMA&#x20;MEDIA&#x20;de&#x20;2025&#x20;&#x1F494;" src="https://img.youtube.com/vi/PyPwD9gQdQQ/mqdefault.jpg" width="320" height="180"></span><span class="head-new-video-desc">XIAOMI REDMI NOTE 14 PRO+ UN MES DESPUÉS | Por esto no es el MEJOR GAMA MEDIA de 2025 💔</span></a></li>    </ul>
+    <p class="head-more-item"><a href="#" class="btn" id="view-more-videos" data-blog="xataka">Ver más vídeos</a></p>
+   </div>
+   </div>
+</div>
+<nav id="search" class="head-menu-container head-menu-searchapp">
+</nav>
+<script>
+ document.getElementById("search").innerHTML = '\
+ <a href="#search" class="head-menu-toggler js-toggle"></a>\
+ <div class="head-menu">\
+  <a href="#search" class="close close-corner js-toggle">Inicio</a>\
+  <h2>Buscar</h2>\
+  <div class="head-menu-search">\
+   <div class="head-search-form js-search-form">\
+    <input id="search-field-2" type="text" placeholder="Buscar en Xataka" class="search-container-2" data-container="#search-container-2">\
+    <button class="head-search-button js-search-button" data-field="#search-field-2">Buscar</button>\
+   </div>\
+  </div>\
+  <section id="search-container-2" class="js-search-results"></section>\
+ </div>';
+</script>
+<nav class="nav nav-list nav-register" id="nav-twitter-register"></nav>
+<div id="react-login"></div>
+<nav class="nav nav-list nav-login" id="nav-login"></nav>
+<nav class="nav nav-list nav-register" id="nav-register"></nav>
+<nav class="nav nav-list nav-login" id="nav-recover"></nav>
+<nav class="nav nav-list nav-login" id="nav-pick"></nav>
+<nav class="nav nav-list nav-login" id="nav-recover-twitter"></nav>
+<nav class="nav nav-list nav-login" id="nav-recover-facebook"></nav>
+<div id="js-edit-user-profile-form"></div>
+<div id="js-user-comments"></div>
+<div id="js-modal-user-deactivate"></div>
+
+  
+    <div id="cookies-overlay" class="cookies-overlay"></div>
+   </div>
+  </div>
+ </div>
+</div>
+  <div id="div-gpt-int" style="width:1px; height:1px;">
+   </div>
+  <div id="div-gpt-int2" style="width:1px; height:1px;">
+   </div>
+ <script>
+ (function() {
+  var lazyElements    = document.getElementsByClassName('sf-lazy')
+  ,   srcsetSupported = false
+  ,   threshold;
+
+  if (!/Edge\/\d+/.test(navigator.userAgent)) {
+   srcsetSupported = 'srcset' in document.createElement('img');
+  }
+
+  function updateAttributes(element) {
+   var sfSrcset = element.getAttribute('data-sf-srcset') || element.getAttribute('sf-srcset');
+   var sfSrc = element.getAttribute('data-sf-src') || element.getAttribute('sf-src');
+   var sizes = element.getAttribute('data-sizes');
+   if (sfSrcset) {
+    element.setAttribute('srcset', sfSrcset);
+   }
+   if (sfSrc) {
+    element.setAttribute('src', sfSrc);
+   }
+   if (sizes) {
+    element.setAttribute('sizes', sizes);
+   }
+   element.classList.remove('sf-lazy');
+  }
+
+  threshold = (window.innerHeight || document.documentElement.clientHeight) + 100;
+  function lazyLoad() {
+   var coords, element, i, isVisible;
+   if (0 == lazyElements.length) {
+    document.removeEventListener('scroll', lazyLoad);
+    return false;
+   }
+
+   for (i = 0; i < lazyElements.length; i++) {
+    element = lazyElements[i];
+    coords = element.getBoundingClientRect();
+    isVisible = (coords.top >= 0 && coords.left >= 0 && coords.top) <= threshold;
+    if (isVisible) {
+     updateAttributes(element);
+    }
+   }
+  }
+
+  if (srcsetSupported) {
+   document.addEventListener('scroll', lazyLoad);
+   lazyLoad();
+  }
+ })();
+</script>
+   <script>
+ var WSL2 = WSL2 || {};
+ WSL2.config = WSL2.config || {};
+ WSL2.config.fbapikey = "355823546895";
+ WSL2.config.fbApiVersion = "v8.0";
+ WSL2.config.siteName = "Xataka";
+ WSL2.config.newsletterSiteName = "Xatakaletter";
+ WSL2.config.jsPath = "https://img.weblogssl.com/LPbackend/prod/v2/js";
+ WSL2.config.gtmContainerId = "GTM-T9QSQ3V";
+ WSL2.config.gtmContainerIdGlobal = "GTM-TWST58M";
+ WSL2.config.imagePath = "https://img.weblogssl.com/css/xataka/p/common";
+ WSL2.config.desktopSiteUrl = "https://www.xataka.com";
+ WSL2.config.cookieDomain = "";
+ WSL2.config.enableEditorialRecommendations = "1";
+ WSL2.config.s3ImagePath = "https://i.blogs.es";
+ WSL2.config.socialTwitter = "xataka";
+ WSL2.config.enableUniformSocialShareGallery = "1";
+ WSL2.config.twitterSocial = "xataka";
+ WSL2.config.enableGiphyInComments = 0;
+ WSL2.config.enablePinterestSharing = 0;
+ WSL2.config.adminUrl = "https://admin.xataka.com";
+ WSL2.config.blogDomain = "xataka.com";
+ WSL2.config.blogMeta = {
+  siteName: "xataka",
+  mnemonic: "XTK",
+  blogDomain: "xataka.com"
+ };
+ WSL2.config.showMxSiteFloatingBox = 1;
+ WSL2.config.enableAdblockMonetization = 1;
+ WSL2.config.insuradsLink = "";
+ WSL2.config.uniformDateTimeFormat = "Y-m-d\TH:i:s\Z";
+ WSL2.config.dailymotionAutoplayLimit = 0;
+ WSL2.config.enableWebpImage = "0";
+ WSL2.config.productSiteUrl = "https://www.xataka.com";
+ WSL2.config.homepageVersion = "v4";
+ WSL2.config.desktopDailymotionPlayerId = "x8gm6";
+ WSL2.config.mobileDailymotionPlayerId = "x8gm4";
+ WSL2.config.dailymotionPlayerIdAutoplayOff = "xbl2m";
+ WSL2.config.enableOneLinkMessage = 1;
+ WSL2.config.disableDatetimeMention = "1";
+ WSL2.config.grecaptchaSiteKey = "6LeiX64UAAAAADw_CPFU4cciCrgrVCwbF_R6yFGu";
+ WSL2.config.timeZone = "Europe/Madrid";
+ WSL2.config.locale = "es";
+ WSL2.config.sendInternalPromotionAnalytics = "1";
+ WSL2.config.enableVideoPrebid = 1;
+ WSL2.config.enableGoogleLogin = 1;
+ WSL2.config.enableSocialLogin = 1;
+ WSL2.config.removeSocialLogin = 1;
+ WSL2.config.enableTaboolaIntegration = "0";
+ WSL2.config.enablePerformanceImprovements = "0";
+ WSL2.config.enableGoogleCustomSearchEngine = "0";
+ WSL2.config.enableInpEventLog = 0;
+ WSL2.config.enableGTMdidomi = "";
+ WSL2.config.enableOpenweb = 0;
+ WSL2.config.openwebSpotId = "sp_elHFZQu4";
+ WSL2.config.enablePageViewParams = "1";
+ WSL2.config.enableInternalClicks = "1";
+ WSL2.config.enableNewSocialShareFB = 1
+ WSL2.config.enableCoAuthor = 0
+ WSL2.config.enableLimitedTimeDeal = "1"
+ WSL2.config.enableDynamicIU = "1";
+ WSL2.config.enableCtcImpressions = "1";
+ WSL2.config.enableBrandEventsTracking = "";
+</script>
+<script>
+ function injectScript(src) {
+  var script = document.createElement('script');
+  script.src = src;
+  script.async = true;
+  if ('ES' === window.country) {
+    script.type = 'didomi/javascript';
+  }
+  var firstScriptTag = document.getElementsByTagName('script')[0];
+  firstScriptTag.parentNode.insertBefore(script, firstScriptTag);
+ }
+
+ if (document.querySelectorAll('div.js-dailymotion').length) {
+  injectScript('https://img.weblogssl.com/LPbackend/prod/v2/js/dailymotion-fec2d28f.js');
+ }
+</script>
+<script>
+ WSL2.config.postSubType = "normal";
+ WSL2.config.redirectDesktopRoot = 'false';
+ WSL2.config.postId = 298745;
+ WSL2.config.postTitle = "Los\u0020coches\u0020m\u00E1s\u0020vendidos\u0020en\u00202023\u0020y\u00202024\u0020en\u0020Espa\u00F1a";
+ WSL2.config.tweetText = "Comentario%20a%20Los%20coches%20m%C3%A1s%20vendidos%20en%202023%20y%202024%20en%20Espa%C3%B1a";
+ WSL2.config.twitterName = "";
+ WSL2.config.postUrl = "https://www.xataka.com/movilidad/coches-vendidos-2023-2024-espana";
+ WSL2.config.recommendationEngineVersion = 1;
+ WSL2.config.device = "desktop";
+ WSL2.config.enableNanomediaHeader = 1;
+</script>
+  <script defer src="https://img.weblogssl.com/LPbackend/prod/v2/js/postpage-fec2d28f.js"></script>
+ </body>
+</html>


### PR DESCRIPTION
When page has an article body specified in JSON-LD, the HTML fragment is passed to `DOMDocument::loadHTML`.
`DOMDocument` will parse a HTML document as ISO-8859-1, unless the document contains an XML encoding declaration or HTML meta tag setting character set.

https://stackoverflow.com/a/39148511/160386

JSON-LD typically does not contain `meta[charset]` tag so we need to add it ourselves.

At this point the input should already be in UTF-8, as we convert all inputs to that encoding everywhere except in `Graby::cleanupHtml`. There we will clarify the requirement in doc comment.

Fixes: https://github.com/j0k3r/graby/issues/359
