### PR TITLE
Handle cookie-gate redirects that loop to the same URL

### DIFF
--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -274,10 +274,6 @@ class HttpClient
      */
     private function isCookieGateRedirect(CircularRedirectionException $e): bool
     {
-        if (!method_exists($e, 'getRequest') || !method_exists($e, 'getResponse')) {
-            return false;
-        }
-
         $request = $e->getRequest();
         $response = $e->getResponse();
 

--- a/src/Extractor/HttpClient.php
+++ b/src/Extractor/HttpClient.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Graby\Extractor;
 
 use Graby\HttpClient\EffectiveResponse;
+use Graby\HttpClient\Plugin\CookiePlugin;
 use Graby\HttpClient\Plugin\History;
 use Graby\HttpClient\Plugin\ServerSideRequestForgeryProtection\ServerSideRequestForgeryProtectionPlugin;
+use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriResolver;
+use Http\Client\Common\Exception\CircularRedirectionException;
 use Http\Client\Common\Exception\LoopException;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin;
@@ -16,6 +19,7 @@ use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\Exception\TransferException;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Message\CookieJar;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -37,6 +41,8 @@ class HttpClient
     private readonly StreamFactoryInterface $streamFactory;
     private readonly UriFactoryInterface $uriFactory;
     private readonly History $responseHistory;
+    private readonly CookieJar $cookieJar;
+    private readonly CookiePlugin $cookiePlugin;
 
     /**
      * @param ClientInterface $client Http client
@@ -69,12 +75,16 @@ class HttpClient
         $this->streamFactory = Psr17FactoryDiscovery::findStreamFactory();
 
         $this->responseHistory = new History();
+        $this->cookieJar = new CookieJar();
+        $this->cookiePlugin = new CookiePlugin($this->cookieJar);
         $this->client = new HttpMethodsClient(
             new PluginClient(
                 $client,
                 [
                     new ServerSideRequestForgeryProtectionPlugin(),
                     new RedirectPlugin(),
+                    // Inner plugin: stores Set-Cookie before RedirectPlugin handles the response.
+                    $this->cookiePlugin,
                     new Plugin\HistoryPlugin($this->responseHistory),
                     new ErrorPlugin(),
                 ],
@@ -142,10 +152,25 @@ class HttpClient
 
             $headers[$header] = $value;
         }
+        $cookieGateRetried = false;
 
         try {
-            /** @var ResponseInterface $response */
-            $response = $this->client->$method($url, $headers);
+            while (true) {
+                try {
+                    /** @var ResponseInterface $response */
+                    $response = $this->client->$method($url, $headers);
+
+                    break;
+                } catch (CircularRedirectionException $e) {
+                    if ($cookieGateRetried || !$this->isCookieGateRedirect($e)) {
+                        throw $e;
+                    }
+
+                    $this->logger->info('Cookie-gate redirect detected on "{url}", retrying with stored cookies', ['url' => (string) $url]);
+                    $this->cookiePlugin->storeSetCookies($e->getRequest(), $e->getResponse());
+                    $cookieGateRetried = true;
+                }
+            }
         } catch (LoopException) {
             $this->logger->info('Endless redirect: ' . ($this->config->getMaxRedirect() + 1) . ' on "{url}"', ['url' => (string) $url]);
 
@@ -242,6 +267,28 @@ class HttpClient
             $effectiveUrl,
             $response->withBody($this->streamFactory->createStream($body))
         );
