### PR TITLE
perf: improve performance of absolute link generation on large pages

### DIFF
--- a/src/Graby.php
+++ b/src/Graby.php
@@ -798,18 +798,16 @@ class Graby
      */
     private function makeAbsolute(UriInterface $base, \DOMElement $elem): void
     {
-        foreach (['a' => 'href', 'img' => 'src', 'iframe' => 'src'] as $tag => $attr) {
-            $elems = $elem->getElementsByTagName($tag);
+        $tagAttrMap = ['a' => 'href', 'img' => 'src', 'iframe' => 'src'];
 
-            for ($i = $elems->length - 1; $i >= 0; --$i) {
-                $e = $elems->item($i);
-                if (null !== $e) {
-                    $this->makeAbsoluteAttr($base, $e, $attr);
-                }
-            }
+        $nodeName = strtolower($elem->nodeName);
+        if (isset($tagAttrMap[$nodeName])) {
+            $this->makeAbsoluteAttr($base, $elem, $tagAttrMap[$nodeName]);
+        }
 
-            if (strtolower($elem->nodeName) === $tag) {
-                $this->makeAbsoluteAttr($base, $elem, $attr);
+        foreach ($tagAttrMap as $tag => $attr) {
+            foreach ($elem->getElementsByTagName($tag) as $e) {
+                $this->makeAbsoluteAttr($base, $e, $attr);
             }
         }
     }

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -879,6 +879,51 @@ class GrabyTest extends TestCase
         $this->assertSame('http://example.org/path/to/image.jpg', $e->firstChild->attributes->getNamedItem('src')->nodeValue);
     }
 
+    /**
+     * A wrapper element (not itself a/img/iframe) holding several url-bearing
+     * descendants of each kind: every descendant must be made absolute.
+     */
+    public function testMakeAbsoluteWithManyChildren(): void
+    {
+        $graby = new Graby();
+
+        $doc = new \DOMDocument();
+        $doc->loadXML(
+            '<div>'
+            . '<a href="/one">1</a>'
+            . '<img src="/a.jpg" />'
+            . '<p><a href="/two">2</a><iframe src="/frame" /></p>'
+            . '<img src="/b.jpg" />'
+            . '</div>'
+        );
+
+        /** @var \DOMElement */
+        $e = $doc->documentElement;
+
+        $reflection = new \ReflectionClass($graby::class);
+        $method = $reflection->getMethod('makeAbsolute');
+
+        $method->invokeArgs($graby, [new Uri('http://example.org'), $e]);
+
+        $hrefs = [];
+        foreach ($doc->getElementsByTagName('a') as $a) {
+            $hrefs[] = $a->getAttribute('href');
+        }
+        $srcs = [];
+        foreach ($doc->getElementsByTagName('img') as $img) {
+            $srcs[] = $img->getAttribute('src');
+        }
+        foreach ($doc->getElementsByTagName('iframe') as $iframe) {
+            $srcs[] = $iframe->getAttribute('src');
+        }
+
+        $this->assertSame(['http://example.org/one', 'http://example.org/two'], $hrefs);
+        $this->assertSame(
+            ['http://example.org/a.jpg', 'http://example.org/b.jpg', 'http://example.org/frame'],
+            $srcs
+        );
+    }
+
     public function testContentLinksRemove(): void
     {
         $httpMockClient = new HttpMockClient();

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -791,6 +791,35 @@ class GrabyTest extends TestCase
     }
 
     /**
+     * A malformed (but non-anchor, non-http) url makes the uri factory throw:
+     * the attribute is then left untouched and the failure is logged.
+     */
+    public function testMakeAbsoluteAttrWithWrongUrl(): void
+    {
+        $logger = new Logger('foo');
+        $handler = new TestHandler();
+        $logger->pushHandler($handler);
+
+        $graby = new Graby();
+        $graby->setLogger($logger);
+
+        $doc = new \DOMDocument();
+        $doc->loadXML('<a href="//example.com:port/p">test</a>');
+
+        /** @var \DOMElement */
+        $e = $doc->documentElement;
+
+        $reflection = new \ReflectionClass($graby::class);
+        $method = $reflection->getMethod('makeAbsoluteAttr');
+
+        $method->invokeArgs($graby, [new Uri('http://example.org'), $e, 'href']);
+
+        // url is invalid so it can't be made absolute: kept as-is
+        $this->assertSame('//example.com:port/p', $e->getAttribute('href'));
+        $this->assertTrue($handler->hasInfoThatContains('Wrong content url'));
+    }
+
+    /**
      * @return iterable<array{string, string, string, string}>
      */
     public function dataForMakeAbsolute(): iterable


### PR DESCRIPTION
I noticed that some (long) Hacker News pages were taking over 30 seconds to generate and sometimes timing out in my configuration. It turned out most of the time was spent in `makeAbsolute`.

This PR does two things:

- First adds a bit of missing test coverage around the child methods.
- Then brings in the actual performance fix which only adds tests, so hopefully there's no hidden regressions here!

Locally (on much faster hardware than where I was getting timeouts) I get:

  | n (elements) | old (ms) | new (ms) | speedup |
  |---:|---:|---:|---:|
  | 900 | 6.2 | 0.7 | 8.8× |
  | 4,500 | 149 | 3.4 | 43× |
  | 9,000 | 627 | 6.8 | 92× |
  | 18,000 | 3,466 | 10.0 | 346× |
  | 30,000 | 10,637 | 17.2 | 618× |

This is AI-assisted. I'm glad to answer any questions or make changes.