### PR TITLE
Ensure `$th` argument is a string

### DIFF
--- a/src/Monolog/Formatter/GrabyFormatter.php
+++ b/src/Monolog/Formatter/GrabyFormatter.php
@@ -41,7 +41,7 @@ class GrabyFormatter extends HtmlFormatter
         if ($record['context']) {
             $embeddedTable = '<table cellspacing="1" width="100%">';
             foreach ($record['context'] as $key => $value) {
-                $embeddedTable .= $this->addRowWithLevel($record['level'], $key, $this->convertToString($value));
+                $embeddedTable .= $this->addRowWithLevel($record['level'], (string) $key, $this->convertToString($value));
             }
             $embeddedTable .= '</table>';
             $output .= $this->addRowWithLevel($record['level'], 'Context', $embeddedTable, false);
@@ -49,7 +49,7 @@ class GrabyFormatter extends HtmlFormatter
         if ($record['extra']) {
             $embeddedTable = '<table cellspacing="1" width="100%">';
             foreach ($record['extra'] as $key => $value) {
-                $embeddedTable .= $this->addRowWithLevel($record['level'], $key, $this->convertToString($value));
+                $embeddedTable .= $this->addRowWithLevel($record['level'], (string) $key, $this->convertToString($value));
             }
             $embeddedTable .= '</table>';
             $output .= $this->addRowWithLevel($record['level'], 'Extra', $embeddedTable, false);

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -293,7 +293,7 @@ class GrabyTest extends TestCase
         $this->assertEmpty($res->getLanguage());
         $this->assertSame('Document1', $res->getTitle());
         $this->assertStringContainsString('Document title', $res->getHtml());
-        $this->assertStringContainsString('Morbi vulputate tincidunt venenatis.', $res->getHtml());
+        $this->assertStringContainsString('Morbi vulputate tincidunt', $res->getHtml());
         $this->assertStringContainsString('http://example.com/test.pdf', (string) $res->getEffectiveResponse()->getEffectiveUri());
         $this->assertNotNull($res->getSummary());
         $this->assertStringContainsString('Document title Calibri : Lorem ipsum dolor sit amet', $res->getSummary());


### PR DESCRIPTION
Looks like it can happen to be an `int` and it then throw an error (in `addRowWithLevel`, line 81).