+    }
+
+    /**
+     * Detect cookie-gate redirects: same URL + Set-Cookie (e.g. Tamedia / Piano CMS).
+     */
+    private function isCookieGateRedirect(CircularRedirectionException $e): bool
+    {
+        if (!method_exists($e, 'getRequest') || !method_exists($e, 'getResponse')) {
+            return false;
+        }
+
+        $request = $e->getRequest();
+        $response = $e->getResponse();
+
+        if (null === $response || !$response->hasHeader('Set-Cookie') || !$response->hasHeader('Location')) {
+            return false;
+        }
+
+        $location = $response->getHeaderLine('Location');
+        $targetUri = UriResolver::resolve($request->getUri(), new Uri($location));
+
+        return (string) $targetUri === (string) $request->getUri();
     }
 
     /**

--- a/src/HttpClient/Plugin/CookiePlugin.php
+++ b/src/HttpClient/Plugin/CookiePlugin.php
@@ -53,28 +53,39 @@ class CookiePlugin implements Plugin
         }
 
         return $next($request)->then(function (ResponseInterface $response) use ($request) {
-            if ($response->hasHeader('Set-Cookie')) {
-                $setCookies = $response->getHeader('Set-Cookie');
-
-                foreach ($setCookies as $setCookie) {
-                    $cookie = $this->createCookie($request, $setCookie);
-
-                    // Cookie invalid do not use it
-                    if (null === $cookie) {
-                        continue;
-                    }
-
-                    // Restrict setting cookie from another domain
-                    if (!preg_match("/\.{$cookie->getDomain()}$/", '.' . $request->getUri()->getHost())) {
-                        continue;
-                    }
-
-                    $this->cookieJar->addCookie($cookie);
-                }
-            }
+            $this->storeSetCookies($request, $response);
 
             return $response;
         });
+    }
+
+    /**
+     * Store Set-Cookie headers from a response into the cookie jar.
+     *
+     * Exposed so HttpClient can persist cookies from a redirect response when
+     * RedirectPlugin aborts before the cookie plugin's response handler runs.
+     */
+    public function storeSetCookies(RequestInterface $request, ResponseInterface $response): void
+    {
+        if (!$response->hasHeader('Set-Cookie')) {
+            return;
+        }
+
+        foreach ($response->getHeader('Set-Cookie') as $setCookie) {
+            $cookie = $this->createCookie($request, $setCookie);
+
+            // Cookie invalid do not use it
+            if (null === $cookie) {
+                continue;
+            }
+
+            // Restrict setting cookie from another domain
+            if (!preg_match("/\.{$cookie->getDomain()}$/", '.' . $request->getUri()->getHost())) {
+                continue;
+            }
+
+            $this->cookieJar->addCookie($cookie);
+        }
     }
 
     /**

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -707,4 +707,38 @@ class HttpClientTest extends TestCase
 
         $this->assertSame($expectedUrl, (string) $res->getEffectiveUri());
     }
+
+    public function testCookieGateRedirectRetriesWithStoredCookie(): void
+    {
+        $articleUrl = 'https://www.tagesanzeiger.ch/example-article-123';
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new Response(
+            302,
+            [
+                'Location' => $articleUrl,
+                'Set-Cookie' => 'entitlementToken=test-token; Domain=.tagesanzeiger.ch; Path=/; Secure; SameSite=Lax',
+                'Content-Type' => 'text/plain; charset=utf-8',
+            ],
+            'Found. Redirecting to ' . $articleUrl
+        ));
+        $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/html'], '<html><body>Article</body></html>'));
+
+        $logger = new Logger('foo');
+        $handler = new TestHandler();
+        $logger->pushHandler($handler);
+
+        $http = new HttpClient($httpMockClient);
+        $http->setLogger($logger);
+
+        $res = $http->fetch(new Uri($articleUrl));
+
+        $this->assertSame(200, $res->getResponse()->getStatusCode());
+        $this->assertSame('text/html', $res->getResponse()->getHeaderLine('content-type'));
+        $this->assertStringContainsString('Article', (string) $res->getResponse()->getBody());
+        $this->assertSame('Cookie-gate redirect detected on "{url}", retrying with stored cookies', $handler->getRecords()[3]['message']);
+
+        /** @var RequestInterface $secondRequest */
+        $secondRequest = $httpMockClient->getRequests()[1];
+        $this->assertStringContainsString('entitlementToken=test-token', $secondRequest->getHeaderLine('Cookie'));
+    }
 }

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -723,19 +723,13 @@ class HttpClientTest extends TestCase
         ));
         $httpMockClient->addResponse(new Response(200, ['Content-Type' => 'text/html'], '<html><body>Article</body></html>'));
 
-        $logger = new Logger('foo');
-        $handler = new TestHandler();
-        $logger->pushHandler($handler);
-
         $http = new HttpClient($httpMockClient);
-        $http->setLogger($logger);
 
         $res = $http->fetch(new Uri($articleUrl));
 
         $this->assertSame(200, $res->getResponse()->getStatusCode());
         $this->assertSame('text/html', $res->getResponse()->getHeaderLine('content-type'));
         $this->assertStringContainsString('Article', (string) $res->getResponse()->getBody());
-        $this->assertSame('Cookie-gate redirect detected on "{url}", retrying with stored cookies', $handler->getRecords()[3]['message']);
 
         /** @var RequestInterface $secondRequest */
         $secondRequest = $httpMockClient->getRequests()[1];
@@ -755,17 +749,11 @@ class HttpClientTest extends TestCase
             'Found. Redirecting to ' . $articleUrl
         ));
 
-        $logger = new Logger('foo');
-        $handler = new TestHandler();
-        $logger->pushHandler($handler);
-
         $http = new HttpClient($httpMockClient);
