### PR TITLE
Remove mtm trackers like for utm

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -262,7 +262,7 @@ class HttpClient
         $uri = new Uri(str_replace('&amp;', '&', $effectiveUrl));
         parse_str($uri->getQuery(), $query);
         $queryParameters = array_filter($query, function ($k) {
-            return !(0 === stripos($k, 'utm_'));
+            return !(0 === stripos($k, 'utm_') || 0 === stripos($k, 'mtm_'));
         }, \ARRAY_FILTER_USE_KEY);
         $effectiveUrl = (string) Uri::withQueryValues(new Uri($uri->withFragment('')->withQuery('')), $queryParameters);
 

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -636,6 +636,10 @@ class HttpClientTest extends TestCase
                 'url' => 'https://example.com/foo?utm_content=111315005',
                 'expectedUrl' => 'https://example.com/foo',
             ],
+            [
+                'url' => 'https://example.com/foo?mtm_campaign=feed',
+                'expectedUrl' => 'https://example.com/foo',
+            ],
         ];
     }
 


### PR DESCRIPTION
Matomo is one of the main alternatives to Google Analytics, for some reason they decided to go with their own marketing tracking parameters prefixed with mtm_