### PR TITLE
Modify `composer.json` to allow `j0k3r/httplug-ssrf-plugin:^3.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "fossar/htmlawed": "^1.3.3",
         "guzzlehttp/psr7": "^2.0",
         "j0k3r/graby-site-config": "^1.0.181",
-        "j0k3r/httplug-ssrf-plugin": "^2.0",
+        "j0k3r/httplug-ssrf-plugin": "^2.0|^3.0",
         "j0k3r/php-readability": "^1.2.9",
         "monolog/monolog": "^1.18.0|^2.3",
         "php-http/client-common": "^2.7",

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -551,11 +551,11 @@ class Graby
      *
      * @return array{
      *   mime: '',
-     * } | array{
+     * }|array{
      *   mime: string,
      *   type: string,
      *   subtype: string,
-     * } | array{
+     * }|array{
      *   mime: string,
      *   type: string,
      *   subtype: string,
@@ -600,11 +600,11 @@ class Graby
      *
      * @param array{
      *   mime: '',
-     * } | array{
+     * }|array{
      *   mime: string,
      *   type: string,
      *   subtype: string,
-     * } | array{
+     * }|array{
      *   mime: string,
      *   type: string,
      *   subtype: string,


### PR DESCRIPTION
When installing Graby as a dependency in another project (e.g. Wallabag), it produces this output.

```
Package php-http/message-factory is abandoned, you should avoid using it. Use psr/http-factory instead.
```

The [3.0 release](https://github.com/j0k3r/httplug-ssrf-plugin/releases/tag/v3.0.0) `j0k3r/httplug-ssrf-plugin` implemented the change suggested above.

However, Graby currently requires `j0k3r/httplug-ssrf-plugin:^2.0`, which prevents it from making use of the above change.

This PR modifies the version requirements in `composer.json` to allow Graby to use either 2.x or 3.x of `j0k3r/httplug-ssrf-plugin` depending on the runtime environment.