### PR TITLE
Jump to Codecov & Remove Guzzle 5

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -132,45 +132,6 @@ jobs:
       - name: "Run PHPUnit"
         run: "php vendor/bin/simple-phpunit -v"
 
-  phpunit-guzzle5:
-    name: "PHPUnit (PHP ${{ matrix.php }} and Guzzle 5)"
-    runs-on: "ubuntu-latest"
-
-    strategy:
-      matrix:
-        php:
-          - "7.4"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php }}"
-          coverage: "none"
-          tools: composer:v2
-          extensions: tidy
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
-
-      - name: "Setup adapter: Guzzle 5"
-        run: |
-          composer remove guzzlehttp/guzzle php-http/guzzle6-adapter --dev -n
-          composer require php-http/guzzle5-adapter --dev -n --with-all-dependencies
-
-      - name: "Setup logs"
-        run: "mkdir -p build/logs"
-
-      - name: "Run PHPUnit"
-        run: "php vendor/bin/simple-phpunit -v"
-
   phpunit-guzzle7:
     name: "PHPUnit (PHP ${{ matrix.php }} and Guzzle 7)"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,16 +90,11 @@ jobs:
       - name: "Run PHPUnit (with coverage)"
         run: "php vendor/bin/simple-phpunit -v --coverage-clover build/logs/clover.xml"
 
-      - name: "Retrieve Coveralls phar"
-        run: "wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.4.2/php-coveralls.phar"
-
-      - name: "Enable Coveralls phar"
-        run: "chmod +x php-coveralls.phar"
-
-      - name: "Upload to Coveralls"
-        run: "php php-coveralls.phar -v -x build/logs/clover.xml"
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./build/logs/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   phpunit-lowest:
     name: "PHPUnit lowest deps (PHP ${{ matrix.php }})"
@@ -248,40 +243,6 @@ jobs:
         run: |
           composer remove php-http/guzzle6-adapter --dev -n
           composer require php-http/curl-client --dev -n
-
-      - name: "Setup logs"
-        run: "mkdir -p build/logs"
-
-      - name: "Run PHPUnit"
-        run: "php vendor/bin/simple-phpunit -v"
-
-  phpunit-composerv1:
-    name: "PHPUnit Composer v1 (PHP ${{ matrix.php }})"
-    runs-on: "ubuntu-latest"
-
-    strategy:
-      matrix:
-        php:
-          - "7.4"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 2
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "${{ matrix.php }}"
-          coverage: "none"
-          tools: composer:v1
-          extensions: tidy
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
 
       - name: "Setup logs"
         run: "mkdir -p build/logs"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Join the chat at https://gitter.im/j0k3r/graby](https://badges.gitter.im/j0k3r/graby.svg)](https://gitter.im/j0k3r/graby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ![CI](https://github.com/j0k3r/graby/workflows/CI/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/j0k3r/graby/badge.svg?branch=master&service=github)](https://coveralls.io/github/j0k3r/graby?branch=master)