-        $http->setLogger($logger);
 
         $res = $http->fetch(new Uri($articleUrl));
 
         $this->assertCount(1, $httpMockClient->getRequests());
         $this->assertSame(302, $res->getResponse()->getStatusCode());
-        $this->assertCount(4, $handler->getRecords());
     }
 }

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -741,4 +741,32 @@ class HttpClientTest extends TestCase
         $secondRequest = $httpMockClient->getRequests()[1];
         $this->assertStringContainsString('entitlementToken=test-token', $secondRequest->getHeaderLine('Cookie'));
     }
+
+    public function testCircularRedirectWithoutCookieGateDoesNotRetry(): void
+    {
+        $articleUrl = 'https://www.tagesanzeiger.ch/example-article-123';
+        $httpMockClient = new HttpMockClient();
+        $httpMockClient->addResponse(new Response(
+            302,
+            [
+                'Location' => $articleUrl,
+                'Content-Type' => 'text/plain; charset=utf-8',
+            ],
+            'Found. Redirecting to ' . $articleUrl
+        ));
+
+        $logger = new Logger('foo');
+        $handler = new TestHandler();
+        $logger->pushHandler($handler);
+
+        $http = new HttpClient($httpMockClient);
+        $http->setLogger($logger);
+
+        $res = $http->fetch(new Uri($articleUrl));
+
+        $this->assertCount(1, $httpMockClient->getRequests());
+        $this->assertSame(302, $res->getResponse()->getStatusCode());
+        $this->assertSame('Request throw exception (with a response): {error_message}', $handler->getRecords()[3]['message']);
+        $this->assertStringContainsString('Circular redirection detected', $handler->getRecords()[3]['context']['error_message']);
+    }
 }

--- a/tests/Extractor/HttpClientTest.php
+++ b/tests/Extractor/HttpClientTest.php
@@ -766,7 +766,6 @@ class HttpClientTest extends TestCase
 
         $this->assertCount(1, $httpMockClient->getRequests());
         $this->assertSame(302, $res->getResponse()->getStatusCode());
-        $this->assertSame('Request throw exception (with a response): {error_message}', $handler->getRecords()[3]['message']);
-        $this->assertStringContainsString('Circular redirection detected', $handler->getRecords()[3]['context']['error_message']);
+        $this->assertCount(4, $handler->getRecords());
     }
 }

--- a/tests/HttpClient/Plugin/CookiePluginTest.php
+++ b/tests/HttpClient/Plugin/CookiePluginTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Graby\HttpClient\Plugin;
+
+use Graby\HttpClient\Plugin\CookiePlugin;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Http\Message\CookieJar;
+use PHPUnit\Framework\TestCase;
+
+class CookiePluginTest extends TestCase
+{
+    public function testStoreSetCookiesIgnoresInvalidCookie(): void
+    {
+        $cookieJar = new CookieJar();
+        $plugin = new CookiePlugin($cookieJar);
+        $request = new Request('GET', 'https://www.tagesanzeiger.ch/article');
+        $response = new Response(302, ['Set-Cookie' => 'invalid-cookie-without-value']);
+
+        $plugin->storeSetCookies($request, $response);
+
+        $this->assertCount(0, $cookieJar->getCookies());
+    }
+
+    public function testStoreSetCookiesIgnoresCookieFromAnotherDomain(): void
+    {
+        $cookieJar = new CookieJar();
+        $plugin = new CookiePlugin($cookieJar);
+        $request = new Request('GET', 'https://www.tagesanzeiger.ch/article');
+        $response = new Response(302, [
+            'Set-Cookie' => 'entitlementToken=test-token; Domain=.example.com; Path=/; Secure',
+        ]);
+
+        $plugin->storeSetCookies($request, $response);
+
+        $this->assertCount(0, $cookieJar->getCookies());
+    }
+}


### PR DESCRIPTION
## Summary

Some sites (for example Tamedia/Piano CMS pages such as `tagesanzeiger.ch`) respond with:

- `302 Found`
- `Set-Cookie`
- `Location` pointing back to the same URL

In this case `RedirectPlugin` raises `CircularRedirectionException` before the cookie plugin can persist the cookie, so the follow-up request never includes the entitlement token.

This patch fixes that by:

- adding `CookiePlugin` to the plugin chain
- exposing `CookiePlugin::storeSetCookies()` for manual persistence
- detecting this specific cookie-gate redirect pattern
- storing cookies from the redirect response
- retrying the request once with the stored cookie

## Test plan

- Added `testCookieGateRedirectRetriesWithStoredCookie`
- Verified that the retry request includes the stored `entitlementToken`