### PR TITLE
Update php-readability and options-resolver versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/psr7": "^2.0",
         "j0k3r/graby-site-config": "^1.0.181",
         "j0k3r/httplug-ssrf-plugin": "^3.0",
-        "j0k3r/php-readability": "^1.3",
+        "j0k3r/php-readability": "^1.3|^2.0",
         "monolog/monolog": "^3.0",
         "php-http/client-common": "^2.7",
         "php-http/discovery": "^1.19",
@@ -31,7 +31,7 @@
         "psr/http-client-implementation": "^1.0",
         "simplepie/simplepie": "^1.8",
         "smalot/pdfparser": "^2.8",
-        "symfony/options-resolver": "^5.4|^6.4|^7.3",
+        "symfony/options-resolver": "^5.4|^6.4|^7.3|^8.0",
         "symfony/polyfill-intl-idn": "^1.26"
     },
     "require-dev": {


### PR DESCRIPTION
Fixes #385.  

Also makes this compatible with Symfony 8.

Necessary for https://github.com/j0k3r/f43.me/issues/2070