+[![codecov](https://codecov.io/github/j0k3r/graby/branch/2.x/graph/badge.svg?token=yyhZtiTBlc)](https://codecov.io/github/j0k3r/graby)
 [![Total Downloads](https://img.shields.io/packagist/dt/j0k3r/graby.svg)](https://packagist.org/packages/j0k3r/graby)
 [![License](https://poser.pugx.org/j0k3r/graby/license)](https://packagist.org/packages/j0k3r/graby)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/j0k3r/graby/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/j0k3r/graby/?branch=master)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Why `php-http/guzzle6-adapter`? Because Graby is decoupled from any HTTP client 
 Graby is tested & should work great with:
 
 - Guzzle 6 (using `php-http/guzzle6-adapter`)
-- Guzzle 5 (using `php-http/guzzle5-adapter`)
 - cURL (using `php-http/curl-client` and a PSR-17 response factory [from this list](https://packagist.org/providers/psr/http-factory-implementation))
 
 ### Retrieve content from an url
@@ -197,20 +196,6 @@ $logs = $this->get('monolog.handler.graby')->getRecords();
 
 If you need to define a timeout, you must create the `Http\Client\HttpClient` manually,
 configure it and inject it to `Graby\Graby`.
-
-- For Guzzle 5:
-
-    ```php
-    use Graby\Graby;
-    use GuzzleHttp\Client as GuzzleClient;
-    use Http\Adapter\Guzzle5\Client as GuzzleAdapter;
-    $guzzle = new GuzzleClient([
-        'defaults' => [
-            'timeout' => 2,
-        ]
-    ]);
-    $graby = new Graby([], new GuzzleAdapter($guzzle));
-    ```
 
 - For Guzzle 6:
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -12,7 +12,7 @@ Graby 1 was hardly tied to Guzzle 5.
 Graby 2 supports any [HTTP client implementation](https://packagist.org/providers/php-http/client-implementation). It is currently tested against:
 
 - Guzzle 6
-- Guzzle 5
+- Guzzle 7
 - cURL
 
 Here is how to install Graby with Guzzle 6:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "fossar/htmlawed": "^1.2.7",
         "http-interop/http-factory-guzzle": "^1.1",
         "j0k3r/graby-site-config": "^1.0.181",
-        "j0k3r/httplug-ssrf-plugin": "^2.0",
+        "j0k3r/httplug-ssrf-plugin": "^2.0|^3.0",
         "j0k3r/php-readability": "^1.2.10",
         "monolog/monolog": "^1.18.0|^2.0",
         "php-http/client-common": "^2.7",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,9 +8,9 @@ parameters:
         - vendor/bin/.phpunit/phpunit-8.5-0/vendor/autoload.php
 
     ignoreErrors:
-        # because we check for some HTTP client to exist or not (Guzzle 5/6 & cURL)
+        # because we check for some HTTP client to exist or not (Guzzle 6 & cURL)
         -
-            message: '#Http\\Adapter\\Guzzle5\\Client\\|Http\\Adapter\\Guzzle6\\Client\\|Http\\Client\\Curl\\Client given#'
+            message: '#Http\\Adapter\\Guzzle6\\Client\\|Http\\Client\\Curl\\Client given#'
             path: %currentWorkingDirectory%/tests/Extractor/HttpClientTest.php
         # we don't want to BC by defining typehint everywhere
         # TODO: remove when jumping to 3.0

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -280,10 +280,6 @@ class HttpClientTest extends TestCase
             $isGuzzle = true;
             $guzzle = new \GuzzleHttp\Client(['timeout' => 2]);
             $adapter = new \Http\Adapter\Guzzle6\Client($guzzle);
-        } elseif (class_exists('Http\Adapter\Guzzle5\Client')) {
-            $isGuzzle = true;
-            $guzzle = new \GuzzleHttp\Client(['defaults' => ['timeout' => 2]]);
-            $adapter = new \Http\Adapter\Guzzle5\Client($guzzle);
         } elseif (class_exists('Http\Client\Curl\Client')) {
             $isCurl = true;
             $adapter = new \Http\Client\Curl\Client(


### PR DESCRIPTION
Looks like Guzzle conflicts with `j0k3r/httplug-ssrf-plugin` v3:

```
   Problem 1
    - Root composer.json requires php-http/guzzle5-adapter * -> satisfiable by php-http/guzzle5-adapter[dev-master, v0.1.0, ..., v0.6.0, v1.0.0, v1.0.1, 2.0.0, 2.0.x-dev].
    - guzzlehttp/guzzle[5.1.0, ..., 5.2.0] require guzzlehttp/ringphp ~1.0 -> satisfiable by guzzlehttp/ringphp[1.0.0, ..., 1.1.x-dev].
    - guzzlehttp/guzzle[5.3.0, ..., 5.3.1] require guzzlehttp/ringphp ^1.1 -> satisfiable by guzzlehttp/ringphp[1.1.0, 1.1.1, 1.1.x-dev].
    - guzzlehttp/guzzle[5.3.2, ..., 5.3.x-dev] require react/promise ^2.2 -> found react/promise[v2.2.0, ..., 2.x-dev] but these were not loaded, likely because it conflicts with another require.
    - guzzlehttp/ringphp[1.0.0, ..., 1.1.x-dev] require react/promise ~2.0 -> found react/promise[v2.0.0, ..., 2.x-dev] but these were not loaded, likely because it conflicts with another require.
    - php-http/guzzle5-adapter v0.1.0 requires php-http/discovery ^0.1 -> found php-http/discovery[v0.1.0, v0.1.1] but it conflicts with your root composer.json require (^1.19).
    - php-http/guzzle5-adapter v0.1.1 requires php-http/httplug ^1.0.0-beta -> found php-http/httplug[v1.0.0-beta, v1.0.0-RC1, v1.0.0, v1.1.0] but it conflicts with your root composer.json require (^2.4).
    - php-http/guzzle5-adapter[v0.2.0, ..., v0.6.0, v1.0.0, ..., v1.0.1] require php-http/httplug ^1.0 -> found php-http/httplug[v1.0.0-alpha, ..., v1.1.0] but it conflicts with your root composer.json require (^2.4).
    - php-http/guzzle5-adapter[dev-master, 2.0.0, ..., 2.0.x-dev] require guzzlehttp/guzzle ^5.1 -> satisfiable by guzzlehttp/guzzle[5.1.0, ..., 5.3.x-dev].
```

So I prefer to remove the support (latest version of Guzzle 5 is from 2019)