### PR TITLE
Add support for guzzlehttp/psr7 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-curl": "*",
         "ext-tidy": "*",
         "fossar/htmlawed": "^1.3.3",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/psr7": "^2.0 || ^3.0",
         "j0k3r/graby-site-config": "^1.0.181",
         "j0k3r/httplug-ssrf-plugin": "^3.0",
         "j0k3r/php-readability": "^2.0.9",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "sort-packages": true,
         "allow-plugins": {
             "phpstan/extension-installer": true,
-            "php-http/discovery": true
+            "php-http/discovery": false
         }
     }
 }


### PR DESCRIPTION
Unrestrict consumers’ choice.

There are no backwards incompatible changes relevant to us and version 3.0 still supports PHP 7.4.
But let’s support both for a while so that people can migrate gradually.

https://github.com/guzzle/psr7/releases/tag/3.0.0
