### PR TITLE
Making ContentExtractor stateless

### DIFF
--- a/src/Extractor/ExtractedContent.php
+++ b/src/Extractor/ExtractedContent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Graby\Extractor;
+
+use Graby\SiteConfig\SiteConfig;
+use Readability\Readability;
+
+/**
+ * Contains the result of content extraction with all extracted data
+ * and the Readability instance for potential reuse.
+ */
+final class ExtractedContent
+{
+    public function __construct(
+        public ?Readability $readability = null,
+        public ?SiteConfig $siteConfig = null,
+        public ?string $title = null,
+        public ?string $language = null,
+        /** @var string[] */
+        public array $authors = [],
+        public ?\DOMElement $content = null,
+        public ?string $image = null,
+        public bool $isNativeAd = false,
+        public ?string $date = null,
+        public bool $isSuccess = false,
+        public ?string $nextPageUrl = null
+    ) {
+    }
+}


### PR DESCRIPTION
Started with Claude to have a first draft and then update the whole stuff.

I'm just wondering if `ExtractedContent` should have getters or all keys public instead.

See https://github.com/j0k3r/graby/issues/275#issuecomment-1491142099