### PR TITLE
Move to php-readability 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/psr7": "^2.0",
         "j0k3r/graby-site-config": "^1.0.181",
         "j0k3r/httplug-ssrf-plugin": "^3.0",
-        "j0k3r/php-readability": "^1.3",
+        "j0k3r/php-readability": "^2.0.9",
         "monolog/monolog": "^3.0",
         "php-http/client-common": "^2.7",
         "php-http/discovery": "^1.19",

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -1112,6 +1112,8 @@ class ContentExtractor
             $readability->addPostFilter($filter, $replacer);
         }
 
+        $readability->loadHtml();
+
         return $readability;
     }
 

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -657,6 +657,13 @@ class ContentExtractor
                 $this->removeAttributes($elems, 'Stripping {length} attributes (post_strip_attr)');
             }
 
+            // Starting with readability 2.0, tidy does not remove inline style attributes anymore during init(), so we do it here
+            foreach ($body->getElementsByTagName('*') as $e) {
+                if ($e->hasAttribute('style')) {
+                    $e->removeAttribute('style');
+                }
+            }
+
             $success = true;
         }
 

--- a/src/Graby.php
+++ b/src/Graby.php
@@ -723,6 +723,7 @@ class Graby
 
         // Build DOM tree from HTML
         $readability = new Readability($html, (string) $url);
+        $readability->loadHtml();
         $xpath = new \DOMXPath($readability->dom);
 
         // Loop through single_page_link xpath expressions

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -401,7 +401,7 @@ class ContentExtractorTest extends TestCase
         return [
             ['commentlist', '<html><body><nav id="commentlist">hello !hello !hello !hello !hello !hello !hello !hello !hello !</nav><p>' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', 'hello !', null],
             ['related_post', '<html><body><nav id="high">' . str_repeat('hello !', 20) . '</nav><p class="related_post">' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', 'this is the best part of the show', null],
-            ['related', '<html><body><nav id="high">' . str_repeat('lorem ipsum dolor', 20) . '</nav><p class="related_post">' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', null, 'class="related_post"'],
+            ['similar', '<html><body><nav id="high">' . str_repeat('lorem ipsum dolor sit amet', 20) . '</nav><p class="similar_post">' . str_repeat('this is the best part of the show', 10) . '</p></body></html>', null, 'class="similar_post"'],
         ];
     }
 

--- a/tests/GrabyTest.php
+++ b/tests/GrabyTest.php
@@ -1065,7 +1065,7 @@ class GrabyTest extends TestCase
             ],
             'script_inject_removed_from_long_text' => [
                 '<html><script src="http://attacker/malicious‑script.js"></script><body><div><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p></div></body></html>',
-                '<div><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p></div>',
+                '<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>',
                 false,
             ],
         ];

--- a/tests/fixtures/site_config/lifehacker.com.au.txt
+++ b/tests/fixtures/site_config/lifehacker.com.au.txt
@@ -9,4 +9,7 @@ author: //div[@class='meta__author']/a
 find_string: <meta http-equiv="refresh"
 replace_string: <meta norefresh
 
+strip_id_or_class: meta__second-row
+strip_id_or_class: trending-river__meta
+
 test_url: https://www.lifehacker.com.au/2019/03/we-tried-mark-zuckerbergs-tricks-for-looking-taller-in-photos/

--- a/tests/fixtures/sites/lifehacker.test
+++ b/tests/fixtures/sites/lifehacker.test
@@ -2532,12 +2532,18 @@ Shouldn't have redirected
 <hr/><p><em>This story has been updated since its original publication.</em></p>
 </article><hr/><section><h2>Comments</h2>
 <div id="votes-modal" tabindex="-1" role="dialog" aria-labelledby="votes-modal">
+<div role="document">
+<div>
+<div>
 <div>
 <div>
 <h3 id="votes-modal-upvote-count">Up Votes</h3>
 </div>
 <div>
 <h3 id="votes-modal-downvote-count">Down Votes</h3>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
In php-readability 1.x, `Readability::__construct()` handled the parsing
of the HTML into $dom; In 2.x the parsing moved into `init()`, leading to
a breaking behavior change as calling `init()` is not necessarily what we
want in certain parts of the extraction logic.

Thus we explicitly call `Readability::loadHtml()` where we need the DOM to
be available.

Depends on https://github.com/j0k3r/php-readability/pull/113