### PR TITLE
Migrating to Codecov

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,16 +85,11 @@ jobs:
       - name: "Run PHPUnit (with coverage)"
         run: "php vendor/bin/simple-phpunit -v --coverage-clover build/logs/clover.xml"
 
-      - name: "Retrieve Coveralls phar"
-        run: "wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.4.2/php-coveralls.phar"
-
-      - name: "Enable Coveralls phar"
-        run: "chmod +x php-coveralls.phar"
-
-      - name: "Upload to Coveralls"
-        run: "php php-coveralls.phar -v -x build/logs/clover.xml"
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./build/logs/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   phpunit-lowest:
     name: "PHPUnit lowest deps (PHP ${{ matrix.php }})"
@@ -164,40 +159,6 @@ jobs:
         run: |
           composer remove php-http/guzzle7-adapter --dev -n
           composer require php-http/curl-client --dev -n
-
-      - name: "Setup logs"
-        run: "mkdir -p build/logs"
-
-      - name: "Run PHPUnit"
-        run: "php vendor/bin/simple-phpunit -v"
-
-  phpunit-composerv1:
-    name: "PHPUnit Composer v1 (PHP ${{ matrix.php }})"
-    runs-on: "ubuntu-latest"
-
-    strategy:
-      matrix:
-        php:
-          - "7.4"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php }}"
-          coverage: "none"
-          tools: composer:v1
-          extensions: tidy
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
 
       - name: "Setup logs"
         run: "mkdir -p build/logs"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Join the chat at https://gitter.im/j0k3r/graby](https://badges.gitter.im/j0k3r/graby.svg)](https://gitter.im/j0k3r/graby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ![CI](https://github.com/j0k3r/graby/workflows/CI/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/j0k3r/graby/badge.svg?branch=master&service=github)](https://coveralls.io/github/j0k3r/graby?branch=master)
+[![codecov](https://codecov.io/github/j0k3r/graby/graph/badge.svg?token=yyhZtiTBlc)](https://codecov.io/github/j0k3r/graby)
 [![Total Downloads](https://img.shields.io/packagist/dt/j0k3r/graby.svg)](https://packagist.org/packages/j0k3r/graby)
 [![License](https://poser.pugx.org/j0k3r/graby/license)](https://packagist.org/packages/j0k3r/graby)
 


### PR DESCRIPTION
Coveralls is too unstable these days.

Also remove composerv1 test as Composer v1 has been phased out on Packagist