### PR TITLE
ContentExtractor: Resolve PHPStan argument type issues

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -34,14 +34,6 @@ parameters:
             paths:
                 - %currentWorkingDirectory%/tests/Extractor/HttpClientTest.php
                 - %currentWorkingDirectory%/tests/SiteConfig/ConfigBuilderTest.php
-        -
-            identifier: argument.type
-            path: %currentWorkingDirectory%/src/Extractor/ContentExtractor.php
-            count: 20
-        -
-            identifier: property.notFound
-            path: %currentWorkingDirectory%/src/Extractor/ContentExtractor.php
-            count: 5
 
     inferPrivatePropertyTypeFromConstructor: true
     treatPhpDocTypesAsCertain: false

--- a/src/Extractor/ContentExtractor.php
+++ b/src/Extractor/ContentExtractor.php
@@ -243,6 +243,8 @@ class ContentExtractor
 
             if ($elems instanceof \DOMNodeList && $elems->length > 0) {
                 foreach ($elems as $elem) {
+                    // For PHPStan: The static XPath expression guarantees the type.
+                    \assert($elem instanceof \DOMAttr);
                     $language = trim($elem->textContent);
                     $this->logger->info('Language matched: {language}', ['language' => $language]);
                 }
@@ -374,9 +376,9 @@ class ContentExtractor
             // check for hentry
             $elems = $xpath->query("//*[contains(concat(' ',normalize-space(@class),' '),' hentry ')]", $readability->dom);
 
-            if (false !== $elems && $this->hasElements($elems)) {
+            $hentry = self::firstNode($elems);
+            if (null !== $hentry) {
                 $this->logger->info('hNews: found hentry');
-                $hentry = $elems->item(0);
 
                 // check for entry-title
                 $extractedTitle = $this->extractTitle(
@@ -760,23 +762,42 @@ class ContentExtractor
     }
 
     /**
-     * Check if given node list exists and has length more than 0.
+     * Check if given node list exists and contains at least one `\DOMNode`.
      *
-     * @param \DOMNodeList<\DOMNode>|false $elems Not force typed because it can also be false
+     * @param \DOMNodeList<\DOMNode|\DOMNameSpaceNode>|false $elems Not force typed because it can also be false
      */
     private function hasElements($elems = false): bool
     {
+        return null !== self::firstNode($elems);
+    }
+
+    /**
+     * Check if given node list exists and returns the first `\DOMNode` if present.
+     *
+     * @param \DOMNodeList<\DOMNode|\DOMNameSpaceNode>|false $elems Not force typed because it can also be false
+     */
+    private static function firstNode($elems = false): ?\DOMNode
+    {
+        // Internal XPath expressions are valid and evaluating invalid external ones will return an error before getting here.
+        // @codeCoverageIgnoreStart
         if (false === $elems) {
-            return false;
+            return null;
+        }
+        // @codeCoverageIgnoreEnd
+
+        foreach ($elems as $elem) {
+            if ($elem instanceof \DOMNode) {
+                return $elem;
+            }
         }
 
-        return $elems->length > 0;
+        return null;
     }
 
     /**
      * Remove elements.
      *
-     * @param \DOMNodeList<\DOMNode>|false $elems Not force typed because it can also be false
+     * @param \DOMNodeList<\DOMNode|\DOMNameSpaceNode>|false $elems Not force typed because it can also be false
      */
     private function removeElements($elems = false, ?string $logMessage = null): void
     {
@@ -791,7 +812,7 @@ class ContentExtractor
         for ($i = $elems->length - 1; $i >= 0; --$i) {
             $item = $elems->item($i);
 
-            if (null !== $item && null !== $item->parentNode) {
+            if ($item instanceof \DOMNode && null !== $item->parentNode) {
                 if ($item instanceof \DOMAttr) {
                     $item->ownerElement->removeAttributeNode($item);
                 } else {
@@ -804,7 +825,7 @@ class ContentExtractor
     /**
      * Remove attributes.
      *
-     * @param \DOMNodeList<\DOMNode>|false $elems Not force typed because it can also be false
+     * @param \DOMNodeList<\DOMNode|\DOMNameSpaceNode>|false $elems Not force typed because it can also be false
      */
     private function removeAttributes($elems = false, ?string $logMessage = null): void
     {
@@ -828,7 +849,7 @@ class ContentExtractor
     /**
      * Wrap elements with provided tag.
      *
-     * @param \DOMNodeList<\DOMNode>|false $elems
+     * @param \DOMNodeList<\DOMNode|\DOMNameSpaceNode>|false $elems
      */
     private function wrapElements($elems = false, string $tag = 'div', ?string $logMessage = null): void
     {
@@ -887,19 +908,20 @@ class ContentExtractor
         // shut up operator as there is no pre-validation possible.
         $elems = @$xpath->query($xpathExpression, $node);
 
-        if (false === $elems || false === $this->hasElements($elems)) {
+        $first = self::firstNode($elems);
+        if (null === $first) {
             return null;
         }
 
         $entityValue = $returnCallback(
-            $elems->item(0)->textContent,
+            $first->textContent,
             []
         );
         $this->logger->info($logMessage, [$entity => $entityValue]);
 
         // remove entity from document
         try {
-            $elems->item(0)->parentNode->removeChild($elems->item(0));
+            $first->parentNode->removeChild($first);
         } catch (\DOMException) {
             // do nothing
         }
@@ -987,6 +1009,8 @@ class ContentExtractor
 
             if ($fns && $fns->length > 0) {
                 foreach ($fns as $fn) {
+                    // For PHPStan: The static XPath expression guarantees the type.
+                    \assert($fn instanceof \DOMElement);
                     if ('' !== trim($fn->textContent)) {
                         $authors[] = trim($fn->textContent);
                         $this->logger->info('hNews: found author: ' . trim($fn->textContent));
@@ -1058,7 +1082,7 @@ class ContentExtractor
         $len = 0;
 
         foreach ($elems as $elem) {
-            if (!isset($elem->parentNode)) {
+            if (!$elem instanceof \DOMNode || null === $elem->parentNode) {
                 continue;
             }
 
@@ -1146,19 +1170,20 @@ class ContentExtractor
 
             $this->logger->info("{$entity} expression evaluated as string: {{$entity}}", [$entity => $entityValue]);
             $this->logger->info('...XPath match: {pattern}', ['pattern', $pattern]);
-        } elseif ($elems instanceof \DOMNodeList && $elems->length > 0) {
-            if (null === $elems->item(0)) {
+        } elseif ($elems instanceof \DOMNodeList) {
+            $first = self::firstNode($elems);
+            if (null === $first) {
                 return null;
             }
 
-            $entityValue = $returnCallback($elems->item(0)->textContent);
+            $entityValue = $returnCallback($first->textContent);
 
             $this->logger->info("{$entity} matched: {{$entity}}", [$entity => $entityValue]);
             $this->logger->info('...XPath match: {pattern}', ['pattern', $pattern]);
 
             // remove entity from document
             try {
-                $elems->item(0)->parentNode->removeChild($elems->item(0));
+                $first->parentNode->removeChild($first);
             } catch (\DOMException) {
                 // do nothing
             }
@@ -1195,6 +1220,10 @@ class ContentExtractor
             $this->logger->info('...XPath match: {pattern}', ['pattern', $pattern]);
         } elseif ($elems instanceof \DOMNodeList && $elems->length > 0) {
             foreach ($elems as $item) {
+                if (!$item instanceof \DOMNode) {
+                    continue;
+                }
+
                 $entityValue[] = $returnCallback($item->textContent);
 
                 // remove entity from document

--- a/tests/Extractor/ContentExtractorTest.php
+++ b/tests/Extractor/ContentExtractorTest.php
@@ -272,6 +272,8 @@ class ContentExtractorTest extends TestCase
             ['string(//*[(@rel = "author")])', '<html>from <a rel="author" href="/user8412228">CaTV</a></html>', ['CaTV']],
             // return nothing because the rel="author" does not exist
             ['string(//*[(@rel = "author")])', '<html>from <a href="/user8412228">CaTV</a></html>', []],
+            // Nonsensical query, returning DOMNameSpaceNode.
+            ['/html/namespace::*', '<html xmlns="http://www.w3.org/1999/xhtml"></html>', []],
         ];
     }
 


### PR DESCRIPTION
`DOMXPath::query()` returns `DOMNodeList` that can contain `DOMNameSpaceNode` items in addition to `DOMNode` items. Now, `DOMNameSpaceNode` items will only be returned when ‘[namespace axis]’ is used, which is unlikely as it is useless for content but PHPStan is not currently smart enough to determine that the axis is not used in the static XPath expression, and there is nothing it could do for dynamic expressions so the inferred return type includes `DOMNameSpaceNode`.

Let’s fix the PHPStan errors by:

1. Adding asserts in cases where the XPath expression is static so we know the item types.
2. Extending helper method types to take the returned value.
3. Adding guards to where the XPath expression is dynamic, though it is improbably anyone will ever use an XPath expression that matches a namespace.
4. Introduce `useFirst` helper in cases where are looking for the first `DomNode`.

[namespace axis]: https://www.w3.org/TR/xpath-10/#axes
