### PR TITLE
Update regex for empty nodes for also excluding img

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -319,8 +319,8 @@ class Graby
         $re = '/^[ \t]*[\r\n]+/m';
         $htmlCleaned = preg_replace($re, '', $html);
 
-        // Remove empty nodes (except iframe, td and th)
-        $re = '/<(?!iframe|td|th)([^>\s]+)[^>]*>(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;|\s)*<\/\1>/m';
+        // Remove empty nodes (except iframe, img, td and th)
+        $re = '/<(?!iframe|img|td|th)([^>\s]+)[^>]*>(?:<br \/>|&nbsp;|&thinsp;|&ensp;|&emsp;|&#8201;|&#8194;|&#8195;|\s)*<\/\1>/m';
         $html = preg_replace($re, '', (string) $htmlCleaned);
 
         // in case html string is too long, keep the html uncleaned to avoid empty html


### PR DESCRIPTION
Some websites using closing `</img>` nodes which is not defined in HTML. In most cases, this results in `<img src="..."></img>` which is currently detected as empty node and therefore removed by graby. So all images from those domains can currently not be fetched by wallabag.

This will fix lot of issues in wallabagger for missing images.

example: https://taz.de/Stadtbilddebatte-wird-praktisch/!6136666/